### PR TITLE
Defer state re-renders while sub-views are active

### DIFF
--- a/extension/src/popup/popup.ts
+++ b/extension/src/popup/popup.ts
@@ -13,6 +13,29 @@ let port: chrome.runtime.Port | null = null;
  * Send a message to the background service worker.
  * Exported for use by components and views.
  */
+/**
+ * Call when entering a sub-view (exit nodes, profiles) to prevent
+ * state updates from clobbering the overlay.
+ */
+export function enterSubView(): void {
+  subViewActive = true;
+  deferredState = null;
+}
+
+/**
+ * Call when leaving a sub-view. Applies any deferred state update.
+ */
+export function leaveSubView(): void {
+  subViewActive = false;
+  const state = deferredState ?? lastKnownState;
+  deferredState = null;
+  if (state) {
+    currentView = null;
+    lastStateSnapshot = null;
+    render(state);
+  }
+}
+
 export function sendMessage(msg: BackgroundMessage): void {
   if (port) {
     port.postMessage(msg);
@@ -27,6 +50,11 @@ export function sendMessage(msg: BackgroundMessage): void {
 let currentView: string | null = null;
 /** Tracks a serialized snapshot of the last rendered state for the same view. */
 let lastStateSnapshot: string | null = null;
+/** When a sub-view (exit nodes, profiles) is active, defer re-renders until it closes. */
+let subViewActive = false;
+let deferredState: TailscaleState | null = null;
+/** Last state passed to render(), so we can always re-render on sub-view exit. */
+let lastKnownState: TailscaleState | null = null;
 
 /**
  * Determines the view name for a given state.
@@ -44,6 +72,14 @@ function viewForState(state: TailscaleState): string {
 function render(state: TailscaleState): void {
   const root = document.getElementById("root");
   if (!root) return;
+
+  lastKnownState = state;
+
+  // If a sub-view is active, defer the re-render until it closes
+  if (subViewActive) {
+    deferredState = state;
+    return;
+  }
 
   const view = viewForState(state);
   const snapshot = JSON.stringify(state);

--- a/extension/src/popup/views/connected.ts
+++ b/extension/src/popup/views/connected.ts
@@ -4,7 +4,7 @@ import { renderHeader } from "../components/header";
 import { renderPeerList } from "../components/peer-list";
 import { renderHealthWarnings } from "../components/health-warnings";
 import { createCopyButton } from "../utils";
-import { sendMessage } from "../popup";
+import { sendMessage, enterSubView, leaveSubView } from "../popup";
 import { createToggle } from "../components/toggle-switch";
 import { renderExitNodes } from "./exit-nodes";
 import { renderProfiles } from "./profiles";
@@ -102,8 +102,9 @@ export function renderConnected(root: HTMLElement, state: TailscaleState): void 
 
   exitRow.appendChild(exitValue);
   exitRow.addEventListener("click", () => {
+    enterSubView();
     renderExitNodes(root, state, () => {
-      renderConnected(root, state);
+      leaveSubView();
     });
   });
   settings.appendChild(exitRow);
@@ -161,8 +162,9 @@ export function renderConnected(root: HTMLElement, state: TailscaleState): void 
 
     profileRow.appendChild(profileValue);
     profileRow.addEventListener("click", () => {
+      enterSubView();
       renderProfiles(root, state, () => {
-        renderConnected(root, state);
+        leaveSubView();
       });
     });
     settings.appendChild(profileRow);


### PR DESCRIPTION
## Summary

- Adds a sub-view deferral mechanism to prevent background state updates from clobbering exit node and profile picker overlays
- State updates arriving while a sub-view is open are stashed and applied when the user navigates back
- Replaces direct `renderConnected` callbacks with `enterSubView`/`leaveSubView` lifecycle hooks

## Test plan

- [ ] Open the exit node picker, verify it stays open when a background state update arrives
- [ ] Open the profile picker, verify same behavior
- [ ] Navigate back from either sub-view, verify the main view re-renders with the latest state
- [ ] Rapidly toggle between sub-views and main view to verify no stale state