### PR TITLE
Fix native host install detection and UX

### DIFF
--- a/extension/src/background/native-host.ts
+++ b/extension/src/background/native-host.ts
@@ -78,10 +78,12 @@ export class NativeHostConnection {
     this.port = null;
     this.onStateChange(false);
 
-    // Detect installation error: native host not found
+    // Detect installation error: native host not found or not allowed
     if (
       errorMessage.includes("not found") ||
-      errorMessage.includes("Specified native messaging host not found")
+      errorMessage.includes("Specified native messaging host not found") ||
+      errorMessage.includes("forbidden") ||
+      errorMessage.includes("is forbidden")
     ) {
       console.error(
         "[NativeHost] Native host not found. Is the native messaging host installed?",

--- a/extension/src/popup/views/needs-install.ts
+++ b/extension/src/popup/views/needs-install.ts
@@ -79,11 +79,18 @@ function buildInstallCommand(
   platform: "macos" | "linux" | "windows" | "unknown",
   extensionID: string,
 ): string {
-  const goInstall = "go install github.com/tailscale/geneva/host@latest";
-  const installFlag = `tailscale-browser-ext --install=${extensionID}`;
+  const flag = `-install C${extensionID}`;
 
   if (platform === "windows") {
-    return `${goInstall}\ntailscale-browser-ext.exe --install=${extensionID}`;
+    return `curl -Lo tailscale-browser-ext.exe https://github.com/tailscale/tailchrome/releases/latest/download/tailscale-browser-ext-windows-amd64.exe\n.\\tailscale-browser-ext.exe ${flag}`;
   }
-  return `${goInstall} && ${installFlag}`;
+
+  const arch = "$(uname -m | sed 's/x86_64/amd64/')";
+
+  if (platform === "linux") {
+    return `curl -Lo tailscale-browser-ext https://github.com/tailscale/tailchrome/releases/latest/download/tailscale-browser-ext-linux-amd64 && chmod +x tailscale-browser-ext && ./tailscale-browser-ext ${flag}`;
+  }
+
+  // macOS (default)
+  return `curl -Lo tailscale-browser-ext https://github.com/tailscale/tailchrome/releases/latest/download/tailscale-browser-ext-darwin-${arch} && chmod +x tailscale-browser-ext && ./tailscale-browser-ext ${flag}`;
 }


### PR DESCRIPTION
## Summary
- Detect "forbidden" native messaging errors (mismatched extension ID) so users see the install screen instead of infinite reconnect loops
- Fix install command flag format from `--install=<id>` to `-install C<id>` to match the Go binary's expected input
- Replace `go install` with curl-based binary download — end users don't have Go installed

## Test plan
- [ ] Load unpacked extension with no native host installed — verify "Setup Required" screen appears
- [ ] Install host with wrong extension ID — verify "Setup Required" screen appears (previously caused infinite reconnect)
- [ ] Verify install command in popup uses correct `-install C<id>` format
- [ ] Verify platform detection shows correct curl command for macOS/Linux/Windows