### PR TITLE
feat(exit-nodes): surface best-available recommendation in picker

### DIFF
--- a/packages/shared/src/background/background.test.ts
+++ b/packages/shared/src/background/background.test.ts
@@ -265,23 +265,13 @@ describe("initBackground", () => {
       expect(toastCalls).toHaveLength(0);
     });
 
-    it("clears stale suggestion and stays quiet on suggest-exit-node errors", async () => {
+    it("stays quiet on suggest-exit-node errors", async () => {
       await setupBackground();
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-
-      // Seed a previous successful suggestion.
-      sendNativeMessage({
-        exitNodeSuggestion: {
-          id: "node-suggested",
-          hostname: "best.example.ts.net",
-          location: null,
-        },
-      });
 
       const popupPort = createPopupPort();
       connectListeners[0]!(popupPort);
       popupPort.postMessage.mockClear();
-      (proxyManager.apply as ReturnType<typeof vi.fn>).mockClear();
 
       sendNativeMessage({
         error: { cmd: "suggest-exit-node", message: "no suggestion available" },
@@ -294,11 +284,6 @@ describe("initBackground", () => {
       expect(toastCalls).toHaveLength(0);
       expect(proxyManager.apply).not.toHaveBeenCalledWith(
         expect.objectContaining({ error: "no suggestion available" })
-      );
-
-      // Stale suggestion must be cleared so the picker doesn't keep showing it.
-      expect(proxyManager.apply).toHaveBeenCalledWith(
-        expect.objectContaining({ exitNodeSuggestion: null })
       );
       warnSpy.mockRestore();
     });

--- a/packages/shared/src/background/background.test.ts
+++ b/packages/shared/src/background/background.test.ts
@@ -232,6 +232,76 @@ describe("initBackground", () => {
         })
       );
     });
+
+    it("stores exit node suggestion in state without showing a toast", async () => {
+      await setupBackground();
+
+      const popupPort = createPopupPort();
+      connectListeners[0]!(popupPort);
+      popupPort.postMessage.mockClear();
+
+      sendNativeMessage({
+        exitNodeSuggestion: {
+          id: "node-suggested",
+          hostname: "best.example.ts.net",
+          location: {
+            city: "Frankfurt",
+            cityCode: "fra",
+            country: "Germany",
+            countryCode: "DE",
+          },
+        },
+      });
+
+      expect(proxyManager.apply).toHaveBeenCalledWith(
+        expect.objectContaining({
+          exitNodeSuggestion: expect.objectContaining({ id: "node-suggested" }),
+        })
+      );
+      // Suggestion arrivals must not push a toast — the picker shows them visually.
+      const toastCalls = popupPort.postMessage.mock.calls.filter(
+        (args: unknown[]) => (args[0] as { type?: string }).type === "toast"
+      );
+      expect(toastCalls).toHaveLength(0);
+    });
+
+    it("clears stale suggestion and stays quiet on suggest-exit-node errors", async () => {
+      await setupBackground();
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      // Seed a previous successful suggestion.
+      sendNativeMessage({
+        exitNodeSuggestion: {
+          id: "node-suggested",
+          hostname: "best.example.ts.net",
+          location: null,
+        },
+      });
+
+      const popupPort = createPopupPort();
+      connectListeners[0]!(popupPort);
+      popupPort.postMessage.mockClear();
+      (proxyManager.apply as ReturnType<typeof vi.fn>).mockClear();
+
+      sendNativeMessage({
+        error: { cmd: "suggest-exit-node", message: "no suggestion available" },
+      });
+
+      // No toast, no sticky error in state.
+      const toastCalls = popupPort.postMessage.mock.calls.filter(
+        (args: unknown[]) => (args[0] as { type?: string }).type === "toast"
+      );
+      expect(toastCalls).toHaveLength(0);
+      expect(proxyManager.apply).not.toHaveBeenCalledWith(
+        expect.objectContaining({ error: "no suggestion available" })
+      );
+
+      // Stale suggestion must be cleared so the picker doesn't keep showing it.
+      expect(proxyManager.apply).toHaveBeenCalledWith(
+        expect.objectContaining({ exitNodeSuggestion: null })
+      );
+      warnSpy.mockRestore();
+    });
   });
 
   describe("popup communication", () => {

--- a/packages/shared/src/background/background.ts
+++ b/packages/shared/src/background/background.ts
@@ -169,13 +169,10 @@ export function initBackground(
       });
     }
 
-    // Exit node suggestion — store in state and show toast, do NOT auto-apply
+    // Exit node suggestion — store in state, do NOT auto-apply.
+    // The popup picker surfaces this in a "Recommended" row; no toast needed.
     if (msg.exitNodeSuggestion) {
       store.update({ exitNodeSuggestion: msg.exitNodeSuggestion });
-      sendToastToPopup(
-        `Suggested exit node: ${msg.exitNodeSuggestion.hostname}`,
-        "info",
-      );
     }
 
     // File send progress
@@ -211,6 +208,16 @@ export function initBackground(
     if (msg.error) {
       if (msg.error.message === "install_error") {
         store.update({ installError: true, hostConnected: false });
+      } else if (msg.error.cmd === "suggest-exit-node") {
+        // Recommendation is a passive feature: log the failure but don't
+        // pollute the popup with a toast or set a sticky error. Clear any
+        // previously cached suggestion so the picker doesn't keep showing a
+        // stale "Recommended" row when the host can no longer recommend one.
+        console.warn(
+          `[Background] suggest-exit-node failed:`,
+          msg.error.message
+        );
+        store.update({ exitNodeSuggestion: null });
       } else {
         console.error(
           `[Background] Native error for cmd="${msg.error.cmd}":`,

--- a/packages/shared/src/background/background.ts
+++ b/packages/shared/src/background/background.ts
@@ -210,14 +210,16 @@ export function initBackground(
         store.update({ installError: true, hostConnected: false });
       } else if (msg.error.cmd === "suggest-exit-node") {
         // Recommendation is a passive feature: log the failure but don't
-        // pollute the popup with a toast or set a sticky error. Clear any
-        // previously cached suggestion so the picker doesn't keep showing a
-        // stale "Recommended" row when the host can no longer recommend one.
+        // pollute the popup with a toast or set a sticky error.
+        //
+        // Do not clear `exitNodeSuggestion` here: suggest-exit-node replies
+        // are not correlated to a specific request in this code path, so a
+        // late error from an older request could otherwise erase a newer
+        // successful recommendation.
         console.warn(
           `[Background] suggest-exit-node failed:`,
           msg.error.message
         );
-        store.update({ exitNodeSuggestion: null });
       } else {
         console.error(
           `[Background] Native error for cmd="${msg.error.cmd}":`,

--- a/packages/shared/src/popup/views/exit-nodes.ts
+++ b/packages/shared/src/popup/views/exit-nodes.ts
@@ -1,4 +1,4 @@
-import type { TailscaleState, PeerInfo } from "../../types";
+import type { TailscaleState, PeerInfo, ExitNodeSuggestion } from "../../types";
 import { addListKeyboardNav } from "../utils";
 import { sendMessage } from "../popup";
 import { iconArrowLeft } from "../icons";
@@ -38,9 +38,13 @@ export function renderExitNodes(
   state: TailscaleState,
   onBack: () => void
 ): void {
-  // Only reset the search query on initial open (not on state-driven re-renders)
-  if (!root.querySelector(".exit-nodes-header")) {
+  // Only reset the search query on initial open (not on state-driven re-renders).
+  // Also request a fresh recommendation so the "Recommended" row reflects the
+  // currently best-available exit node.
+  const initialOpen = !root.querySelector(".exit-nodes-header");
+  if (initialOpen) {
     exitNodeSearchQuery = "";
+    sendMessage({ type: "suggest-exit-node" });
   }
   root.textContent = "";
   const view = document.createElement("div");
@@ -144,14 +148,14 @@ function renderExitNodeList(
 
   const filtered = filterExitNodes(allExitNodes, exitNodeSearchQuery);
 
-  // Suggested exit node (hidden when searching)
+  // Recommended exit node (hidden when searching)
   if (!exitNodeSearchQuery && state.exitNodeSuggestion) {
     const suggestSection = document.createElement("div");
     suggestSection.className = "exit-nodes-section exit-nodes-section--suggested";
 
     const suggestHeader = document.createElement("div");
     suggestHeader.className = "section-header";
-    suggestHeader.textContent = "Suggested";
+    suggestHeader.textContent = "Recommended";
     suggestSection.appendChild(suggestHeader);
 
     const suggestion = state.exitNodeSuggestion;
@@ -160,8 +164,20 @@ function renderExitNodeList(
       : suggestion.hostname;
     const isSelected =
       state.exitNode != null && state.exitNode.id === state.exitNodeSuggestion.id;
-    const suggestRow = createExitNodeRow(suggestLabel, null, isSelected, () =>
-      sendMessage({ type: "set-exit-node", nodeID: state.exitNodeSuggestion!.id })
+    // Match against the peer list so we can show the flag and online indicator,
+    // then fall back to a synthetic node carrying just the suggestion's location.
+    const matchingPeer =
+      allExitNodes.find((n) => n.id === suggestion.id) ?? null;
+    const rowNode: PeerInfo | null =
+      matchingPeer ?? (suggestion.location
+        ? { ...synthesizeSuggestionPeer(suggestion) }
+        : null);
+    const suggestRow = createExitNodeRow(
+      suggestLabel,
+      rowNode,
+      isSelected,
+      () => sendMessage({ type: "set-exit-node", nodeID: state.exitNodeSuggestion!.id }),
+      "Best available",
     );
     suggestSection.appendChild(suggestRow);
     container.appendChild(suggestSection);
@@ -365,7 +381,8 @@ function createExitNodeRow(
   label: string,
   node: PeerInfo | null,
   isSelected: boolean,
-  onSelect: () => void
+  onSelect: () => void,
+  subLabelOverride?: string,
 ): HTMLElement {
   const row = document.createElement("div");
   row.className = "exit-node-row" + (isSelected ? " exit-node-row--selected" : "");
@@ -385,7 +402,12 @@ function createExitNodeRow(
   nameEl.textContent = label;
   info.appendChild(nameEl);
 
-  if (node) {
+  if (subLabelOverride) {
+    const sub = document.createElement("span");
+    sub.className = "exit-node-status";
+    sub.textContent = subLabelOverride;
+    info.appendChild(sub);
+  } else if (node) {
     const status = document.createElement("span");
     status.className = "exit-node-status";
     const dot = document.createElement("span");
@@ -498,4 +520,37 @@ function countryCodeToEmoji(code: string): string {
     a + upper.charCodeAt(0) - 65,
     a + upper.charCodeAt(1) - 65
   );
+}
+
+/**
+ * Builds a placeholder PeerInfo for the recommended exit node when the suggestion's
+ * peer isn't in our peer list (e.g. the netmap hasn't propagated it yet). Only the
+ * fields used by the row renderer are populated.
+ */
+function synthesizeSuggestionPeer(suggestion: ExitNodeSuggestion): PeerInfo {
+  return {
+    id: suggestion.id,
+    hostname: suggestion.hostname,
+    dnsName: "",
+    tailscaleIPs: [],
+    os: "",
+    online: true,
+    active: false,
+    exitNode: false,
+    exitNodeOption: true,
+    isSubnetRouter: false,
+    subnets: [],
+    tags: [],
+    rxBytes: 0,
+    txBytes: 0,
+    lastSeen: null,
+    lastHandshake: null,
+    location: suggestion.location,
+    taildropTarget: false,
+    sshHost: false,
+    userId: 0,
+    userName: "",
+    userLoginName: "",
+    userProfilePicURL: "",
+  };
 }


### PR DESCRIPTION
## What

Wires up the existing `suggest-exit-node` plumbing so the picker fetches a fresh recommendation on open and renders it under a **Recommended** row with the country flag and a "Best available" hint. The noisy toast that fired on every suggestion arrival is gone, `suggest-exit-node` failures are silently swallowed, and any stale suggestion is cleared from state when the host can no longer provide one.

## Why

Closes #64

## How to Test

- [x] Open the popup with Mullvad available; open Exit Nodes — a "Recommended" row appears at the top with the city/country, flag, and "Best available" subtitle.
- [x] Pick the recommended row; the exit node applies and the row stays selected.
- [x] Without Mullvad, opening Exit Nodes does not show a toast or sticky error and no "Recommended" row renders.
- [x] After a successful suggestion, simulate a host failure on the next refresh — the stale Recommended row disappears.

## Checklist

- [x] Tested in Chrome
- [x] Tested in Firefox
- [ ] Updated README if needed