### PR TITLE
Remember exit node when reconnecting

### DIFF
--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -21,6 +21,9 @@ const badgeManager = new BadgeManager();
 // Connected popup ports
 const popupPorts: Set<chrome.runtime.Port> = new Set();
 
+// Track whether we've attempted to restore exit node for this connection
+let exitNodeRestoreAttempted = false;
+
 // ---------------------------------------------------------------------------
 // Subscribe to state changes
 // ---------------------------------------------------------------------------
@@ -92,6 +95,30 @@ function handleNativeMessage(msg: NativeReply): void {
   // Status update
   if (msg.status) {
     store.applyStatusUpdate(msg.status);
+
+    // Restore saved exit node after reconnection
+    if (
+      !exitNodeRestoreAttempted &&
+      msg.status.backendState === "Running" &&
+      !msg.status.exitNode
+    ) {
+      exitNodeRestoreAttempted = true;
+      chrome.storage.local.get("lastExitNodeID").then((result) => {
+        if (result["lastExitNodeID"]) {
+          console.log(
+            "[Background] Restoring saved exit node:",
+            result["lastExitNodeID"]
+          );
+          nativeHost.send({
+            cmd: "set-exit-node",
+            nodeID: result["lastExitNodeID"],
+          });
+        }
+      });
+    } else if (msg.status.backendState === "Running" && msg.status.exitNode) {
+      // Mark as attempted if already has an exit node
+      exitNodeRestoreAttempted = true;
+    }
   }
 
   // Profiles result
@@ -166,6 +193,9 @@ function handleNativeMessage(msg: NativeReply): void {
 }
 
 function handleNativeStateChange(connected: boolean): void {
+  if (!connected) {
+    exitNodeRestoreAttempted = false;
+  }
   store.update({
     hostConnected: connected,
     // Clear install error on successful connection, reset state when disconnected
@@ -283,11 +313,13 @@ function handlePopupMessage(msg: BackgroundMessage): void {
 
     case "set-exit-node": {
       nativeHost.send({ cmd: "set-exit-node", nodeID: msg.nodeID });
+      chrome.storage.local.set({ lastExitNodeID: msg.nodeID });
       break;
     }
 
     case "clear-exit-node": {
       nativeHost.send({ cmd: "set-exit-node", nodeID: "" });
+      chrome.storage.local.remove("lastExitNodeID");
       break;
     }
 


### PR DESCRIPTION
## Summary
- Persists the selected exit node ID to `chrome.storage.local` when the user picks an exit node
- Automatically restores the saved exit node after the extension reconnects to the native host (e.g. browser restart, service worker restart)
- Clears the saved preference when the user explicitly selects "None (direct connection)"
- Uses a per-connection flag to ensure restore only runs once per reconnection

## Test plan
- [x] Select an exit node, close and reopen the browser — verify the exit node is automatically re-selected
- [x] Select an exit node, then clear it, restart the browser — verify no exit node is restored
- [x] Select exit node A, then switch to exit node B, restart — verify exit node B is restored
- [x] Disconnect/reconnect the native host — verify the exit node is restored

Fixes #14