### PR TITLE
Prepare extension for Chrome Web Store submission

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,10 @@ host-all:
 	cd host && GOOS=linux   GOARCH=amd64 CGO_ENABLED=0 go build $(LDFLAGS) -o ../dist/tailscale-browser-ext-linux-amd64 .
 	cd host && GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build $(LDFLAGS) -o ../dist/tailscale-browser-ext-windows-amd64.exe .
 
+zip: extension
+	mkdir -p dist
+	cd extension/dist && zip -r ../../dist/tailchrome-$(VERSION).zip .
+
 clean:
 	rm -rf dist/ extension/dist/
 

--- a/extension/src/popup/components/header.ts
+++ b/extension/src/popup/components/header.ts
@@ -59,7 +59,7 @@ export function renderHeader(
 
   const wordmark = document.createElement("span");
   wordmark.className = "header-wordmark";
-  wordmark.textContent = "Tailscale";
+  wordmark.textContent = "Tailchrome";
   logo.appendChild(wordmark);
 
   const toggle = createToggle(connected, () => {

--- a/extension/src/popup/popup.html
+++ b/extension/src/popup/popup.html
@@ -9,7 +9,7 @@
 </head>
 <body>
   <div id="root">
-    <p style="color:red;padding:20px;font-size:16px">Loading Tailscale…</p>
+    <p style="color:red;padding:20px;font-size:16px">Loading Tailchrome…</p>
   </div>
   <script type="module" src="popup.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- Add `make zip` target to bundle the extension distribution into a CWS-ready zip file
- Fix remaining "Tailscale" → "Tailchrome" branding in popup UI
- Extension bundle meets all Chrome Web Store best practices: MV3, minified code, no remote code, all permissions justified

## Details
The zip output from `make zip` produces `dist/tailchrome-<version>.zip` containing the compiled extension ready for CWS submission. Manifest and build configuration have been verified for compliance.