### PR TITLE
Prefer DNS names over IPs when opening devices

### DIFF
--- a/extension/src/popup/components/peer-item.ts
+++ b/extension/src/popup/components/peer-item.ts
@@ -46,10 +46,15 @@ export function formatRelativeTime(isoDate: string | null): string {
   return "long ago";
 }
 
+export interface PeerItemOptions {
+  /** When true, MagicDNS is enabled and DNS names can be used to reach peers. */
+  magicDNS?: boolean;
+}
+
 /**
  * Creates a single peer item row element with expandable actions.
  */
-export function createPeerItem(peer: PeerInfo): HTMLElement {
+export function createPeerItem(peer: PeerInfo, options: PeerItemOptions = {}): HTMLElement {
   const container = document.createElement("div");
   container.className = "peer-item-container";
 
@@ -124,7 +129,7 @@ export function createPeerItem(peer: PeerInfo): HTMLElement {
   }
 
   if (peer.online) {
-    const openTarget = shortDNS || firstIP;
+    const openTarget = (options.magicDNS && shortDNS) || firstIP;
     if (openTarget) {
       actions.appendChild(createActionButton("Open", () => {
         chrome.tabs.create({ url: `http://${openTarget}/` });

--- a/extension/src/popup/components/peer-list.ts
+++ b/extension/src/popup/components/peer-list.ts
@@ -1,5 +1,5 @@
 import type { PeerInfo } from "../../shared/types";
-import { createPeerItem } from "./peer-item";
+import { createPeerItem, type PeerItemOptions } from "./peer-item";
 
 /**
  * Creates a section header element with label and optional count.
@@ -25,7 +25,7 @@ function createSectionHeader(label: string, count: number): HTMLElement {
  * Renders the peer list, grouped by online/offline status.
  * Online peers appear first, followed by offline peers.
  */
-export function renderPeerList(container: HTMLElement, peers: PeerInfo[]): void {
+export function renderPeerList(container: HTMLElement, peers: PeerInfo[], options: PeerItemOptions = {}): void {
   container.textContent = "";
 
   if (peers.length === 0) {
@@ -60,7 +60,7 @@ export function renderPeerList(container: HTMLElement, peers: PeerInfo[]): void 
     const list = document.createElement("div");
     list.className = "peer-list";
     for (const peer of online) {
-      list.appendChild(createPeerItem(peer));
+      list.appendChild(createPeerItem(peer, options));
     }
     container.appendChild(list);
   }
@@ -71,7 +71,7 @@ export function renderPeerList(container: HTMLElement, peers: PeerInfo[]): void 
     const list = document.createElement("div");
     list.className = "peer-list";
     for (const peer of offline) {
-      list.appendChild(createPeerItem(peer));
+      list.appendChild(createPeerItem(peer, options));
     }
     container.appendChild(list);
   }

--- a/extension/src/popup/views/connected.ts
+++ b/extension/src/popup/views/connected.ts
@@ -185,7 +185,7 @@ export function renderConnected(root: HTMLElement, state: TailscaleState): void 
 
   // --- Peer List ---
   const peerContainer = document.createElement("div");
-  renderPeerList(peerContainer, state.peers);
+  renderPeerList(peerContainer, state.peers, { magicDNS: state.prefs?.corpDNS ?? true });
   view.appendChild(peerContainer);
 
   // --- Footer ---


### PR DESCRIPTION
## Summary
- The "Open" button now uses the device's Tailscale DNS name (e.g., `homeassistant.tail125ee2.ts.net`) instead of the raw IP, with IP as fallback
- Fixes services like Home Assistant that reject connections by IP due to Host header validation
- Enables proper TLS cert validation for Tailscale's Let's Encrypt certs (issued for `*.ts.net`, not `100.x.x.x`)
- "Copy IP" and "Copy DNS" buttons remain unchanged for users who need either

Closes #20

## Test plan
- [x] Click "Open" on a device — verify it navigates to `http://<dnsname>/` 
- [x] Verify Home Assistant or similar hostname-sensitive services load correctly
- [x] Test with a device that has no DNS name — verify fallback to IP
- [x] Verify "Copy IP" and "Copy DNS" still work independently