### PR TITLE
Release v0.1.5

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5/m925fPufiafHbegmZwPoowhf4XOlaEKseW/9Q3u47OQ6ALk/hSYqVOjvv2SZSVIVbVJs5CrfmjWqf65Y6Nf3EkkDYHiimLXifO1XekQMQWsp1KZNHR8ymKDyOE/BFFpl2QgQgfwvNLUYZv6z9+lS95UBZk4rkpm3qS3yFuMaShdURljE/DyrmelRQDCy8YJsoj2yyf4qkap3DCw5k2z5nRGxmw71E4JwavlKySIH5C+wCMo/EoHkjrS/uupbpTxvfTIuXYmmPhx3yyCwBazNrkNjNe5NQk1cLvUkrGvnzo8PO2Zx3Qh9qRZUtdMZ7p1xDzUZi37uePw6QT1xjKwQIDAQAB",
   "name": "Tailchrome",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Access your tailnet from your browser. Run a full Tailscale node per browser profile without affecting system networking.",
   "permissions": [
     "proxy",

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tailscale-browser-extension",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tailscale-browser-extension",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "devDependencies": {
         "@types/chrome": "^0.0.300",
         "esbuild": "^0.24.0",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailscale-browser-extension",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "scripts": {
     "build": "node esbuild.config.mjs",


### PR DESCRIPTION
## Summary
- Bump version to 0.1.5 across extension manifest, package.json, and package-lock.json

## Changes since v0.1.4
- Remember exit node selection across reconnections (#16)

## Test plan
- [x] Type checking passes
- [x] All 39 tests pass
- [x] Extension builds successfully