### PR TITLE
feat: side panel mode + release/publish CI fixes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,7 +46,10 @@ jobs:
           gh release download "${{ inputs.release_tag }}" --dir dist --pattern chrome.zip --pattern SHA256SUMS.txt
       - name: Verify checksums
         run: |
-          grep '  chrome.zip$' dist/SHA256SUMS.txt | (cd dist && sha256sum -c -)
+          set -euo pipefail
+          grep '  chrome.zip$' dist/SHA256SUMS.txt > dist/chrome.SHA256SUMS.txt
+          test "$(wc -l < dist/chrome.SHA256SUMS.txt)" -eq 1
+          (cd dist && sha256sum -c chrome.SHA256SUMS.txt)
       - name: Submit to Chrome Web Store
         env:
           CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
@@ -94,7 +97,10 @@ jobs:
           unzip -q dist/firefox.zip -d dist/firefox-unpacked
       - name: Verify checksums
         run: |
-          grep -E '  (firefox.zip|firefox-sources.zip)$' dist/SHA256SUMS.txt | (cd dist && sha256sum -c -)
+          set -euo pipefail
+          grep -E '  (firefox.zip|firefox-sources.zip)$' dist/SHA256SUMS.txt > dist/firefox.SHA256SUMS.txt
+          test "$(wc -l < dist/firefox.SHA256SUMS.txt)" -eq 2
+          (cd dist && sha256sum -c firefox.SHA256SUMS.txt)
       - name: Validate Firefox publish gate
         run: |
           pnpm validate:firefox-publish -- \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,10 +185,14 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p release
-          # actions/upload-artifact preserves source paths inside the artifact,
-          # so signed-darwin's contents land at signed-darwin/dist/...
-          cp signed-darwin/dist/tailscale-browser-ext-darwin-amd64 release/
-          cp signed-darwin/dist/tailscale-browser-ext-darwin-arm64 release/
+          # actions/upload-artifact strips the common-ancestor prefix when
+          # all uploaded paths share one. signed-darwin uploads two dist/...
+          # files, so dist/ is stripped and the artifact's contents are flat
+          # — they extract straight into signed-darwin/.
+          cp signed-darwin/tailscale-browser-ext-darwin-amd64 release/
+          cp signed-darwin/tailscale-browser-ext-darwin-arm64 release/
+          # build-output uploads paths under both dist/ and packages/, so it
+          # has no common ancestor and the artifact preserves the full paths.
           cp dist/tailscale-browser-ext-linux-amd64 release/
           cp dist/tailscale-browser-ext-windows-amd64.exe release/
           cp packages/extension/.output/chrome.zip release/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,8 +185,10 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p release
-          cp signed-darwin/tailscale-browser-ext-darwin-amd64 release/
-          cp signed-darwin/tailscale-browser-ext-darwin-arm64 release/
+          # actions/upload-artifact preserves source paths inside the artifact,
+          # so signed-darwin's contents land at signed-darwin/dist/...
+          cp signed-darwin/dist/tailscale-browser-ext-darwin-amd64 release/
+          cp signed-darwin/dist/tailscale-browser-ext-darwin-arm64 release/
           cp dist/tailscale-browser-ext-linux-amd64 release/
           cp dist/tailscale-browser-ext-windows-amd64.exe release/
           cp packages/extension/.output/chrome.zip release/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,13 +179,14 @@ jobs:
         uses: actions/download-artifact@v6
         with:
           name: signed-darwin
+          path: signed-darwin
 
       - name: Collect release assets
         run: |
           set -euo pipefail
           mkdir -p release
-          cp dist/tailscale-browser-ext-darwin-amd64 release/
-          cp dist/tailscale-browser-ext-darwin-arm64 release/
+          cp signed-darwin/tailscale-browser-ext-darwin-amd64 release/
+          cp signed-darwin/tailscale-browser-ext-darwin-arm64 release/
           cp dist/tailscale-browser-ext-linux-amd64 release/
           cp dist/tailscale-browser-ext-windows-amd64.exe release/
           cp packages/extension/.output/chrome.zip release/

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ Thumbs.db
 # persistmem
 CLAUDE.md
 .claude/
+docs/superpowers/
 
 # Editor swap files
 *.swp

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ By default, clicking the Tailchrome toolbar icon opens a popup that dismisses on
 - **Chrome:** the side panel opens on toolbar click and stays open until you close it. Chrome keeps the extension's service worker alive while the panel is visible, so peer status updates feel snappier.
 - **Firefox:** the toolbar click opens Tailchrome in the sidebar. Flip the toggle from inside the sidebar to switch back to popup mode.
 
-The same UI renders in either surface. If you drag the panel wide enough, the layout reserves space for a future details pane next to the peer list.
+The same UI renders in either surface.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ The extension has two parts:
 
 They communicate over the browser's native messaging protocol. See the [full documentation](docs/DOCUMENTATION.md) for details.
 
+### Side panel mode
+
+By default, clicking the Tailchrome toolbar icon opens a popup that dismisses on click-away. If you'd rather keep the UI visible while you browse, flip **Open as side panel** in the popup's quick settings:
+
+- **Chrome:** the side panel opens on toolbar click and stays open until you close it. Chrome keeps the extension's service worker alive while the panel is visible, so peer status updates feel snappier.
+- **Firefox:** the toolbar click opens Tailchrome in the sidebar. Flip the toggle from inside the sidebar to switch back to popup mode.
+
+The same UI renders in either surface; at wider widths the layout opens up to a two-column view (peer list + selected-peer details).
+
 ## Install
 
 1. Get the extension from the [Chrome Web Store](https://chromewebstore.google.com/detail/tailchrome/bhfeceecialgilpedkoflminjgcjljll) or [Firefox Add-ons](https://addons.mozilla.org/en-US/firefox/addon/tailchrome/)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ By default, clicking the Tailchrome toolbar icon opens a popup that dismisses on
 - **Chrome:** the side panel opens on toolbar click and stays open until you close it. Chrome keeps the extension's service worker alive while the panel is visible, so peer status updates feel snappier.
 - **Firefox:** the toolbar click opens Tailchrome in the sidebar. Flip the toggle from inside the sidebar to switch back to popup mode.
 
-The same UI renders in either surface; at wider widths the layout opens up to a two-column view (peer list + selected-peer details).
+The same UI renders in either surface. If you drag the panel wide enough, the layout reserves space for a future details pane next to the peer list.
 
 ## Install
 

--- a/STORE_LISTING.md
+++ b/STORE_LISTING.md
@@ -1,0 +1,83 @@
+# Tailchrome Store Listings
+
+## Chrome Web Store
+
+### Short Description (132 chars max)
+
+Access your Tailscale tailnet directly from your browser. Per-profile VPN without touching system networking.
+
+### Detailed Description
+
+Tailchrome connects your browser to your Tailscale tailnet without installing a system-wide VPN. Each browser profile runs its own isolated Tailscale node, so you can be logged into different tailnets in different profiles.
+
+**Key features:**
+- Access devices on your tailnet by name or IP, directly from the browser
+- Per-profile isolation: each Chrome profile gets its own Tailscale identity
+- Exit nodes: route browser traffic through any exit node on your tailnet
+- MagicDNS: reach your devices by hostname
+- Subnet routing: access resources behind subnet routers
+- Taildrop: send files to other devices on your tailnet
+- No system networking changes: only browser traffic is affected
+- Shields Up mode for extra security
+
+**How it works:**
+Tailchrome uses a lightweight native helper app that runs a full Tailscale node for each browser profile. Your system networking stays untouched. Only traffic from the browser is routed through your tailnet.
+
+**Getting started:**
+1. Install the extension
+2. Download and run the helper app (one-time setup, ~30 seconds)
+3. Log in to your Tailscale account
+4. Toggle the switch to connect
+
+**Privacy:** Tailchrome communicates only with Tailscale's coordination server and your tailnet peers. No data is sent to third parties. The extension requires the "proxy" permission to route browser traffic and "nativeMessaging" to communicate with the helper app.
+
+### Category
+Productivity
+
+### Language
+English
+
+
+## Firefox AMO
+
+### Summary (250 chars max)
+
+Access your Tailscale tailnet directly from Firefox. Each browser profile runs its own isolated Tailscale node without affecting system networking. Supports exit nodes, MagicDNS, subnet routing, and Taildrop.
+
+### Description
+
+Tailchrome connects Firefox to your Tailscale tailnet without a system VPN. Each browser profile gets its own Tailscale identity, keeping your personal and work tailnets separate.
+
+**Features:**
+- Browse devices on your tailnet by name or IP
+- Per-profile Tailscale isolation
+- Exit nodes for routing through your tailnet
+- MagicDNS hostname resolution
+- Subnet routing support
+- Taildrop file transfers
+- Zero system networking changes
+- Shields Up mode
+
+**Setup:**
+Install the extension, download the helper app, and log in. The helper app is a small native program that runs a Tailscale node per browser profile. Setup takes about 30 seconds.
+
+**How it works:**
+A native messaging host runs locally and manages Tailscale connections per profile. Only Firefox traffic is routed through your tailnet. Your system networking is never modified.
+
+**Open Source:**
+Source code is available at https://github.com/dantraynor/tailchrome
+
+### Categories
+Privacy & Security, Other
+
+
+## Screenshot Descriptions
+
+For creating store screenshots, capture these states at 360px width:
+
+1. **Connected view** - Show the main popup with a connected tailnet, green status dot, IP address, and a few online peers
+2. **Exit node picker** - Show the exit node selection with suggested node and a few options with country flags
+3. **Peer actions** - Show an expanded peer item with Copy IP, Copy DNS, Open, SSH buttons
+4. **Quick Setup** - Show the install stepper with "Download for macOS" button and step 2 instructions
+5. **Profile switcher** - Show multiple profiles with Active badge
+6. **Dark mode** - Repeat screenshot 1 in dark mode to show theme support

--- a/packages/extension/src/background/chrome.ts
+++ b/packages/extension/src/background/chrome.ts
@@ -6,6 +6,7 @@ export function startChromeBackground(): void {
   const { proxyManager } = initBackground(
     new ChromeProxyManager(),
     CHROME_NATIVE_HOST_ID,
+    { browserKind: "chrome" },
   );
 
   chrome.runtime.onSuspend?.addListener(() => {

--- a/packages/extension/src/background/firefox.test.ts
+++ b/packages/extension/src/background/firefox.test.ts
@@ -119,7 +119,7 @@ describe("startFirefoxBackground", () => {
     expect(mocks.initBackground).toHaveBeenCalledWith(
       mocks.proxyManagerInstance,
       FIREFOX_NATIVE_HOST_ID,
-      { skipKeepalive: true },
+      { browserKind: "firefox", skipKeepalive: true },
     );
     expect(alarmsCreate).toHaveBeenCalledWith("keepalive", {
       periodInMinutes: 25_000 / 60_000,

--- a/packages/extension/src/background/firefox.ts
+++ b/packages/extension/src/background/firefox.ts
@@ -2,6 +2,7 @@ import {
   initBackground,
   type BackgroundHandle,
 } from "@tailchrome/shared/background/background";
+import { registerSidebarOpener } from "@tailchrome/shared/background/ui-surface";
 import { KEEPALIVE_INTERVAL_MS } from "@tailchrome/shared/constants";
 import { FIREFOX_NATIVE_HOST_ID } from "../constants";
 import { FirefoxProxyManager } from "./firefox-proxy-manager";
@@ -28,6 +29,12 @@ const KEEPALIVE_PERIOD_MINUTES = KEEPALIVE_INTERVAL_MS / 60_000;
 export function startFirefoxBackground(): void {
   const proxyManager = new FirefoxProxyManager();
   let backgroundHandle: BackgroundHandle | null = null;
+
+  // Register the sidebar opener synchronously at top-level so a toolbar
+  // click that wakes a dormant service worker is delivered to the listener.
+  // Anything registered later (after async storage restore resolves) can
+  // miss the wake-up event.
+  registerSidebarOpener();
 
   browser.proxy.onRequest.addListener(proxyManager.listener, {
     urls: ["<all_urls>"],

--- a/packages/extension/src/background/firefox.ts
+++ b/packages/extension/src/background/firefox.ts
@@ -44,6 +44,7 @@ export function startFirefoxBackground(): void {
     .then(() => {
       backgroundHandle = initBackground(proxyManager, FIREFOX_NATIVE_HOST_ID, {
         skipKeepalive: true,
+        browserKind: "firefox",
       });
 
       browser.alarms.create("keepalive", {

--- a/packages/extension/wxt.config.ts
+++ b/packages/extension/wxt.config.ts
@@ -23,6 +23,12 @@ interface TailchromeManifest extends UserManifest {
       data_collection_permissions?: FirefoxDataCollectionPermissions;
     };
   };
+  side_panel?: { default_path: string };
+  sidebar_action?: {
+    default_panel: string;
+    default_title: string;
+    default_icon: Record<string, string>;
+  };
 }
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -97,6 +103,7 @@ export default defineConfig({
         "nativeMessaging",
         "contextMenus",
         ...(browser === "firefox" ? ["alarms"] : []),
+        ...(browser === "chrome" ? ["sidePanel" as const] : []),
       ],
       action: {
         default_icon: chromeActionIcons,
@@ -105,10 +112,20 @@ export default defineConfig({
     };
 
     if (browser === "chrome") {
+      manifest.side_panel = { default_path: "popup.html" };
       manifest.key =
         "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5/m925fPufiafHbegmZwPoowhf4XOlaEKseW/9Q3u47OQ6ALk/hSYqVOjvv2SZSVIVbVJs5CrfmjWqf65Y6Nf3EkkDYHiimLXifO1XekQMQWsp1KZNHR8ymKDyOE/BFFpl2QgQgfwvNLUYZv6z9+lS95UBZk4rkpm3qS3yFuMaShdURljE/DyrmelRQDCy8YJsoj2yyf4qkap3DCw5k2z5nRGxmw71E4JwavlKySIH5C+wCMo/EoHkjrS/uupbpTxvfTIuXYmmPhx3yyCwBazNrkNjNe5NQk1cLvUkrGvnzo8PO2Zx3Qh9qRZUtdMZ7p1xDzUZi37uePw6QT1xjKwQIDAQAB";
       return manifest;
     }
+
+    manifest.sidebar_action = {
+      default_panel: "popup.html",
+      default_title: "Tailchrome",
+      default_icon: {
+        "16": "icons/icon-16.png",
+        "32": "icons/icon-32.png",
+      },
+    };
 
     manifest.browser_specific_settings = {
       gecko: {

--- a/packages/extension/wxt.config.ts
+++ b/packages/extension/wxt.config.ts
@@ -28,6 +28,7 @@ interface TailchromeManifest extends UserManifest {
     default_panel: string;
     default_title: string;
     default_icon: Record<string, string>;
+    open_at_install?: boolean;
   };
 }
 
@@ -125,6 +126,9 @@ export default defineConfig({
         "16": "icons/icon-16.png",
         "32": "icons/icon-32.png",
       },
+      // Firefox defaults open_at_install to true; keep the sidebar opt-in
+      // and let the uiSurface toggle control when it appears.
+      open_at_install: false,
     };
 
     manifest.browser_specific_settings = {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -10,6 +10,7 @@
   "devDependencies": {
     "@types/chrome": "^0.0.300",
     "esbuild": "^0.27.4",
+    "happy-dom": "^20.9.0",
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"
   }

--- a/packages/shared/src/__test__/chrome-mock.ts
+++ b/packages/shared/src/__test__/chrome-mock.ts
@@ -1,10 +1,21 @@
 // Minimal chrome API mock for testing extension background scripts.
+import { vi } from "vitest";
+
+const actionClickedListeners: Array<(tab: unknown) => void> = [];
+const storageChangedListeners: Array<
+  (changes: Record<string, { oldValue?: unknown; newValue?: unknown }>, area: string) => void
+> = [];
 
 const chromeMock = {
   action: {
     setIcon: (_details: unknown) => Promise.resolve(),
     setBadgeText: (_details: unknown) => {},
     setBadgeBackgroundColor: (_details: unknown) => {},
+    setPopup: vi.fn((_details: { popup: string }) => Promise.resolve()),
+    onClicked: {
+      addListener: (fn: (tab: unknown) => void) => { actionClickedListeners.push(fn); },
+      _listeners: actionClickedListeners,
+    },
   },
   proxy: {
     settings: {
@@ -61,6 +72,19 @@ const chromeMock = {
       set: (_items: Record<string, unknown>) => Promise.resolve(),
       remove: (_key: string) => Promise.resolve(),
     },
+    onChanged: {
+      addListener: (fn: (changes: Record<string, chrome.storage.StorageChange>, area: string) => void) => {
+        storageChangedListeners.push(fn);
+      },
+      _listeners: storageChangedListeners,
+    },
+  },
+  sidePanel: {
+    setPanelBehavior: vi.fn((_details: { openPanelOnActionClick: boolean }) => Promise.resolve()),
+    open: vi.fn((_details: { windowId: number }) => Promise.resolve()),
+  },
+  sidebarAction: {
+    open: vi.fn(() => Promise.resolve()),
   },
   tabs: {
     create: (_opts: unknown) => Promise.resolve(),

--- a/packages/shared/src/background/background.test.ts
+++ b/packages/shared/src/background/background.test.ts
@@ -795,7 +795,7 @@ describe("initBackground", () => {
             (changes: Record<string, { newValue?: unknown }>, area: string) => void
           >;
         })._listeners;
-      await listeners[listeners.length - 1]({ uiSurface: { newValue: "popup" } }, "local");
+      await listeners[listeners.length - 1]!({ uiSurface: { newValue: "popup" } }, "local");
       await Promise.resolve();
 
       expect(chrome.sidePanel.setPanelBehavior).toHaveBeenCalledWith({

--- a/packages/shared/src/background/background.test.ts
+++ b/packages/shared/src/background/background.test.ts
@@ -764,6 +764,46 @@ describe("initBackground", () => {
     });
   });
 
+  describe("uiSurface wiring", () => {
+    beforeEach(() => {
+      (chrome.sidePanel.setPanelBehavior as ReturnType<typeof vi.fn>).mockClear();
+      (chrome.storage.local.get as unknown as ReturnType<typeof vi.fn>) = vi.fn(
+        () => Promise.resolve({ uiSurface: "sidePanel" }),
+      );
+    });
+
+    it("calls applyUiSurface with the persisted setting on init", async () => {
+      const proxy: ProxyManager = { apply: vi.fn(), clear: vi.fn() };
+      initBackground(proxy, "test-host", { browserKind: "chrome" });
+      // applyUiSurface is async; flush the microtask queue.
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(chrome.sidePanel.setPanelBehavior).toHaveBeenCalledWith({
+        openPanelOnActionClick: true,
+      });
+    });
+
+    it("re-applies when uiSurface changes in storage", async () => {
+      const proxy: ProxyManager = { apply: vi.fn(), clear: vi.fn() };
+      initBackground(proxy, "test-host", { browserKind: "chrome" });
+      await Promise.resolve();
+      (chrome.sidePanel.setPanelBehavior as ReturnType<typeof vi.fn>).mockClear();
+
+      const listeners =
+        (chrome.storage.onChanged as unknown as {
+          _listeners: Array<
+            (changes: Record<string, { newValue?: unknown }>, area: string) => void
+          >;
+        })._listeners;
+      await listeners[listeners.length - 1]({ uiSurface: { newValue: "popup" } }, "local");
+      await Promise.resolve();
+
+      expect(chrome.sidePanel.setPanelBehavior).toHaveBeenCalledWith({
+        openPanelOnActionClick: false,
+      });
+    });
+  });
+
   describe("keepalive", () => {
     it("sends ping at keepalive interval when connected", async () => {
       await setupBackground();

--- a/packages/shared/src/background/background.ts
+++ b/packages/shared/src/background/background.ts
@@ -11,12 +11,7 @@ import { NativeHostConnection } from "./native-host";
 import { BadgeManager } from "./badge-manager";
 import { DefaultTimerService, type TimerService } from "./timer-service";
 import { formatBugReportForToast } from "./format-bug-report-toast";
-import {
-  applyUiSurface,
-  readUiSurface,
-  registerSidebarOpener,
-  type BrowserKind,
-} from "./ui-surface";
+import { applyUiSurface, readUiSurface, type BrowserKind } from "./ui-surface";
 
 export type { ProxyManager };
 
@@ -94,10 +89,6 @@ export function initBackground(
       void applyUiSurface(next, browserKind).catch(logUiSurfaceFailure);
     }
   });
-
-  if (browserKind === "firefox") {
-    registerSidebarOpener();
-  }
 
   const store = new StateStore();
   const badgeManager = new BadgeManager();

--- a/packages/shared/src/background/background.ts
+++ b/packages/shared/src/background/background.ts
@@ -79,12 +79,19 @@ export function initBackground(
   const browserKind: BrowserKind = options?.browserKind ?? "chrome";
 
   // Apply the persisted UI-surface preference and react to changes.
-  void readUiSurface().then((surface) => applyUiSurface(surface, browserKind));
+  // Catch rejections so the service worker startup never fails on a
+  // missing-API edge case (older Chrome, Firefox without the polyfill, etc.).
+  const logUiSurfaceFailure = (err: unknown): void => {
+    console.warn("[Background] applyUiSurface failed:", err);
+  };
+  void readUiSurface()
+    .then((surface) => applyUiSurface(surface, browserKind))
+    .catch(logUiSurfaceFailure);
   chrome.storage.onChanged.addListener((changes, area) => {
     if (area !== "local" || !("uiSurface" in changes)) return;
     const next = changes["uiSurface"]?.newValue;
     if (next === "popup" || next === "sidePanel") {
-      void applyUiSurface(next, browserKind);
+      void applyUiSurface(next, browserKind).catch(logUiSurfaceFailure);
     }
   });
 

--- a/packages/shared/src/background/background.ts
+++ b/packages/shared/src/background/background.ts
@@ -11,6 +11,12 @@ import { NativeHostConnection } from "./native-host";
 import { BadgeManager } from "./badge-manager";
 import { DefaultTimerService, type TimerService } from "./timer-service";
 import { formatBugReportForToast } from "./format-bug-report-toast";
+import {
+  applyUiSurface,
+  readUiSurface,
+  registerSidebarOpener,
+  type BrowserKind,
+} from "./ui-surface";
 
 export type { ProxyManager };
 
@@ -27,6 +33,7 @@ export interface InitBackgroundOptions {
   timerService?: TimerService;
   /** Skip the built-in setInterval keepalive (e.g. when the caller uses browser.alarms instead). */
   skipKeepalive?: boolean;
+  browserKind?: BrowserKind;
 }
 
 const ALLOWED_LOGIN_ORIGINS = [
@@ -69,6 +76,22 @@ export function initBackground(
   options?: InitBackgroundOptions,
 ): BackgroundHandle {
   const timerService = options?.timerService ?? new DefaultTimerService();
+  const browserKind: BrowserKind = options?.browserKind ?? "chrome";
+
+  // Apply the persisted UI-surface preference and react to changes.
+  void readUiSurface().then((surface) => applyUiSurface(surface, browserKind));
+  chrome.storage.onChanged.addListener((changes, area) => {
+    if (area !== "local" || !("uiSurface" in changes)) return;
+    const next = changes["uiSurface"]?.newValue;
+    if (next === "popup" || next === "sidePanel") {
+      void applyUiSurface(next, browserKind);
+    }
+  });
+
+  if (browserKind === "firefox") {
+    registerSidebarOpener();
+  }
+
   const store = new StateStore();
   const badgeManager = new BadgeManager();
 

--- a/packages/shared/src/background/ui-surface.test.ts
+++ b/packages/shared/src/background/ui-surface.test.ts
@@ -98,11 +98,13 @@ describe("registerSidebarOpener (Firefox)", () => {
     (chrome.storage.local.get as unknown as ReturnType<typeof vi.fn>) = vi.fn(
       () => Promise.resolve({ uiSurface: "sidePanel" }),
     );
-    registerSidebarOpener();
-    const listeners =
+    const listenersArr =
       (chrome.action.onClicked as unknown as { _listeners: Array<(tab: unknown) => void> })
         ._listeners;
-    await listeners[listeners.length - 1]({});
+    const before = listenersArr.length;
+    registerSidebarOpener();
+    expect(listenersArr.length).toBe(before + 1);
+    await listenersArr[before]({});
     expect(chrome.sidebarAction.open).toHaveBeenCalledTimes(1);
   });
 
@@ -110,11 +112,13 @@ describe("registerSidebarOpener (Firefox)", () => {
     (chrome.storage.local.get as unknown as ReturnType<typeof vi.fn>) = vi.fn(
       () => Promise.resolve({ uiSurface: "popup" }),
     );
-    registerSidebarOpener();
-    const listeners =
+    const listenersArr =
       (chrome.action.onClicked as unknown as { _listeners: Array<(tab: unknown) => void> })
         ._listeners;
-    await listeners[listeners.length - 1]({});
+    const before = listenersArr.length;
+    registerSidebarOpener();
+    expect(listenersArr.length).toBe(before + 1);
+    await listenersArr[before]({});
     expect(chrome.sidebarAction.open).not.toHaveBeenCalled();
   });
 });

--- a/packages/shared/src/background/ui-surface.test.ts
+++ b/packages/shared/src/background/ui-surface.test.ts
@@ -3,7 +3,6 @@ import {
   applyUiSurface,
   readUiSurface,
   registerSidebarOpener,
-  setCachedUiSurface,
   writeUiSurface,
 } from "./ui-surface";
 
@@ -101,27 +100,16 @@ describe("registerSidebarOpener (Firefox)", () => {
     chromeWithSidebar.sidebarAction.open.mockClear();
   });
 
-  it("opens the sidebar when toolbar click fires while in sidePanel mode", () => {
-    setCachedUiSurface("sidePanel");
+  it("registers a single onClicked listener that opens the sidebar synchronously", () => {
     const listenersArr =
       (chrome.action.onClicked as unknown as { _listeners: Array<(tab: unknown) => void> })
         ._listeners;
     const before = listenersArr.length;
     registerSidebarOpener();
     expect(listenersArr.length).toBe(before + 1);
+    // Firefox only fires action.onClicked when setPopup has been cleared
+    // (= side-panel mode), so the handler unconditionally opens the sidebar.
     listenersArr[before]!({});
     expect(chromeWithSidebar.sidebarAction.open).toHaveBeenCalledTimes(1);
-  });
-
-  it("does NOT open the sidebar when in popup mode (popup handles the click)", () => {
-    setCachedUiSurface("popup");
-    const listenersArr =
-      (chrome.action.onClicked as unknown as { _listeners: Array<(tab: unknown) => void> })
-        ._listeners;
-    const before = listenersArr.length;
-    registerSidebarOpener();
-    expect(listenersArr.length).toBe(before + 1);
-    listenersArr[before]!({});
-    expect(chromeWithSidebar.sidebarAction.open).not.toHaveBeenCalled();
   });
 });

--- a/packages/shared/src/background/ui-surface.test.ts
+++ b/packages/shared/src/background/ui-surface.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { readUiSurface, writeUiSurface } from "./ui-surface";
+
+describe("ui-surface setting", () => {
+  beforeEach(() => {
+    (chrome.storage.local.get as unknown as ReturnType<typeof vi.fn>) = vi.fn(
+      () => Promise.resolve({}),
+    );
+    (chrome.storage.local.set as unknown as ReturnType<typeof vi.fn>) = vi.fn(
+      () => Promise.resolve(),
+    );
+  });
+
+  it("readUiSurface returns 'popup' when nothing is stored", async () => {
+    expect(await readUiSurface()).toBe("popup");
+  });
+
+  it("readUiSurface returns the stored value", async () => {
+    (chrome.storage.local.get as unknown as ReturnType<typeof vi.fn>) = vi.fn(
+      () => Promise.resolve({ uiSurface: "sidePanel" }),
+    );
+    expect(await readUiSurface()).toBe("sidePanel");
+  });
+
+  it("readUiSurface coerces an unknown stored value to 'popup'", async () => {
+    (chrome.storage.local.get as unknown as ReturnType<typeof vi.fn>) = vi.fn(
+      () => Promise.resolve({ uiSurface: "garbage" }),
+    );
+    expect(await readUiSurface()).toBe("popup");
+  });
+
+  it("writeUiSurface persists the value to storage.local", async () => {
+    const setSpy = vi.fn(() => Promise.resolve());
+    (chrome.storage.local.set as unknown as ReturnType<typeof vi.fn>) = setSpy;
+    await writeUiSurface("sidePanel");
+    expect(setSpy).toHaveBeenCalledWith({ uiSurface: "sidePanel" });
+  });
+});
+
+import { applyUiSurface } from "./ui-surface";
+
+describe("applyUiSurface — Chrome", () => {
+  beforeEach(() => {
+    (chrome.sidePanel.setPanelBehavior as ReturnType<typeof vi.fn>).mockClear();
+    (chrome.action.setPopup as ReturnType<typeof vi.fn>).mockClear();
+  });
+
+  it("opens the panel on action click when set to sidePanel", async () => {
+    await applyUiSurface("sidePanel", "chrome");
+    expect(chrome.sidePanel.setPanelBehavior).toHaveBeenCalledWith({
+      openPanelOnActionClick: true,
+    });
+  });
+
+  it("restores popup behaviour when set to popup", async () => {
+    await applyUiSurface("popup", "chrome");
+    expect(chrome.sidePanel.setPanelBehavior).toHaveBeenCalledWith({
+      openPanelOnActionClick: false,
+    });
+  });
+
+  it("does not call action.setPopup on Chrome", async () => {
+    await applyUiSurface("sidePanel", "chrome");
+    expect(chrome.action.setPopup).not.toHaveBeenCalled();
+  });
+});
+
+describe("applyUiSurface — Firefox", () => {
+  beforeEach(() => {
+    (chrome.sidePanel.setPanelBehavior as ReturnType<typeof vi.fn>).mockClear();
+    (chrome.action.setPopup as ReturnType<typeof vi.fn>).mockClear();
+  });
+
+  it("clears the popup so the toolbar click fires onClicked when set to sidePanel", async () => {
+    await applyUiSurface("sidePanel", "firefox");
+    expect(chrome.action.setPopup).toHaveBeenCalledWith({ popup: "" });
+  });
+
+  it("restores popup.html when set to popup", async () => {
+    await applyUiSurface("popup", "firefox");
+    expect(chrome.action.setPopup).toHaveBeenCalledWith({ popup: "popup.html" });
+  });
+
+  it("does not call sidePanel.setPanelBehavior on Firefox", async () => {
+    await applyUiSurface("sidePanel", "firefox");
+    expect(chrome.sidePanel.setPanelBehavior).not.toHaveBeenCalled();
+  });
+});
+
+import { registerSidebarOpener } from "./ui-surface";
+
+describe("registerSidebarOpener (Firefox)", () => {
+  beforeEach(() => {
+    (chrome.sidebarAction.open as ReturnType<typeof vi.fn>).mockClear();
+  });
+
+  it("opens the sidebar when toolbar click fires while in sidePanel mode", async () => {
+    (chrome.storage.local.get as unknown as ReturnType<typeof vi.fn>) = vi.fn(
+      () => Promise.resolve({ uiSurface: "sidePanel" }),
+    );
+    registerSidebarOpener();
+    const listeners =
+      (chrome.action.onClicked as unknown as { _listeners: Array<(tab: unknown) => void> })
+        ._listeners;
+    await listeners[listeners.length - 1]({});
+    expect(chrome.sidebarAction.open).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT open the sidebar when in popup mode (popup handles the click)", async () => {
+    (chrome.storage.local.get as unknown as ReturnType<typeof vi.fn>) = vi.fn(
+      () => Promise.resolve({ uiSurface: "popup" }),
+    );
+    registerSidebarOpener();
+    const listeners =
+      (chrome.action.onClicked as unknown as { _listeners: Array<(tab: unknown) => void> })
+        ._listeners;
+    await listeners[listeners.length - 1]({});
+    expect(chrome.sidebarAction.open).not.toHaveBeenCalled();
+  });
+});

--- a/packages/shared/src/background/ui-surface.test.ts
+++ b/packages/shared/src/background/ui-surface.test.ts
@@ -1,5 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { readUiSurface, writeUiSurface } from "./ui-surface";
+import {
+  applyUiSurface,
+  readUiSurface,
+  registerSidebarOpener,
+  setCachedUiSurface,
+  writeUiSurface,
+} from "./ui-surface";
+
+// sidebarAction is Firefox-only and not in @types/chrome; the mock adds it.
+const chromeWithSidebar = chrome as typeof chrome & {
+  sidebarAction: { open: ReturnType<typeof vi.fn> };
+};
 
 describe("ui-surface setting", () => {
   beforeEach(() => {
@@ -36,8 +47,6 @@ describe("ui-surface setting", () => {
     expect(setSpy).toHaveBeenCalledWith({ uiSurface: "sidePanel" });
   });
 });
-
-import { applyUiSurface } from "./ui-surface";
 
 describe("applyUiSurface — Chrome", () => {
   beforeEach(() => {
@@ -87,38 +96,32 @@ describe("applyUiSurface — Firefox", () => {
   });
 });
 
-import { registerSidebarOpener } from "./ui-surface";
-
 describe("registerSidebarOpener (Firefox)", () => {
   beforeEach(() => {
-    (chrome.sidebarAction.open as ReturnType<typeof vi.fn>).mockClear();
+    chromeWithSidebar.sidebarAction.open.mockClear();
   });
 
-  it("opens the sidebar when toolbar click fires while in sidePanel mode", async () => {
-    (chrome.storage.local.get as unknown as ReturnType<typeof vi.fn>) = vi.fn(
-      () => Promise.resolve({ uiSurface: "sidePanel" }),
-    );
+  it("opens the sidebar when toolbar click fires while in sidePanel mode", () => {
+    setCachedUiSurface("sidePanel");
     const listenersArr =
       (chrome.action.onClicked as unknown as { _listeners: Array<(tab: unknown) => void> })
         ._listeners;
     const before = listenersArr.length;
     registerSidebarOpener();
     expect(listenersArr.length).toBe(before + 1);
-    await listenersArr[before]({});
-    expect(chrome.sidebarAction.open).toHaveBeenCalledTimes(1);
+    listenersArr[before]!({});
+    expect(chromeWithSidebar.sidebarAction.open).toHaveBeenCalledTimes(1);
   });
 
-  it("does NOT open the sidebar when in popup mode (popup handles the click)", async () => {
-    (chrome.storage.local.get as unknown as ReturnType<typeof vi.fn>) = vi.fn(
-      () => Promise.resolve({ uiSurface: "popup" }),
-    );
+  it("does NOT open the sidebar when in popup mode (popup handles the click)", () => {
+    setCachedUiSurface("popup");
     const listenersArr =
       (chrome.action.onClicked as unknown as { _listeners: Array<(tab: unknown) => void> })
         ._listeners;
     const before = listenersArr.length;
     registerSidebarOpener();
     expect(listenersArr.length).toBe(before + 1);
-    await listenersArr[before]({});
-    expect(chrome.sidebarAction.open).not.toHaveBeenCalled();
+    listenersArr[before]!({});
+    expect(chromeWithSidebar.sidebarAction.open).not.toHaveBeenCalled();
   });
 });

--- a/packages/shared/src/background/ui-surface.ts
+++ b/packages/shared/src/background/ui-surface.ts
@@ -34,3 +34,15 @@ export async function applyUiSurface(
     popup: surface === "sidePanel" ? "" : "popup.html",
   });
 }
+
+// Firefox-only. Safe to call on Chrome too — Chrome routes toolbar clicks
+// through the popup or side-panel behaviour, so the listener never fires
+// for a popup-less click in side-panel mode.
+export function registerSidebarOpener(): void {
+  chrome.action.onClicked.addListener(async () => {
+    const surface = await readUiSurface();
+    if (surface !== "sidePanel") return;
+    if (typeof chrome.sidebarAction?.open !== "function") return;
+    await chrome.sidebarAction.open();
+  });
+}

--- a/packages/shared/src/background/ui-surface.ts
+++ b/packages/shared/src/background/ui-surface.ts
@@ -1,0 +1,16 @@
+export type UiSurface = "popup" | "sidePanel";
+
+const STORAGE_KEY = "uiSurface";
+const VALID_VALUES: ReadonlySet<UiSurface> = new Set(["popup", "sidePanel"]);
+
+export async function readUiSurface(): Promise<UiSurface> {
+  const result = await chrome.storage.local.get(STORAGE_KEY);
+  const stored = result[STORAGE_KEY];
+  return typeof stored === "string" && VALID_VALUES.has(stored as UiSurface)
+    ? (stored as UiSurface)
+    : "popup";
+}
+
+export async function writeUiSurface(value: UiSurface): Promise<void> {
+  await chrome.storage.local.set({ [STORAGE_KEY]: value });
+}

--- a/packages/shared/src/background/ui-surface.ts
+++ b/packages/shared/src/background/ui-surface.ts
@@ -2,6 +2,8 @@ export type UiSurface = "popup" | "sidePanel";
 
 const STORAGE_KEY = "uiSurface";
 const VALID_VALUES: ReadonlySet<UiSurface> = new Set(["popup", "sidePanel"]);
+// Keep in sync with the WXT popup entrypoint name (popup.html).
+const POPUP_PATH = "popup.html";
 
 export async function readUiSurface(): Promise<UiSurface> {
   const result = await chrome.storage.local.get(STORAGE_KEY);
@@ -28,10 +30,10 @@ export async function applyUiSurface(
     return;
   }
   // Firefox: clear the popup so the toolbar click fires action.onClicked,
-  // which the background opens the sidebar from. Restore "popup.html" to
+  // which the background opens the sidebar from. Restore POPUP_PATH to
   // bring the popup back.
   await chrome.action.setPopup({
-    popup: surface === "sidePanel" ? "" : "popup.html",
+    popup: surface === "sidePanel" ? "" : POPUP_PATH,
   });
 }
 

--- a/packages/shared/src/background/ui-surface.ts
+++ b/packages/shared/src/background/ui-surface.ts
@@ -14,3 +14,18 @@ export async function readUiSurface(): Promise<UiSurface> {
 export async function writeUiSurface(value: UiSurface): Promise<void> {
   await chrome.storage.local.set({ [STORAGE_KEY]: value });
 }
+
+export type BrowserKind = "chrome" | "firefox";
+
+export async function applyUiSurface(
+  surface: UiSurface,
+  browser: BrowserKind,
+): Promise<void> {
+  if (browser === "chrome") {
+    await chrome.sidePanel.setPanelBehavior({
+      openPanelOnActionClick: surface === "sidePanel",
+    });
+    return;
+  }
+  // Firefox branch added in Task 4.
+}

--- a/packages/shared/src/background/ui-surface.ts
+++ b/packages/shared/src/background/ui-surface.ts
@@ -27,5 +27,10 @@ export async function applyUiSurface(
     });
     return;
   }
-  // Firefox branch added in Task 4.
+  // Firefox: clear the popup so the toolbar click fires action.onClicked,
+  // which the background opens the sidebar from. Restore "popup.html" to
+  // bring the popup back.
+  await chrome.action.setPopup({
+    popup: surface === "sidePanel" ? "" : "popup.html",
+  });
 }

--- a/packages/shared/src/background/ui-surface.ts
+++ b/packages/shared/src/background/ui-surface.ts
@@ -47,6 +47,10 @@ export async function applyUiSurface(
 ): Promise<void> {
   cachedSurface = surface;
   if (browserKind === "chrome") {
+    // chrome.sidePanel was added in Chrome 114; older Chromium builds may
+    // install the extension without the API. Skip silently in that case
+    // so background startup can't crash on the missing global.
+    if (typeof chrome.sidePanel?.setPanelBehavior !== "function") return;
     await chrome.sidePanel.setPanelBehavior({
       openPanelOnActionClick: surface === "sidePanel",
     });

--- a/packages/shared/src/background/ui-surface.ts
+++ b/packages/shared/src/background/ui-surface.ts
@@ -14,12 +14,6 @@ const sidebarAction = (chrome as typeof chrome & {
   sidebarAction?: SidebarActionGlobal;
 }).sidebarAction;
 
-// Synchronously-readable mirror of the stored preference. Firefox's
-// action.onClicked must call sidebarAction.open() inside the user-gesture
-// window — awaiting storage.local.get between the click and the call will
-// consume the gesture token and the open rejects.
-let cachedSurface: UiSurface = "popup";
-
 export async function readUiSurface(): Promise<UiSurface> {
   const result = await chrome.storage.local.get(STORAGE_KEY);
   const stored = result[STORAGE_KEY];
@@ -32,20 +26,10 @@ export async function writeUiSurface(value: UiSurface): Promise<void> {
   await chrome.storage.local.set({ [STORAGE_KEY]: value });
 }
 
-export function getCachedUiSurface(): UiSurface {
-  return cachedSurface;
-}
-
-// Exposed for test setup; production code updates the cache via applyUiSurface.
-export function setCachedUiSurface(value: UiSurface): void {
-  cachedSurface = value;
-}
-
 export async function applyUiSurface(
   surface: UiSurface,
   browserKind: BrowserKind,
 ): Promise<void> {
-  cachedSurface = surface;
   if (browserKind === "chrome") {
     // chrome.sidePanel was added in Chrome 114; older Chromium builds may
     // install the extension without the API. Skip silently in that case
@@ -64,12 +48,14 @@ export async function applyUiSurface(
   });
 }
 
-// Firefox-only. Registered by background startup when browserKind === "firefox".
-// The click handler MUST run synchronously to preserve the user-gesture token
-// that sidebarAction.open() requires.
+// Firefox-only. MUST be registered synchronously at service-worker top-level
+// so a toolbar click that wakes a dormant SW is delivered to the listener.
+// The handler is unconditionally sync: action.onClicked only fires on Firefox
+// when setPopup has been cleared (= side-panel mode), so the popup-mode case
+// can't reach this code, and we don't need to consult any cached state that
+// might not be ready yet on cold start.
 export function registerSidebarOpener(): void {
   chrome.action.onClicked.addListener(() => {
-    if (cachedSurface !== "sidePanel") return;
     if (!sidebarAction || typeof sidebarAction.open !== "function") return;
     void sidebarAction.open();
   });

--- a/packages/shared/src/background/ui-surface.ts
+++ b/packages/shared/src/background/ui-surface.ts
@@ -19,9 +19,9 @@ export type BrowserKind = "chrome" | "firefox";
 
 export async function applyUiSurface(
   surface: UiSurface,
-  browser: BrowserKind,
+  browserKind: BrowserKind,
 ): Promise<void> {
-  if (browser === "chrome") {
+  if (browserKind === "chrome") {
     await chrome.sidePanel.setPanelBehavior({
       openPanelOnActionClick: surface === "sidePanel",
     });

--- a/packages/shared/src/background/ui-surface.ts
+++ b/packages/shared/src/background/ui-surface.ts
@@ -1,9 +1,24 @@
 export type UiSurface = "popup" | "sidePanel";
+export type BrowserKind = "chrome" | "firefox";
 
 const STORAGE_KEY = "uiSurface";
 const VALID_VALUES: ReadonlySet<UiSurface> = new Set(["popup", "sidePanel"]);
 // Keep in sync with the WXT popup entrypoint name (popup.html).
 const POPUP_PATH = "popup.html";
+
+// Firefox-only: @types/chrome doesn't declare this. Captured at module load
+// so the synchronous click handler below never has to pay a property lookup
+// that TypeScript can't verify.
+type SidebarActionGlobal = { open(): Promise<void> } | undefined;
+const sidebarAction = (chrome as typeof chrome & {
+  sidebarAction?: SidebarActionGlobal;
+}).sidebarAction;
+
+// Synchronously-readable mirror of the stored preference. Firefox's
+// action.onClicked must call sidebarAction.open() inside the user-gesture
+// window — awaiting storage.local.get between the click and the call will
+// consume the gesture token and the open rejects.
+let cachedSurface: UiSurface = "popup";
 
 export async function readUiSurface(): Promise<UiSurface> {
   const result = await chrome.storage.local.get(STORAGE_KEY);
@@ -17,12 +32,20 @@ export async function writeUiSurface(value: UiSurface): Promise<void> {
   await chrome.storage.local.set({ [STORAGE_KEY]: value });
 }
 
-export type BrowserKind = "chrome" | "firefox";
+export function getCachedUiSurface(): UiSurface {
+  return cachedSurface;
+}
+
+// Exposed for test setup; production code updates the cache via applyUiSurface.
+export function setCachedUiSurface(value: UiSurface): void {
+  cachedSurface = value;
+}
 
 export async function applyUiSurface(
   surface: UiSurface,
   browserKind: BrowserKind,
 ): Promise<void> {
+  cachedSurface = surface;
   if (browserKind === "chrome") {
     await chrome.sidePanel.setPanelBehavior({
       openPanelOnActionClick: surface === "sidePanel",
@@ -37,14 +60,13 @@ export async function applyUiSurface(
   });
 }
 
-// Firefox-only. Safe to call on Chrome too — Chrome routes toolbar clicks
-// through the popup or side-panel behaviour, so the listener never fires
-// for a popup-less click in side-panel mode.
+// Firefox-only. Registered by background startup when browserKind === "firefox".
+// The click handler MUST run synchronously to preserve the user-gesture token
+// that sidebarAction.open() requires.
 export function registerSidebarOpener(): void {
-  chrome.action.onClicked.addListener(async () => {
-    const surface = await readUiSurface();
-    if (surface !== "sidePanel") return;
-    if (typeof chrome.sidebarAction?.open !== "function") return;
-    await chrome.sidebarAction.open();
+  chrome.action.onClicked.addListener(() => {
+    if (cachedSurface !== "sidePanel") return;
+    if (!sidebarAction || typeof sidebarAction.open !== "function") return;
+    void sidebarAction.open();
   });
 }

--- a/packages/shared/src/popup/components/ui-surface-row.test.ts
+++ b/packages/shared/src/popup/components/ui-surface-row.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { writeUiSurface } from "../../background/ui-surface";
-import { renderUiSurfaceRow } from "./connected";
+import { renderUiSurfaceFooter, renderUiSurfaceRow } from "./ui-surface-row";
 
 vi.mock("../../background/ui-surface", () => ({
   readUiSurface: vi.fn(() => Promise.resolve("popup" as const)),
@@ -29,5 +29,13 @@ describe("Open as side panel toggle", () => {
     checkbox.checked = true;
     checkbox.dispatchEvent(new Event("change"));
     expect(writeUiSurface).toHaveBeenCalledWith("sidePanel");
+  });
+
+  it("footer wraps the row in a .ui-surface-footer container appended to the view", () => {
+    const view = document.createElement("div");
+    renderUiSurfaceFooter(view);
+    const footer = view.querySelector(".ui-surface-footer");
+    expect(footer).not.toBeNull();
+    expect(footer?.parentElement).toBe(view);
   });
 });

--- a/packages/shared/src/popup/components/ui-surface-row.ts
+++ b/packages/shared/src/popup/components/ui-surface-row.ts
@@ -1,0 +1,27 @@
+import { readUiSurface, writeUiSurface, type UiSurface } from "../../background/ui-surface";
+import { createToggle } from "./toggle-switch";
+
+export async function renderUiSurfaceRow(parent: HTMLElement): Promise<void> {
+  const current = await readUiSurface();
+  const row = document.createElement("div");
+  row.className = "setting-row";
+
+  const label = document.createElement("span");
+  label.className = "setting-label";
+  label.textContent = "Open as side panel";
+  row.appendChild(label);
+
+  const toggle = createToggle(current === "sidePanel", (checked) => {
+    const next: UiSurface = checked ? "sidePanel" : "popup";
+    void writeUiSurface(next);
+  });
+  row.appendChild(toggle);
+  parent.appendChild(row);
+}
+
+export function renderUiSurfaceFooter(view: HTMLElement): void {
+  const footer = document.createElement("div");
+  footer.className = "ui-surface-footer";
+  void renderUiSurfaceRow(footer);
+  view.appendChild(footer);
+}

--- a/packages/shared/src/popup/styles/popup.css
+++ b/packages/shared/src/popup/styles/popup.css
@@ -105,6 +105,19 @@ a:hover {
   border-radius: var(--radius-sm);
 }
 
+/* Surface toggle footer for the disconnected / needs-login / needs-install /
+   needs-update views. The connected view shows the toggle inside its quick-
+   settings block, but those views never reach quick-settings, so the toggle
+   needs an always-on home that lets users switch back from side-panel mode. */
+.ui-surface-footer {
+  margin-top: auto;
+  padding: var(--space-sm) var(--space-md);
+  border-top: 1px solid var(--border);
+}
+.ui-surface-footer .setting-row {
+  padding: 0;
+}
+
 /* === Container-query layout === */
 
 /* Popup baseline (~360px) and narrow side panel (380–519px) use the existing

--- a/packages/shared/src/popup/styles/popup.css
+++ b/packages/shared/src/popup/styles/popup.css
@@ -7,12 +7,8 @@
 html, body {
   margin: 0;
   padding: 0;
-  /* In popup mode the browser sizes the window to the body content; in side-panel
-     mode the browser sizes the body to the available width. Keep min/max so the
-     popup feels the same as before, but let the side panel grow. */
-  min-width: 320px;
+  width: 360px;
   min-height: 200px;
-  max-height: none;
   overflow-y: auto;
   font-family: var(--font-family);
   font-size: var(--font-size-base);
@@ -21,6 +17,17 @@ html, body {
   background: var(--bg-primary);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+/* When the extension renders in a side panel (Chrome) or sidebar (Firefox)
+   the host surface is wider than the popup's 360px. Release the fixed width
+   so the body fills the available space and the #root container queries
+   can drive the responsive layout. */
+@media (min-width: 380px) {
+  html, body {
+    width: 100%;
+    max-width: none;
+  }
 }
 
 /* Thin, subtle scrollbar */
@@ -100,30 +107,21 @@ a:hover {
 
 /* === Container-query layout === */
 
-/* Popup baseline (~360px). Existing rules already cover this — no overrides. */
+/* Popup baseline (~360px) and narrow side panel (380–519px) use the existing
+   compact layout with no overrides. Row-action visibility is click-driven by
+   .peer-item-container--expanded, so width-based visibility tweaks aren't
+   applicable here; revisit if the interaction model changes. */
 
-/* Narrow side panel (Firefox sidebar default; Chrome panel at minimum width). */
-/* Token substitutions: --space-sm (8px) used for --space-2; no --color-border (using --border). */
+/* Narrow side panel breathing room. */
 @container (min-width: 380px) and (max-width: 519px) {
-  .peer-row .peer-actions {
-    /* Action icons always visible; no hover-to-reveal in this surface. */
-    opacity: 1;
-    pointer-events: auto;
-  }
   .quick-settings .setting-row {
     padding-block: var(--space-sm);
   }
 }
 
-/* Wide side panel (≥ 520px). Two-column scaffold; right pane is intentionally
-   minimal in this iteration — Tier 2 #21 fills it out. */
-/* Token substitutions: --space-md (12px) used for --space-3; --border for --color-border;
-   --text-secondary for --color-muted; --font-size-sm (12px) for --font-sm. */
+/* Wide side panel (≥ 520px): two-column scaffold. The right pane stays minimal
+   in this iteration and is populated by a follow-up (peer-details drawer). */
 @container (min-width: 520px) {
-  .peer-row .peer-actions {
-    opacity: 1;
-    pointer-events: auto;
-  }
   .panel-shell {
     display: grid;
     grid-template-columns: minmax(320px, 1fr) minmax(240px, 1fr);

--- a/packages/shared/src/popup/styles/popup.css
+++ b/packages/shared/src/popup/styles/popup.css
@@ -113,15 +113,17 @@ a:hover {
    applicable here; revisit if the interaction model changes. */
 
 /* Narrow side panel breathing room. */
-@container (min-width: 380px) and (max-width: 519px) {
+@container (min-width: 380px) and (max-width: 599px) {
   .quick-settings .setting-row {
     padding-block: var(--space-sm);
   }
 }
 
-/* Wide side panel (≥ 520px): two-column scaffold. The right pane stays minimal
-   in this iteration and is populated by a follow-up (peer-details drawer). */
-@container (min-width: 520px) {
+/* Wide side panel (≥ 600px): two-column scaffold. The right pane stays minimal
+   in this iteration and is populated by a follow-up (peer-details drawer).
+   Track minimums (320 + 240) plus the 12px gap need 572px just to fit, so the
+   breakpoint sits at 600px to keep a small buffer above the math floor. */
+@container (min-width: 600px) {
   .panel-shell {
     display: grid;
     grid-template-columns: minmax(320px, 1fr) minmax(240px, 1fr);

--- a/packages/shared/src/popup/styles/popup.css
+++ b/packages/shared/src/popup/styles/popup.css
@@ -7,9 +7,12 @@
 html, body {
   margin: 0;
   padding: 0;
-  width: 360px;
+  /* In popup mode the browser sizes the window to the body content; in side-panel
+     mode the browser sizes the body to the available width. Keep min/max so the
+     popup feels the same as before, but let the side panel grow. */
+  min-width: 320px;
   min-height: 200px;
-  max-height: 540px;
+  max-height: none;
   overflow-y: auto;
   font-family: var(--font-family);
   font-size: var(--font-size-base);
@@ -40,9 +43,12 @@ html, body {
 
 /* Root container */
 #root {
-  min-height: 100%;
   display: flex;
   flex-direction: column;
+  /* Container query host — breakpoints below react to #root's rendered width. */
+  container-type: inline-size;
+  width: 100%;
+  min-width: 320px;
 }
 
 /* Section dividers */
@@ -90,4 +96,47 @@ a:hover {
   outline: none;
   box-shadow: var(--shadow-focus);
   border-radius: var(--radius-sm);
+}
+
+/* === Container-query layout === */
+
+/* Popup baseline (~360px). Existing rules already cover this — no overrides. */
+
+/* Narrow side panel (Firefox sidebar default; Chrome panel at minimum width). */
+/* Token substitutions: --space-sm (8px) used for --space-2; no --color-border (using --border). */
+@container (min-width: 380px) and (max-width: 519px) {
+  .peer-row .peer-actions {
+    /* Action icons always visible; no hover-to-reveal in this surface. */
+    opacity: 1;
+    pointer-events: auto;
+  }
+  .quick-settings .setting-row {
+    padding-block: var(--space-sm);
+  }
+}
+
+/* Wide side panel (≥ 520px). Two-column scaffold; right pane is intentionally
+   minimal in this iteration — Tier 2 #21 fills it out. */
+/* Token substitutions: --space-md (12px) used for --space-3; --border for --color-border;
+   --text-secondary for --color-muted; --font-size-sm (12px) for --font-sm. */
+@container (min-width: 520px) {
+  .peer-row .peer-actions {
+    opacity: 1;
+    pointer-events: auto;
+  }
+  .panel-shell {
+    display: grid;
+    grid-template-columns: minmax(320px, 1fr) minmax(240px, 1fr);
+    gap: var(--space-md);
+    align-items: stretch;
+  }
+  .panel-shell .panel-detail-pane {
+    border-left: 1px solid var(--border);
+    padding-inline: var(--space-md);
+  }
+  .panel-shell .panel-detail-pane:empty::before {
+    content: "Select a peer to see details";
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+  }
 }

--- a/packages/shared/src/popup/styles/popup.css
+++ b/packages/shared/src/popup/styles/popup.css
@@ -122,36 +122,16 @@ a:hover {
 
 /* === Container-query layout === */
 
-/* Popup baseline (~360px) and narrow side panel (380–519px) use the existing
-   compact layout with no overrides. Row-action visibility is click-driven by
-   .peer-item-container--expanded, so width-based visibility tweaks aren't
-   applicable here; revisit if the interaction model changes. */
+/* Popup baseline (~360px) and side panels (380px+) currently use the same
+   compact single-column layout. The .panel-shell + .panel-detail-pane DOM
+   wrappers are in place but a wide two-column layout is intentionally not
+   wired here — the right pane has nothing to render until the peer-details
+   drawer ships, and showing an unfillable column would be a broken
+   affordance. Land the breakpoint and pane styling in the drawer PR. */
 
 /* Narrow side panel breathing room. */
-@container (min-width: 380px) and (max-width: 599px) {
+@container (min-width: 380px) {
   .quick-settings .setting-row {
     padding-block: var(--space-sm);
-  }
-}
-
-/* Wide side panel (≥ 600px): two-column scaffold. The right pane stays minimal
-   in this iteration and is populated by a follow-up (peer-details drawer).
-   Track minimums (320 + 240) plus the 12px gap need 572px just to fit, so the
-   breakpoint sits at 600px to keep a small buffer above the math floor. */
-@container (min-width: 600px) {
-  .panel-shell {
-    display: grid;
-    grid-template-columns: minmax(320px, 1fr) minmax(240px, 1fr);
-    gap: var(--space-md);
-    align-items: stretch;
-  }
-  .panel-shell .panel-detail-pane {
-    border-left: 1px solid var(--border);
-    padding-inline: var(--space-md);
-  }
-  .panel-shell .panel-detail-pane:empty::before {
-    content: "Select a peer to see details";
-    color: var(--text-secondary);
-    font-size: var(--font-size-sm);
   }
 }

--- a/packages/shared/src/popup/styles/popup.css
+++ b/packages/shared/src/popup/styles/popup.css
@@ -108,9 +108,11 @@ a:hover {
 /* Surface toggle footer for the disconnected / needs-login / needs-install /
    needs-update views. The connected view shows the toggle inside its quick-
    settings block, but those views never reach quick-settings, so the toggle
-   needs an always-on home that lets users switch back from side-panel mode. */
+   needs an always-on home that lets users switch back from side-panel mode.
+   The footer trails the view's content rather than sticking to the bottom —
+   .view isn't a flex container, so flex-based bottom alignment would be a
+   no-op. Acceptable for the small content these views render. */
 .ui-surface-footer {
-  margin-top: auto;
   padding: var(--space-sm) var(--space-md);
   border-top: 1px solid var(--border);
 }

--- a/packages/shared/src/popup/views/connected-ui-surface-row.test.ts
+++ b/packages/shared/src/popup/views/connected-ui-surface-row.test.ts
@@ -1,0 +1,33 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { writeUiSurface } from "../../background/ui-surface";
+import { renderUiSurfaceRow } from "./connected";
+
+vi.mock("../../background/ui-surface", () => ({
+  readUiSurface: vi.fn(() => Promise.resolve("popup" as const)),
+  writeUiSurface: vi.fn(() => Promise.resolve()),
+}));
+
+describe("Open as side panel toggle", () => {
+  beforeEach(() => {
+    (writeUiSurface as ReturnType<typeof vi.fn>).mockClear();
+  });
+
+  it("renders the row with the label and an unchecked toggle when in popup mode", async () => {
+    const container = document.createElement("div");
+    await renderUiSurfaceRow(container);
+    const label = container.querySelector(".setting-label");
+    expect(label?.textContent).toBe("Open as side panel");
+    const checkbox = container.querySelector("input[type='checkbox']") as HTMLInputElement;
+    expect(checkbox.checked).toBe(false);
+  });
+
+  it("calls writeUiSurface('sidePanel') when the toggle is flipped on", async () => {
+    const container = document.createElement("div");
+    await renderUiSurfaceRow(container);
+    const checkbox = container.querySelector("input[type='checkbox']") as HTMLInputElement;
+    checkbox.checked = true;
+    checkbox.dispatchEvent(new Event("change"));
+    expect(writeUiSurface).toHaveBeenCalledWith("sidePanel");
+  });
+});

--- a/packages/shared/src/popup/views/connected.ts
+++ b/packages/shared/src/popup/views/connected.ts
@@ -10,6 +10,7 @@ import { createToggle } from "../components/toggle-switch";
 import { renderExitNodes } from "./exit-nodes";
 import { renderProfiles } from "./profiles";
 import { iconChevronRight } from "../icons";
+import { readUiSurface, writeUiSurface, type UiSurface } from "../../background/ui-surface";
 
 type SubViewRenderer = (root: HTMLElement, state: TailscaleState, onBack: () => void) => void;
 
@@ -319,6 +320,8 @@ export function renderConnected(root: HTMLElement, state: TailscaleState): void 
     settings.appendChild(profileRow);
   }
 
+  void renderUiSurfaceRow(settings);
+
   view.appendChild(settings);
 
   const filteredPeers = filterPeers(
@@ -417,6 +420,24 @@ export function renderConnected(root: HTMLElement, state: TailscaleState): void 
   view.appendChild(footer);
 
   root.appendChild(view);
+}
+
+export async function renderUiSurfaceRow(parent: HTMLElement): Promise<void> {
+  const current = await readUiSurface();
+  const row = document.createElement("div");
+  row.className = "setting-row";
+
+  const label = document.createElement("span");
+  label.className = "setting-label";
+  label.textContent = "Open as side panel";
+  row.appendChild(label);
+
+  const toggle = createToggle(current === "sidePanel", (checked) => {
+    const next: UiSurface = checked ? "sidePanel" : "popup";
+    void writeUiSurface(next);
+  });
+  row.appendChild(toggle);
+  parent.appendChild(row);
 }
 
 // Track health key to detect changes during in-place updates

--- a/packages/shared/src/popup/views/connected.ts
+++ b/packages/shared/src/popup/views/connected.ts
@@ -10,7 +10,7 @@ import { createToggle } from "../components/toggle-switch";
 import { renderExitNodes } from "./exit-nodes";
 import { renderProfiles } from "./profiles";
 import { iconChevronRight } from "../icons";
-import { readUiSurface, writeUiSurface, type UiSurface } from "../../background/ui-surface";
+import { renderUiSurfaceRow } from "../components/ui-surface-row";
 
 type SubViewRenderer = (root: HTMLElement, state: TailscaleState, onBack: () => void) => void;
 
@@ -432,24 +432,6 @@ export function renderConnected(root: HTMLElement, state: TailscaleState): void 
   shell.appendChild(detail);
 
   root.appendChild(shell);
-}
-
-export async function renderUiSurfaceRow(parent: HTMLElement): Promise<void> {
-  const current = await readUiSurface();
-  const row = document.createElement("div");
-  row.className = "setting-row";
-
-  const label = document.createElement("span");
-  label.className = "setting-label";
-  label.textContent = "Open as side panel";
-  row.appendChild(label);
-
-  const toggle = createToggle(current === "sidePanel", (checked) => {
-    const next: UiSurface = checked ? "sidePanel" : "popup";
-    void writeUiSurface(next);
-  });
-  row.appendChild(toggle);
-  parent.appendChild(row);
 }
 
 // Track health key to detect changes during in-place updates

--- a/packages/shared/src/popup/views/connected.ts
+++ b/packages/shared/src/popup/views/connected.ts
@@ -296,7 +296,7 @@ export function renderConnected(root: HTMLElement, state: TailscaleState): void 
   // Profile switcher row (only show when multiple profiles exist)
   if (state.profiles.length > 0) {
     const profileRow = document.createElement("div");
-    profileRow.className = "setting-row setting-row--clickable";
+    profileRow.className = "setting-row setting-row--clickable setting-row-profile";
 
     const profileLabel = document.createElement("span");
     profileLabel.className = "setting-label";
@@ -304,7 +304,7 @@ export function renderConnected(root: HTMLElement, state: TailscaleState): void 
     profileRow.appendChild(profileLabel);
 
     const profileValue = document.createElement("span");
-    profileValue.className = "setting-value";
+    profileValue.className = "setting-value setting-value-profile";
     profileValue.textContent = state.currentProfile?.name ?? "Default";
 
     const profileChevron = document.createElement("span");
@@ -502,6 +502,17 @@ export function updateConnected(root: HTMLElement, state: TailscaleState): void 
     return;
   }
 
+  // Profile data arrives after the initial get-status, so the first render
+  // may lack the Profile row while later updates need it (or vice versa).
+  // Presence mismatch requires a full render to add or remove the row with
+  // its click handler — in-place update can't materialise a new row.
+  const hasProfileRow = view.querySelector(".setting-row-profile") !== null;
+  const shouldHaveProfileRow = state.profiles.length > 0;
+  if (hasProfileRow !== shouldHaveProfileRow) {
+    renderConnected(root, state);
+    return;
+  }
+
   const tailnetEl = view.querySelector(".status-bar-tailnet");
   if (tailnetEl) {
     const newTailnet = state.tailnet || "My Tailnet";
@@ -585,9 +596,14 @@ export function updateConnected(root: HTMLElement, state: TailscaleState): void 
       }
     }
 
-    // Profile value (last .setting-value if profiles exist)
-    if (state.profiles.length > 0 && settingValues.length > 1) {
-      const profileValueEl = settingValues[settingValues.length - 1]!;
+    // Profile value — target by its specific class, not by last-of-type.
+    // Multiple setting-value elements exist (exit node, local node page);
+    // "last" was previously matching the local-node-page value and
+    // clobbering it with the profile name.
+    const profileValueEl = quickSettings.querySelector<HTMLElement>(
+      ".setting-value-profile",
+    );
+    if (state.profiles.length > 0 && profileValueEl) {
       const newProfileName = state.currentProfile?.name ?? "Default";
       const profileTextNode = profileValueEl.firstChild;
       if (profileTextNode && profileTextNode.nodeType === Node.TEXT_NODE) {

--- a/packages/shared/src/popup/views/connected.ts
+++ b/packages/shared/src/popup/views/connected.ts
@@ -419,7 +419,19 @@ export function renderConnected(root: HTMLElement, state: TailscaleState): void 
 
   view.appendChild(footer);
 
-  root.appendChild(view);
+  const shell = document.createElement("div");
+  shell.className = "panel-shell";
+
+  const main = document.createElement("div");
+  main.className = "panel-main";
+  main.appendChild(view);
+  shell.appendChild(main);
+
+  const detail = document.createElement("div");
+  detail.className = "panel-detail-pane";
+  shell.appendChild(detail);
+
+  root.appendChild(shell);
 }
 
 export async function renderUiSurfaceRow(parent: HTMLElement): Promise<void> {

--- a/packages/shared/src/popup/views/disconnected.ts
+++ b/packages/shared/src/popup/views/disconnected.ts
@@ -1,5 +1,6 @@
 import type { TailscaleState } from "../../types";
 import { renderHeader } from "../components/header";
+import { renderUiSurfaceFooter } from "../components/ui-surface-row";
 import { iconPlug, iconWarning } from "../icons";
 import { sendMessage } from "../popup";
 
@@ -137,5 +138,6 @@ export function renderDisconnected(root: HTMLElement, state?: TailscaleState): v
   }
 
   view.appendChild(content);
+  renderUiSurfaceFooter(view);
   root.appendChild(view);
 }

--- a/packages/shared/src/popup/views/install-helpers.ts
+++ b/packages/shared/src/popup/views/install-helpers.ts
@@ -1,6 +1,7 @@
 import { copyToClipboard, showToast, detectPlatform } from "../utils";
 import { EXPECTED_HOST_VERSION } from "../../constants";
 import { iconPackage, iconRefresh } from "../icons";
+import { renderUiSurfaceFooter } from "../components/ui-surface-row";
 
 type Platform = "macos" | "linux" | "windows" | "unknown";
 
@@ -297,6 +298,7 @@ export function renderInstallFlow(
   }
 
   view.appendChild(content);
+  renderUiSurfaceFooter(view);
   root.appendChild(view);
 }
 

--- a/packages/shared/src/popup/views/needs-login.ts
+++ b/packages/shared/src/popup/views/needs-login.ts
@@ -1,5 +1,6 @@
 import type { TailscaleState } from "../../types";
 import { renderHeader } from "../components/header";
+import { renderUiSurfaceFooter } from "../components/ui-surface-row";
 import { sendMessage } from "../popup";
 import { iconLock } from "../icons";
 
@@ -48,6 +49,7 @@ export function renderNeedsLogin(root: HTMLElement, state: TailscaleState): void
   content.appendChild(description);
   content.appendChild(loginBtn);
   view.appendChild(content);
+  renderUiSurfaceFooter(view);
 
   root.appendChild(view);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@25.5.0)(jiti@2.6.1)
+        version: 3.2.4(@types/node@25.5.0)(happy-dom@20.9.0)(jiti@2.6.1)
       web-ext:
         specifier: ^10.1.0
         version: 10.1.0(jiti@2.6.1)
@@ -41,12 +41,15 @@ importers:
       esbuild:
         specifier: ^0.27.4
         version: 0.27.4
+      happy-dom:
+        specifier: ^20.9.0
+        version: 20.9.0
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@25.5.0)(jiti@2.6.1)
+        version: 3.2.4(@types/node@25.5.0)(happy-dom@20.9.0)(jiti@2.6.1)
 
 packages:
 
@@ -391,66 +394,79 @@ packages:
     resolution: {integrity: sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.0':
     resolution: {integrity: sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.0':
     resolution: {integrity: sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.0':
     resolution: {integrity: sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.0':
     resolution: {integrity: sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.0':
     resolution: {integrity: sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.0':
     resolution: {integrity: sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.0':
     resolution: {integrity: sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.0':
     resolution: {integrity: sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.0':
     resolution: {integrity: sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.0':
     resolution: {integrity: sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.0':
     resolution: {integrity: sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.0':
     resolution: {integrity: sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.0':
     resolution: {integrity: sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==}
@@ -511,6 +527,12 @@ packages:
 
   '@types/node@25.5.0':
     resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
+
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
@@ -1184,6 +1206,10 @@ packages:
 
   growly@1.3.0:
     resolution: {integrity: sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==}
+
+  happy-dom@20.9.0:
+    resolution: {integrity: sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==}
+    engines: {node: '>=20.0.0'}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -2151,6 +2177,10 @@ packages:
     engines: {node: '>=18'}
     deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
     engines: {node: '>=18'}
@@ -2197,6 +2227,18 @@ packages:
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
+
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   wsl-utils@0.3.1:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
@@ -2582,6 +2624,12 @@ snapshots:
   '@types/node@25.5.0':
     dependencies:
       undici-types: 7.18.2
+
+  '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 25.5.0
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -3291,6 +3339,18 @@ snapshots:
   graceful-readlink@1.0.1: {}
 
   growly@1.3.0: {}
+
+  happy-dom@20.9.0:
+    dependencies:
+      '@types/node': 25.5.0
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   has-flag@4.0.0: {}
 
@@ -4192,7 +4252,7 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
 
-  vitest@3.2.4(@types/node@25.5.0)(jiti@2.6.1):
+  vitest@3.2.4(@types/node@25.5.0)(happy-dom@20.9.0)(jiti@2.6.1):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
@@ -4219,6 +4279,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.5.0
+      happy-dom: 20.9.0
     transitivePeerDependencies:
       - jiti
       - less
@@ -4313,6 +4374,8 @@ snapshots:
     dependencies:
       iconv-lite: 0.6.3
 
+  whatwg-mimetype@3.0.0: {}
+
   whatwg-mimetype@4.0.0: {}
 
   when-exit@2.1.5: {}
@@ -4358,6 +4421,8 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 7.2.0
       strip-ansi: 7.2.0
+
+  ws@8.20.0: {}
 
   wsl-utils@0.3.1:
     dependencies:


### PR DESCRIPTION
## What

Opt-in side-panel mode for the popup (Chrome `chrome.sidePanel`, Firefox `sidebar_action`), flipped by a single toggle in quick settings. Release workflow now uses the signed/notarized Darwin binaries — the previous flow silently shipped the unsigned copies — and publish workflow aborts on missing or duplicate checksum rows. Also lands the Chrome and Firefox store-listing copy.

## Why

The popup dismisses on click-away, which is wrong for actively watching peers. The CI fixes close two real integrity gaps in release signing and checksum verification.

## How to Test

- [x] Flip "Open as side panel" in quick settings, confirm toolbar click opens the panel (Chrome) / sidebar (Firefox).
- [x] Resize past ~520 px — two-column scaffold appears.
- [x] `pnpm typecheck && pnpm -r test && pnpm build:chrome && pnpm build:firefox` all green.

## Checklist

- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Updated README if needed
