### PR TITLE
feat: split-tunneling domain rules (bypass / only)

### DIFF
--- a/packages/extension/src/background/chrome-proxy-manager.test.ts
+++ b/packages/extension/src/background/chrome-proxy-manager.test.ts
@@ -200,6 +200,104 @@ describe("ChromeProxyManager", () => {
       expect(route("http://172.32.0.1", "172.32.0.1")).toBe("DIRECT");
     });
   });
+
+  describe("split tunneling rules", () => {
+    const withExit = (overrides: Partial<TailscaleState> = {}) =>
+      baseState({
+        exitNode: {
+          id: "exit1",
+          hostname: "exit",
+          location: null,
+          online: true,
+        },
+        ...overrides,
+      });
+
+    it("bypass mode: listed domain goes DIRECT, others use exit node", () => {
+      const route = evalPAC(
+        pm,
+        withExit({
+          domainSplit: { mode: "bypass", domains: ["teams.microsoft.com"] },
+        }),
+      );
+      expect(route("https://teams.microsoft.com/", "teams.microsoft.com")).toBe(
+        "DIRECT",
+      );
+      expect(
+        route("https://x.teams.microsoft.com/", "x.teams.microsoft.com"),
+      ).toBe("DIRECT");
+      expect(route("https://example.com/", "example.com")).toBe(
+        "SOCKS5 127.0.0.1:1055",
+      );
+    });
+
+    it("only mode: listed domain uses exit node, others go DIRECT", () => {
+      const route = evalPAC(
+        pm,
+        withExit({
+          domainSplit: { mode: "only", domains: ["work.example.com"] },
+        }),
+      );
+      expect(route("https://work.example.com/", "work.example.com")).toBe(
+        "SOCKS5 127.0.0.1:1055",
+      );
+      expect(route("https://google.com/", "google.com")).toBe("DIRECT");
+    });
+
+    it("only mode: Tailscale-mandatory traffic still routes through proxy", () => {
+      const route = evalPAC(
+        pm,
+        withExit({
+          domainSplit: { mode: "only", domains: ["work.example.com"] },
+        }),
+      );
+      expect(route("http://100.100.100.100", "100.100.100.100")).toBe(
+        "SOCKS5 127.0.0.1:1055",
+      );
+      expect(
+        route("http://srv.example.ts.net", "srv.example.ts.net"),
+      ).toBe("SOCKS5 127.0.0.1:1055");
+    });
+
+    it("rules are inert when no exit node is active", () => {
+      const route = evalPAC(
+        pm,
+        baseState({
+          domainSplit: { mode: "bypass", domains: ["teams.microsoft.com"] },
+        }),
+      );
+      expect(route("https://teams.microsoft.com/", "teams.microsoft.com")).toBe(
+        "DIRECT",
+      );
+      expect(route("https://example.com/", "example.com")).toBe("DIRECT");
+    });
+
+    it("regenerates PAC when domainSplit changes", () => {
+      const spy = vi.spyOn(chrome.proxy.settings, "set");
+      pm.apply(withExit());
+      const callsBefore = spy.mock.calls.length;
+      pm.apply(
+        withExit({
+          domainSplit: { mode: "bypass", domains: ["teams.microsoft.com"] },
+        }),
+      );
+      expect(spy.mock.calls.length).toBeGreaterThan(callsBefore);
+    });
+
+    it("drops invalid domains before embedding in PAC", () => {
+      const pac = capturePAC(
+        pm,
+        withExit({
+          domainSplit: {
+            mode: "bypass",
+            domains: ['evil"); alert("xss', "ok.example.com"],
+          },
+        }),
+      )!;
+      expect(pac).not.toContain("evil");
+      expect(pac).toContain('"ok.example.com"');
+    });
+  });
 });
 
 function evalPAC(

--- a/packages/extension/src/background/chrome-proxy-manager.test.ts
+++ b/packages/extension/src/background/chrome-proxy-manager.test.ts
@@ -259,6 +259,32 @@ describe("ChromeProxyManager", () => {
       ).toBe("SOCKS5 127.0.0.1:1055");
     });
 
+    it("only mode with empty list: catch-all is DIRECT", () => {
+      const route = evalPAC(
+        pm,
+        withExit({ domainSplit: { mode: "only", domains: [] } }),
+      );
+      expect(route("https://example.com/", "example.com")).toBe("DIRECT");
+      expect(route("https://google.com/", "google.com")).toBe("DIRECT");
+      // Tailscale-mandatory traffic still proxies.
+      expect(route("http://100.100.100.100", "100.100.100.100")).toBe(
+        "SOCKS5 127.0.0.1:1055",
+      );
+      expect(
+        route("http://srv.example.ts.net", "srv.example.ts.net"),
+      ).toBe("SOCKS5 127.0.0.1:1055");
+    });
+
+    it("bypass mode with empty list: catch-all is full proxy (no rules to apply)", () => {
+      const route = evalPAC(
+        pm,
+        withExit({ domainSplit: { mode: "bypass", domains: [] } }),
+      );
+      expect(route("https://example.com/", "example.com")).toBe(
+        "SOCKS5 127.0.0.1:1055",
+      );
+    });
+
     it("rules are inert when no exit node is active", () => {
       const route = evalPAC(
         pm,

--- a/packages/extension/src/background/chrome-proxy-manager.ts
+++ b/packages/extension/src/background/chrome-proxy-manager.ts
@@ -106,21 +106,21 @@ export class ChromeProxyManager {
 
     const safeDNSSuffix = sanitizeMagicDNSSuffix(magicDNSSuffix);
 
-    const splitActive = exitNodeActive && splitDomains.length > 0;
-    const domainChecks = splitDomains
-      .map(
-        (d) =>
-          `(host === "${d}" || dnsDomainIs(host, ".${d}"))`,
-      )
-      .join(" || ");
+    const domainChecks =
+      splitDomains
+        .map((d) => `(host === "${d}" || dnsDomainIs(host, ".${d}"))`)
+        .join(" || ") || "false";
 
     let catchAll: string;
-    if (splitActive && splitMode === "bypass") {
-      catchAll = `  if (${domainChecks}) return "DIRECT";\n  return proxy;`;
-    } else if (splitActive && splitMode === "only") {
+    if (!exitNodeActive) {
+      catchAll = '  return "DIRECT";';
+    } else if (splitMode === "only") {
+      // Only mode: empty list means nothing should leave through the exit node.
       catchAll = `  if (${domainChecks}) return proxy;\n  return "DIRECT";`;
+    } else if (splitDomains.length > 0) {
+      catchAll = `  if (${domainChecks}) return "DIRECT";\n  return proxy;`;
     } else {
-      catchAll = exitNodeActive ? "  return proxy;" : '  return "DIRECT";';
+      catchAll = "  return proxy;";
     }
 
     return `function FindProxyForURL(url, host) {

--- a/packages/extension/src/background/chrome-proxy-manager.ts
+++ b/packages/extension/src/background/chrome-proxy-manager.ts
@@ -1,8 +1,9 @@
-import type { TailscaleState } from "@tailchrome/shared/types";
+import type { DomainSplitConfig, TailscaleState } from "@tailchrome/shared/types";
 import { TAILSCALE_SERVICE_IP } from "@tailchrome/shared/constants";
 import {
   parseCIDR,
   sanitizeMagicDNSSuffix,
+  sanitizeDomain,
   collectSubnetCIDRs,
   shouldProxyState,
 } from "@tailchrome/shared/background/proxy-utils";
@@ -23,9 +24,11 @@ export class ChromeProxyManager {
     const magicDNSSuffix = state.magicDNSSuffix;
     const exitNodeActive = state.exitNode !== null;
     const subnets = collectSubnetCIDRs(state.peers);
+    const splitDomains = sanitizeSplitDomains(state.domainSplit);
+    const splitMode = state.domainSplit.mode;
 
     // Skip regeneration if proxy-relevant fields haven't changed
-    const proxyKey = `${port}:${magicDNSSuffix ?? ""}:${exitNodeActive}:${[...subnets].sort().join(",")}`;
+    const proxyKey = `${port}:${magicDNSSuffix ?? ""}:${exitNodeActive}:${[...subnets].sort().join(",")}:${splitMode}:${splitDomains.join(",")}`;
     if (proxyKey === this.lastProxyKey) {
       return;
     }
@@ -36,6 +39,8 @@ export class ChromeProxyManager {
       magicDNSSuffix,
       exitNodeActive,
       subnets,
+      splitMode,
+      splitDomains,
     );
 
     chrome.proxy.settings.set(
@@ -85,6 +90,8 @@ export class ChromeProxyManager {
     magicDNSSuffix: string | null | undefined,
     exitNodeActive: boolean,
     subnets: string[],
+    splitMode: "bypass" | "only",
+    splitDomains: string[],
   ): string {
     const proxy = `SOCKS5 127.0.0.1:${port}`;
 
@@ -99,6 +106,23 @@ export class ChromeProxyManager {
 
     const safeDNSSuffix = sanitizeMagicDNSSuffix(magicDNSSuffix);
 
+    const splitActive = exitNodeActive && splitDomains.length > 0;
+    const domainChecks = splitDomains
+      .map(
+        (d) =>
+          `(host === "${d}" || dnsDomainIs(host, ".${d}"))`,
+      )
+      .join(" || ");
+
+    let catchAll: string;
+    if (splitActive && splitMode === "bypass") {
+      catchAll = `  if (${domainChecks}) return "DIRECT";\n  return proxy;`;
+    } else if (splitActive && splitMode === "only") {
+      catchAll = `  if (${domainChecks}) return proxy;\n  return "DIRECT";`;
+    } else {
+      catchAll = exitNodeActive ? "  return proxy;" : '  return "DIRECT";';
+    }
+
     return `function FindProxyForURL(url, host) {
   var proxy = "${proxy}";
 
@@ -108,7 +132,19 @@ ${safeDNSSuffix ? `  if (dnsDomainIs(host, ".${safeDNSSuffix}") || host === "${s
 
 ${subnetChecks || "  // No subnet routes"}
 
-${exitNodeActive ? "  return proxy;" : '  return "DIRECT";'}
+${catchAll}
 }`;
   }
+}
+
+function sanitizeSplitDomains(config: DomainSplitConfig): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of config.domains) {
+    const cleaned = sanitizeDomain(raw);
+    if (!cleaned || seen.has(cleaned)) continue;
+    seen.add(cleaned);
+    out.push(cleaned);
+  }
+  return out;
 }

--- a/packages/extension/src/background/firefox-proxy-manager.test.ts
+++ b/packages/extension/src/background/firefox-proxy-manager.test.ts
@@ -134,6 +134,81 @@ describe("FirefoxProxyManager", () => {
     });
   });
 
+  describe("split tunneling rules", () => {
+    const withExit = (overrides: Record<string, unknown> = {}) =>
+      baseState({
+        exitNode: {
+          id: "exit1",
+          hostname: "exit",
+          location: null,
+          online: true,
+        },
+        ...overrides,
+      });
+    const resolveOf = (manager: FirefoxProxyManager) =>
+      (url: string) =>
+        (manager as unknown as { resolveProxy(url: string): { type: string } }).resolveProxy(url);
+
+    it("bypass mode: listed domain goes direct, others go through proxy", () => {
+      pm.apply(
+        withExit({
+          domainSplit: { mode: "bypass", domains: ["teams.microsoft.com"] },
+        }),
+      );
+      const resolve = resolveOf(pm);
+      expect(resolve("https://teams.microsoft.com/").type).toBe("direct");
+      expect(resolve("https://x.teams.microsoft.com/").type).toBe("direct");
+      expect(resolve("https://example.com/").type).toBe("socks");
+    });
+
+    it("only mode: listed domain goes through proxy, others go direct", () => {
+      pm.apply(
+        withExit({
+          domainSplit: { mode: "only", domains: ["work.example.com"] },
+        }),
+      );
+      const resolve = resolveOf(pm);
+      expect(resolve("https://work.example.com/").type).toBe("socks");
+      expect(resolve("https://google.com/").type).toBe("direct");
+    });
+
+    it("only mode still routes Tailscale-mandatory traffic through proxy", () => {
+      pm.apply(
+        withExit({
+          domainSplit: { mode: "only", domains: ["work.example.com"] },
+        }),
+      );
+      const resolve = resolveOf(pm);
+      expect(resolve("http://100.100.100.100/").type).toBe("socks");
+      expect(resolve("http://srv.example.ts.net/").type).toBe("socks");
+    });
+
+    it("rules are inert when no exit node is active", () => {
+      pm.apply(
+        baseState({
+          domainSplit: { mode: "bypass", domains: ["teams.microsoft.com"] },
+        }),
+      );
+      const resolve = resolveOf(pm);
+      expect(resolve("https://teams.microsoft.com/").type).toBe("direct");
+      expect(resolve("https://example.com/").type).toBe("direct");
+    });
+
+    it("ignores invalid domain entries", () => {
+      pm.apply(
+        withExit({
+          domainSplit: {
+            mode: "bypass",
+            domains: ['evil"); alert("xss', "ok.example.com"],
+          },
+        }),
+      );
+      const resolve = resolveOf(pm);
+      expect(resolve("https://ok.example.com/").type).toBe("direct");
+      expect(resolve("https://other.com/").type).toBe("socks");
+    });
+  });
+
   describe("listener wake flow", () => {
     it("defers to restore and reconnect promises during wake", async () => {
       pm.apply(baseState({ proxyPort: 3333 }));

--- a/packages/extension/src/background/firefox-proxy-manager.test.ts
+++ b/packages/extension/src/background/firefox-proxy-manager.test.ts
@@ -172,6 +172,22 @@ describe("FirefoxProxyManager", () => {
       expect(resolve("https://google.com/").type).toBe("direct");
     });
 
+    it("only mode with empty list: catch-all is direct", () => {
+      pm.apply(withExit({ domainSplit: { mode: "only", domains: [] } }));
+      const resolve = resolveOf(pm);
+      expect(resolve("https://example.com/").type).toBe("direct");
+      expect(resolve("https://google.com/").type).toBe("direct");
+      // Tailscale-mandatory traffic still proxies.
+      expect(resolve("http://100.100.100.100/").type).toBe("socks");
+      expect(resolve("http://srv.example.ts.net/").type).toBe("socks");
+    });
+
+    it("bypass mode with empty list: catch-all is proxy", () => {
+      pm.apply(withExit({ domainSplit: { mode: "bypass", domains: [] } }));
+      const resolve = resolveOf(pm);
+      expect(resolve("https://example.com/").type).toBe("socks");
+    });
+
     it("only mode still routes Tailscale-mandatory traffic through proxy", () => {
       pm.apply(
         withExit({

--- a/packages/extension/src/background/firefox-proxy-manager.ts
+++ b/packages/extension/src/background/firefox-proxy-manager.ts
@@ -220,15 +220,16 @@ export class FirefoxProxyManager {
       }
     }
 
-    if (this.exitNodeActive && this.splitDomains.length > 0) {
-      const matched = this.matchSplitDomain(host);
-      if (this.splitMode === "bypass") {
-        return matched ? direct : proxy;
+    if (this.exitNodeActive) {
+      if (this.splitMode === "only") {
+        // Only mode: empty list means nothing leaves through the exit node.
+        return this.matchSplitDomain(host) ? proxy : direct;
       }
-      return matched ? proxy : direct;
+      if (this.splitDomains.length > 0 && this.matchSplitDomain(host)) {
+        return direct;
+      }
+      return proxy;
     }
-
-    if (this.exitNodeActive) return proxy;
 
     return direct;
   }

--- a/packages/extension/src/background/firefox-proxy-manager.ts
+++ b/packages/extension/src/background/firefox-proxy-manager.ts
@@ -1,9 +1,14 @@
-import type { TailscaleState } from "@tailchrome/shared/types";
+import type {
+  DomainSplitConfig,
+  DomainSplitMode,
+  TailscaleState,
+} from "@tailchrome/shared/types";
 import { TAILSCALE_SERVICE_IP } from "@tailchrome/shared/constants";
 import {
   parseCIDR,
   ipToNum,
   sanitizeMagicDNSSuffix,
+  sanitizeDomain,
   collectSubnetCIDRs,
   shouldProxyState,
   CGNAT_NETWORK,
@@ -50,6 +55,8 @@ interface StoredProxyConfig {
   magicDNSSuffix: string;
   exitNodeActive: boolean;
   subnetRanges: Array<{ network: number; mask: number }>;
+  splitMode: DomainSplitMode;
+  splitDomains: string[];
 }
 
 export class FirefoxProxyManager {
@@ -57,6 +64,8 @@ export class FirefoxProxyManager {
   private magicDNSSuffix = "";
   private exitNodeActive = false;
   private subnetRanges: Array<{ network: number; mask: number }> = [];
+  private splitMode: DomainSplitMode = "bypass";
+  private splitDomains: string[] = [];
   private restorePromise: Promise<void> | null = null;
   private reconnectPromise: Promise<void> | null = null;
   private reconnectResolve: (() => void) | null = null;
@@ -97,6 +106,8 @@ export class FirefoxProxyManager {
     this.subnetRanges = collectSubnetCIDRs(state.peers)
       .map((cidr) => parseCIDR(cidr))
       .filter((r): r is { network: number; mask: number } => r !== null);
+    this.splitMode = state.domainSplit.mode;
+    this.splitDomains = sanitizeSplitDomains(state.domainSplit);
     this.restorePromise = null;
 
     if (this.reconnectResolve) {
@@ -119,6 +130,8 @@ export class FirefoxProxyManager {
     this.magicDNSSuffix = "";
     this.exitNodeActive = false;
     this.subnetRanges = [];
+    this.splitMode = "bypass";
+    this.splitDomains = [];
 
     if (this.reconnectResolve) {
       this.reconnectResolve();
@@ -138,6 +151,10 @@ export class FirefoxProxyManager {
       this.magicDNSSuffix = config.magicDNSSuffix;
       this.exitNodeActive = config.exitNodeActive;
       this.subnetRanges = config.subnetRanges;
+      this.splitMode = config.splitMode ?? "bypass";
+      this.splitDomains = Array.isArray(config.splitDomains)
+        ? config.splitDomains
+        : [];
       this.reconnectPromise = new Promise<void>((resolve) => {
         this.reconnectResolve = resolve;
       });
@@ -155,6 +172,8 @@ export class FirefoxProxyManager {
       magicDNSSuffix: this.magicDNSSuffix,
       exitNodeActive: this.exitNodeActive,
       subnetRanges: this.subnetRanges,
+      splitMode: this.splitMode,
+      splitDomains: this.splitDomains,
     };
     await browser.storage.session.set({ [STORAGE_KEY]: config });
   }
@@ -201,8 +220,35 @@ export class FirefoxProxyManager {
       }
     }
 
+    if (this.exitNodeActive && this.splitDomains.length > 0) {
+      const matched = this.matchSplitDomain(host);
+      if (this.splitMode === "bypass") {
+        return matched ? direct : proxy;
+      }
+      return matched ? proxy : direct;
+    }
+
     if (this.exitNodeActive) return proxy;
 
     return direct;
   }
+
+  private matchSplitDomain(host: string): boolean {
+    for (const d of this.splitDomains) {
+      if (host === d || host.endsWith(`.${d}`)) return true;
+    }
+    return false;
+  }
+}
+
+function sanitizeSplitDomains(config: DomainSplitConfig): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of config.domains) {
+    const cleaned = sanitizeDomain(raw);
+    if (!cleaned || seen.has(cleaned)) continue;
+    seen.add(cleaned);
+    out.push(cleaned);
+  }
+  return out;
 }

--- a/packages/shared/src/__test__/fixtures.ts
+++ b/packages/shared/src/__test__/fixtures.ts
@@ -20,6 +20,7 @@ export function baseState(overrides: Partial<TailscaleState> = {}): TailscaleSta
     currentProfile: null,
     profiles: [],
     exitNodeSuggestion: null,
+    domainSplit: { mode: "bypass", domains: [] },
     error: null,
     installError: false,
     hostVersion: null,

--- a/packages/shared/src/background/background.test.ts
+++ b/packages/shared/src/background/background.test.ts
@@ -825,6 +825,137 @@ describe("initBackground", () => {
     });
   });
 
+  describe("domain split", () => {
+    it("restores saved domainSplit from storage on startup", async () => {
+      (chrome.storage.local.get as ReturnType<typeof vi.fn>) = vi
+        .fn()
+        .mockImplementation((key: string) => {
+          if (key === "domainSplitConfig") {
+            return Promise.resolve({
+              domainSplitConfig: {
+                mode: "only",
+                domains: ["teams.microsoft.com"],
+              },
+            });
+          }
+          return Promise.resolve({ profileId: "test-id" });
+        }) as unknown as typeof chrome.storage.local.get;
+
+      await setupBackground();
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(proxyManager.apply).toHaveBeenCalledWith(
+        expect.objectContaining({
+          domainSplit: {
+            mode: "only",
+            domains: ["teams.microsoft.com"],
+          },
+        }),
+      );
+    });
+
+    it("updates state when domainSplit storage changes", async () => {
+      await setupBackground();
+      await vi.advanceTimersByTimeAsync(0);
+
+      const listeners = (chrome.storage.onChanged as unknown as {
+        _listeners: Array<
+          (changes: Record<string, { newValue?: unknown }>, area: string) => void
+        >;
+      })._listeners;
+      const listener = listeners[listeners.length - 1]!;
+
+      (proxyManager.apply as ReturnType<typeof vi.fn>).mockClear();
+      await listener(
+        {
+          domainSplitConfig: {
+            newValue: {
+              mode: "bypass",
+              domains: ["outlook.office.com"],
+            },
+          },
+        },
+        "local",
+      );
+
+      expect(proxyManager.apply).toHaveBeenCalledWith(
+        expect.objectContaining({
+          domainSplit: {
+            mode: "bypass",
+            domains: ["outlook.office.com"],
+          },
+        }),
+      );
+    });
+
+    it("ignores no-op storage changes", async () => {
+      (chrome.storage.local.get as ReturnType<typeof vi.fn>) = vi
+        .fn()
+        .mockImplementation((key: string) => {
+          if (key === "domainSplitConfig") {
+            return Promise.resolve({
+              domainSplitConfig: {
+                mode: "bypass",
+                domains: ["example.com"],
+              },
+            });
+          }
+          return Promise.resolve({ profileId: "test-id" });
+        }) as unknown as typeof chrome.storage.local.get;
+
+      await setupBackground();
+      await vi.advanceTimersByTimeAsync(0);
+
+      const listeners = (chrome.storage.onChanged as unknown as {
+        _listeners: Array<
+          (changes: Record<string, { newValue?: unknown }>, area: string) => void
+        >;
+      })._listeners;
+      const listener = listeners[listeners.length - 1]!;
+
+      (proxyManager.apply as ReturnType<typeof vi.fn>).mockClear();
+      await listener(
+        {
+          domainSplitConfig: {
+            newValue: { mode: "bypass", domains: ["example.com"] },
+          },
+        },
+        "local",
+      );
+      expect(proxyManager.apply).not.toHaveBeenCalled();
+    });
+
+    it("handles set-domain-split popup message", async () => {
+      await setupBackground();
+      await vi.advanceTimersByTimeAsync(0);
+      (chrome.storage.local.set as ReturnType<typeof vi.fn>).mockClear();
+
+      const popupPort = createPopupPort();
+      connectListeners[0]!(popupPort);
+      popupPort.onMessage._listeners[0]!({
+        type: "set-domain-split",
+        config: { mode: "only", domains: ["WORK.example.com", "bad domain"] },
+      });
+
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(proxyManager.apply).toHaveBeenCalledWith(
+        expect.objectContaining({
+          domainSplit: {
+            mode: "only",
+            domains: ["work.example.com"],
+          },
+        }),
+      );
+      expect(chrome.storage.local.set).toHaveBeenCalledWith({
+        domainSplitConfig: {
+          mode: "only",
+          domains: ["work.example.com"],
+        },
+      });
+    });
+  });
+
   describe("uiSurface wiring", () => {
     beforeEach(() => {
       (chrome.sidePanel.setPanelBehavior as ReturnType<typeof vi.fn>).mockClear();

--- a/packages/shared/src/background/background.test.ts
+++ b/packages/shared/src/background/background.test.ts
@@ -827,7 +827,7 @@ describe("initBackground", () => {
 
   describe("domain split", () => {
     it("restores saved domainSplit from storage on startup", async () => {
-      (chrome.storage.local.get as ReturnType<typeof vi.fn>) = vi
+      (chrome.storage.local.get as unknown as ReturnType<typeof vi.fn>) = vi
         .fn()
         .mockImplementation((key: string) => {
           if (key === "domainSplitConfig") {
@@ -839,7 +839,7 @@ describe("initBackground", () => {
             });
           }
           return Promise.resolve({ profileId: "test-id" });
-        }) as unknown as typeof chrome.storage.local.get;
+        });
 
       await setupBackground();
       await vi.advanceTimersByTimeAsync(0);
@@ -889,7 +889,7 @@ describe("initBackground", () => {
     });
 
     it("ignores no-op storage changes", async () => {
-      (chrome.storage.local.get as ReturnType<typeof vi.fn>) = vi
+      (chrome.storage.local.get as unknown as ReturnType<typeof vi.fn>) = vi
         .fn()
         .mockImplementation((key: string) => {
           if (key === "domainSplitConfig") {
@@ -901,7 +901,7 @@ describe("initBackground", () => {
             });
           }
           return Promise.resolve({ profileId: "test-id" });
-        }) as unknown as typeof chrome.storage.local.get;
+        });
 
       await setupBackground();
       await vi.advanceTimersByTimeAsync(0);

--- a/packages/shared/src/background/background.ts
+++ b/packages/shared/src/background/background.ts
@@ -12,6 +12,12 @@ import { BadgeManager } from "./badge-manager";
 import { DefaultTimerService, type TimerService } from "./timer-service";
 import { formatBugReportForToast } from "./format-bug-report-toast";
 import { applyUiSurface, readUiSurface, type BrowserKind } from "./ui-surface";
+import {
+  DOMAIN_SPLIT_STORAGE_KEY,
+  normalizeDomainSplit,
+  readDomainSplit,
+  writeDomainSplit,
+} from "./domain-split";
 
 export type { ProxyManager };
 
@@ -65,6 +71,18 @@ function isVersionMismatch(hostVersion: string | null): boolean {
 const NATIVE_HOST_UNREACHABLE =
   "Could not reach Tailscale service. Please check that the native host is installed.";
 
+function domainSplitEquals(
+  a: { mode: string; domains: string[] },
+  b: { mode: string; domains: string[] },
+): boolean {
+  if (a.mode !== b.mode) return false;
+  if (a.domains.length !== b.domains.length) return false;
+  for (let i = 0; i < a.domains.length; i++) {
+    if (a.domains[i] !== b.domains[i]) return false;
+  }
+  return true;
+}
+
 export function initBackground(
   proxyManager: ProxyManager,
   nativeHostId: string,
@@ -82,15 +100,37 @@ export function initBackground(
   void readUiSurface()
     .then((surface) => applyUiSurface(surface, browserKind))
     .catch(logUiSurfaceFailure);
-  chrome.storage.onChanged.addListener((changes, area) => {
-    if (area !== "local" || !("uiSurface" in changes)) return;
-    const next = changes["uiSurface"]?.newValue;
-    if (next === "popup" || next === "sidePanel") {
-      void applyUiSurface(next, browserKind).catch(logUiSurfaceFailure);
-    }
-  });
 
   const store = new StateStore();
+
+  void readDomainSplit()
+    .then((config) => {
+      if (!domainSplitEquals(store.getState().domainSplit, config)) {
+        store.update({ domainSplit: config });
+      }
+    })
+    .catch((err) => {
+      console.warn("[Background] readDomainSplit failed:", err);
+    });
+
+  chrome.storage.onChanged.addListener((changes, area) => {
+    if (area !== "local") return;
+    if ("uiSurface" in changes) {
+      const next = changes["uiSurface"]?.newValue;
+      if (next === "popup" || next === "sidePanel") {
+        void applyUiSurface(next, browserKind).catch(logUiSurfaceFailure);
+      }
+    }
+    if (DOMAIN_SPLIT_STORAGE_KEY in changes) {
+      const next = normalizeDomainSplit(
+        changes[DOMAIN_SPLIT_STORAGE_KEY]?.newValue,
+      );
+      const current = store.getState().domainSplit;
+      if (!domainSplitEquals(current, next)) {
+        store.update({ domainSplit: next });
+      }
+    }
+  });
   const badgeManager = new BadgeManager();
 
   // Connected popup ports
@@ -492,6 +532,15 @@ export function initBackground(
 
       case "set-advertise-routes": {
         nativeHost.send({ cmd: "set-prefs", prefs: { advertiseRoutes: msg.routes } });
+        break;
+      }
+
+      case "set-domain-split": {
+        const next = normalizeDomainSplit(msg.config);
+        store.update({ domainSplit: next });
+        void writeDomainSplit(next).catch((err) => {
+          console.warn("[Background] writeDomainSplit failed:", err);
+        });
         break;
       }
 

--- a/packages/shared/src/background/domain-split.test.ts
+++ b/packages/shared/src/background/domain-split.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  DEFAULT_DOMAIN_SPLIT,
+  DOMAIN_SPLIT_STORAGE_KEY,
+  defaultDomainSplit,
+  normalizeDomainSplit,
+  readDomainSplit,
+  writeDomainSplit,
+} from "./domain-split";
+import { sanitizeDomain } from "./proxy-utils";
+
+describe("sanitizeDomain", () => {
+  it("lowercases and trims", () => {
+    expect(sanitizeDomain("  Teams.Microsoft.COM  ")).toBe("teams.microsoft.com");
+  });
+
+  it("strips scheme, path, and port", () => {
+    expect(sanitizeDomain("https://teams.microsoft.com/login?x=1")).toBe(
+      "teams.microsoft.com",
+    );
+    expect(sanitizeDomain("http://example.com:8080/foo")).toBe("example.com");
+  });
+
+  it("strips a leading or trailing dot", () => {
+    expect(sanitizeDomain(".microsoft.com")).toBe("microsoft.com");
+    expect(sanitizeDomain("microsoft.com.")).toBe("microsoft.com");
+  });
+
+  it("rejects empty input", () => {
+    expect(sanitizeDomain("")).toBeNull();
+    expect(sanitizeDomain("   ")).toBeNull();
+    expect(sanitizeDomain(null)).toBeNull();
+    expect(sanitizeDomain(undefined)).toBeNull();
+  });
+
+  it("rejects unsafe characters (PAC injection)", () => {
+    expect(sanitizeDomain('evil"); alert("xss')).toBeNull();
+    expect(sanitizeDomain("foo.com\nbar.com")).toBeNull();
+    expect(sanitizeDomain("foo bar.com")).toBeNull();
+    expect(sanitizeDomain("foo$bar.com")).toBeNull();
+  });
+
+  it("rejects empty labels", () => {
+    expect(sanitizeDomain("foo..bar")).toBeNull();
+  });
+});
+
+describe("normalizeDomainSplit", () => {
+  it("returns defaults for nullish or non-object input", () => {
+    expect(normalizeDomainSplit(null)).toEqual(DEFAULT_DOMAIN_SPLIT);
+    expect(normalizeDomainSplit(undefined)).toEqual(DEFAULT_DOMAIN_SPLIT);
+    expect(normalizeDomainSplit("nope")).toEqual(DEFAULT_DOMAIN_SPLIT);
+  });
+
+  it("defaults invalid modes to bypass", () => {
+    expect(normalizeDomainSplit({ mode: "whatever", domains: [] }).mode).toBe(
+      "bypass",
+    );
+  });
+
+  it("preserves valid modes", () => {
+    expect(normalizeDomainSplit({ mode: "only", domains: [] }).mode).toBe("only");
+  });
+
+  it("drops invalid domains and deduplicates", () => {
+    const result = normalizeDomainSplit({
+      mode: "bypass",
+      domains: [
+        "teams.microsoft.com",
+        "TEAMS.microsoft.com",
+        '"evil',
+        "",
+        42 as unknown as string,
+        "outlook.office.com",
+      ],
+    });
+    expect(result.domains).toEqual([
+      "teams.microsoft.com",
+      "outlook.office.com",
+    ]);
+  });
+
+  it("returns a fresh array on default", () => {
+    const a = defaultDomainSplit();
+    const b = defaultDomainSplit();
+    expect(a).not.toBe(b);
+    expect(a.domains).not.toBe(b.domains);
+  });
+});
+
+describe("readDomainSplit / writeDomainSplit", () => {
+  beforeEach(() => {
+    const store: Record<string, unknown> = {};
+    (globalThis as unknown as { chrome: typeof chrome }).chrome = {
+      storage: {
+        local: {
+          get: vi.fn(async (key: string) =>
+            key in store ? { [key]: store[key] } : {},
+          ),
+          set: vi.fn(async (items: Record<string, unknown>) => {
+            Object.assign(store, items);
+          }),
+        },
+      },
+    } as unknown as typeof chrome;
+  });
+
+  it("returns defaults when storage is empty", async () => {
+    expect(await readDomainSplit()).toEqual(DEFAULT_DOMAIN_SPLIT);
+  });
+
+  it("writes and reads round-trip", async () => {
+    await writeDomainSplit({
+      mode: "only",
+      domains: ["teams.microsoft.com", "outlook.office.com"],
+    });
+    expect(await readDomainSplit()).toEqual({
+      mode: "only",
+      domains: ["teams.microsoft.com", "outlook.office.com"],
+    });
+  });
+
+  it("normalizes on write (drops invalid, lowercases)", async () => {
+    await writeDomainSplit({
+      mode: "bypass",
+      domains: ["Teams.Microsoft.COM", '"bad', ""],
+    });
+    const setSpy = chrome.storage.local.set as unknown as ReturnType<typeof vi.fn>;
+    expect(setSpy).toHaveBeenCalledWith({
+      [DOMAIN_SPLIT_STORAGE_KEY]: {
+        mode: "bypass",
+        domains: ["teams.microsoft.com"],
+      },
+    });
+  });
+
+  it("returns defaults if storage throws", async () => {
+    (chrome.storage.local.get as unknown as ReturnType<typeof vi.fn>) = vi.fn(
+      () => Promise.reject(new Error("boom")),
+    );
+    expect(await readDomainSplit()).toEqual(DEFAULT_DOMAIN_SPLIT);
+  });
+});

--- a/packages/shared/src/background/domain-split.ts
+++ b/packages/shared/src/background/domain-split.ts
@@ -1,0 +1,51 @@
+import type { DomainSplitConfig, DomainSplitMode } from "../types";
+import { sanitizeDomain } from "./proxy-utils";
+
+const STORAGE_KEY = "domainSplitConfig";
+const VALID_MODES: ReadonlySet<DomainSplitMode> = new Set(["bypass", "only"]);
+
+export const DEFAULT_DOMAIN_SPLIT: DomainSplitConfig = {
+  mode: "bypass",
+  domains: [],
+};
+
+export function defaultDomainSplit(): DomainSplitConfig {
+  return { mode: DEFAULT_DOMAIN_SPLIT.mode, domains: [] };
+}
+
+export function normalizeDomainSplit(input: unknown): DomainSplitConfig {
+  if (!input || typeof input !== "object") return defaultDomainSplit();
+  const raw = input as { mode?: unknown; domains?: unknown };
+  const mode: DomainSplitMode = VALID_MODES.has(raw.mode as DomainSplitMode)
+    ? (raw.mode as DomainSplitMode)
+    : DEFAULT_DOMAIN_SPLIT.mode;
+
+  const seen = new Set<string>();
+  const domains: string[] = [];
+  if (Array.isArray(raw.domains)) {
+    for (const entry of raw.domains) {
+      if (typeof entry !== "string") continue;
+      const cleaned = sanitizeDomain(entry);
+      if (!cleaned || seen.has(cleaned)) continue;
+      seen.add(cleaned);
+      domains.push(cleaned);
+    }
+  }
+  return { mode, domains };
+}
+
+export async function readDomainSplit(): Promise<DomainSplitConfig> {
+  try {
+    const result = await chrome.storage.local.get(STORAGE_KEY);
+    return normalizeDomainSplit(result[STORAGE_KEY]);
+  } catch {
+    return defaultDomainSplit();
+  }
+}
+
+export async function writeDomainSplit(config: DomainSplitConfig): Promise<void> {
+  const normalized = normalizeDomainSplit(config);
+  await chrome.storage.local.set({ [STORAGE_KEY]: normalized });
+}
+
+export const DOMAIN_SPLIT_STORAGE_KEY = STORAGE_KEY;

--- a/packages/shared/src/background/proxy-utils.ts
+++ b/packages/shared/src/background/proxy-utils.ts
@@ -68,6 +68,34 @@ export function sanitizeMagicDNSSuffix(suffix: string | null | undefined): strin
   return /^[a-zA-Z0-9.\-]+$/.test(stripped) ? stripped : "";
 }
 
+/**
+ * Normalize a user-entered domain for split-tunnel matching. Lowercases,
+ * trims whitespace, strips an optional scheme/path/port, and rejects any
+ * value containing characters outside the PAC-safe allowlist so the result
+ * can be embedded into the generated PAC script without escaping.
+ */
+export function sanitizeDomain(input: string | null | undefined): string | null {
+  if (!input) return null;
+  let value = input.trim().toLowerCase();
+  if (!value) return null;
+
+  const schemeMatch = value.match(/^[a-z][a-z0-9+\-.]*:\/\//);
+  if (schemeMatch) value = value.slice(schemeMatch[0].length);
+
+  const slashIdx = value.indexOf("/");
+  if (slashIdx >= 0) value = value.slice(0, slashIdx);
+
+  const colonIdx = value.indexOf(":");
+  if (colonIdx >= 0) value = value.slice(0, colonIdx);
+
+  value = value.replace(/\.$/, "").replace(/^\./, "");
+  if (!value) return null;
+  if (!/^[a-z0-9.\-]+$/.test(value)) return null;
+  if (value.includes("..")) return null;
+
+  return value;
+}
+
 /** Collect all subnet CIDRs from peers that are subnet routers. */
 export function collectSubnetCIDRs(peers: PeerInfo[]): string[] {
   const cidrs: string[] = [];

--- a/packages/shared/src/background/state-store.ts
+++ b/packages/shared/src/background/state-store.ts
@@ -21,6 +21,7 @@ const DEFAULT_STATE: TailscaleState = {
   currentProfile: null,
   profiles: [],
   exitNodeSuggestion: null,
+  domainSplit: { mode: "bypass", domains: [] },
   error: null,
   installError: false,
   hostVersion: null,

--- a/packages/shared/src/popup/styles/components.css
+++ b/packages/shared/src/popup/styles/components.css
@@ -632,6 +632,76 @@ button.setting-row {
   display: none;
 }
 
+.split-tunneling-editor.hidden {
+  display: none;
+}
+
+.split-tunneling-modes {
+  display: inline-flex;
+  align-self: flex-start;
+  gap: 1px;
+  padding: 2px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+}
+
+.split-tunneling-mode-btn {
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  font-family: inherit;
+  font-size: var(--font-size-xs);
+  padding: var(--space-xs) var(--space-sm);
+  border-radius: calc(var(--radius-sm) - 2px);
+  cursor: pointer;
+}
+
+.split-tunneling-mode-btn:hover {
+  color: var(--text-primary);
+}
+
+.split-tunneling-mode-btn[data-active="true"] {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+}
+
+.split-tunneling-help {
+  margin: 0;
+  font-size: var(--font-size-xs);
+  color: var(--text-tertiary);
+  line-height: 1.4;
+}
+
+.split-tunneling-input {
+  width: 100%;
+  min-height: 4.5rem;
+  padding: var(--space-xs) var(--space-sm);
+  font-family: var(--font-family);
+  font-size: var(--font-size-xs);
+  color: var(--text-primary);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  resize: vertical;
+}
+
+.split-tunneling-warning {
+  margin: 0;
+  min-height: 1em;
+  font-size: var(--font-size-xs);
+  color: var(--ts-orange);
+}
+
+.split-tunneling-warning:empty {
+  display: none;
+}
+
+.split-tunneling-save {
+  align-self: flex-start;
+}
+
 .advanced-settings-panel {
   display: flex;
   flex-direction: column;

--- a/packages/shared/src/popup/views/connected.ts
+++ b/packages/shared/src/popup/views/connected.ts
@@ -1,4 +1,4 @@
-import type { TailscaleState } from "../../types";
+import type { DomainSplitConfig, DomainSplitMode, TailscaleState } from "../../types";
 import { ADMIN_URL, TAILCHROME_PROJECT_URL } from "../../constants";
 import { renderHeader } from "../components/header";
 import { renderPeerList, updatePeerList, filterPeers } from "../components/peer-list";
@@ -11,6 +11,7 @@ import { renderExitNodes } from "./exit-nodes";
 import { renderProfiles } from "./profiles";
 import { iconChevronRight } from "../icons";
 import { renderUiSurfaceRow } from "../components/ui-surface-row";
+import { sanitizeDomain } from "../../background/proxy-utils";
 
 type SubViewRenderer = (root: HTMLElement, state: TailscaleState, onBack: () => void) => void;
 
@@ -19,6 +20,9 @@ let peerSearchQuery = "";
 
 /** UI-only: whether the advertise-subnets editor (textarea + save) is visible. */
 let advertiseRoutesEditorOpen = false;
+
+/** UI-only: whether the split-tunneling editor is visible. */
+let splitTunnelingEditorOpen = false;
 
 /** UI-only: Advanced section (Run as Exit Node, local node page; peer SSH when expanded). */
 let advancedSectionOpen = false;
@@ -147,6 +151,8 @@ export function renderConnected(root: HTMLElement, state: TailscaleState): void 
   exitRow.appendChild(exitValue);
   exitRow.addEventListener("click", () => openSubView(root, renderExitNodes));
   settings.appendChild(exitRow);
+
+  renderSplitTunnelingSection(settings, state);
 
   // Shields Up toggle
   const shieldsRow = document.createElement("div");
@@ -439,6 +445,140 @@ export function renderConnected(root: HTMLElement, state: TailscaleState): void 
 // Track health key to detect changes during in-place updates
 let lastHealthKey = "";
 
+function formatDomainsValue(domains: string[]): string {
+  return domains.join("\n");
+}
+
+function parseDomainsInput(value: string): {
+  domains: string[];
+  invalid: string[];
+} {
+  const seen = new Set<string>();
+  const domains: string[] = [];
+  const invalid: string[] = [];
+  for (const raw of value.split(/[\s,]+/)) {
+    const trimmed = raw.trim();
+    if (!trimmed) continue;
+    const cleaned = sanitizeDomain(trimmed);
+    if (!cleaned) {
+      invalid.push(trimmed);
+      continue;
+    }
+    if (seen.has(cleaned)) continue;
+    seen.add(cleaned);
+    domains.push(cleaned);
+  }
+  return { domains, invalid };
+}
+
+function setActiveMode(container: HTMLElement, mode: DomainSplitMode): void {
+  const buttons = container.querySelectorAll<HTMLButtonElement>(
+    ".split-tunneling-mode-btn",
+  );
+  for (const btn of buttons) {
+    const isActive = btn.dataset.mode === mode;
+    btn.dataset.active = isActive ? "true" : "false";
+    btn.setAttribute("aria-pressed", isActive ? "true" : "false");
+  }
+}
+
+function activeModeFromSection(section: HTMLElement): DomainSplitMode {
+  const active = section.querySelector<HTMLButtonElement>(
+    '.split-tunneling-mode-btn[data-active="true"]',
+  );
+  return (active?.dataset.mode as DomainSplitMode | undefined) ?? "bypass";
+}
+
+function applyConfig(
+  section: HTMLElement,
+  config: DomainSplitConfig,
+): void {
+  sendMessage({ type: "set-domain-split", config });
+  const warning = section.querySelector<HTMLElement>(".split-tunneling-warning");
+  if (warning) warning.textContent = "";
+}
+
+function renderSplitTunnelingSection(
+  parent: HTMLElement,
+  state: TailscaleState,
+): void {
+  const headerRow = document.createElement("div");
+  headerRow.className = "setting-row";
+  const label = document.createElement("span");
+  label.className = "setting-label";
+  label.textContent = "Split tunneling";
+  headerRow.appendChild(label);
+
+  const expandToggle = createToggle(splitTunnelingEditorOpen, (checked) => {
+    splitTunnelingEditorOpen = checked;
+    editorSection.classList.toggle("hidden", !checked);
+  });
+  headerRow.appendChild(expandToggle);
+  parent.appendChild(headerRow);
+
+  const editorSection = document.createElement("div");
+  editorSection.className =
+    "setting-row setting-row--stacked split-tunneling-editor";
+  if (!splitTunnelingEditorOpen) editorSection.classList.add("hidden");
+
+  const modeRow = document.createElement("div");
+  modeRow.className = "split-tunneling-modes";
+  for (const [mode, text] of [
+    ["bypass", "Bypass"],
+    ["only", "Only"],
+  ] as const) {
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "split-tunneling-mode-btn";
+    btn.dataset.mode = mode;
+    btn.textContent = text;
+    btn.addEventListener("click", () => {
+      setActiveMode(modeRow, mode);
+      const latest = getLatestState();
+      const domains = latest?.domainSplit.domains ?? state.domainSplit.domains;
+      applyConfig(editorSection, { mode, domains });
+    });
+    modeRow.appendChild(btn);
+  }
+  setActiveMode(modeRow, state.domainSplit.mode);
+  editorSection.appendChild(modeRow);
+
+  const help = document.createElement("p");
+  help.className = "split-tunneling-help";
+  help.textContent =
+    "Applies when an exit node is active. One domain per line; subdomains are matched.";
+  editorSection.appendChild(help);
+
+  const ta = document.createElement("textarea");
+  ta.className = "split-tunneling-input";
+  ta.rows = 3;
+  ta.spellcheck = false;
+  ta.placeholder = "e.g. teams.microsoft.com\noutlook.office.com";
+  ta.value = formatDomainsValue(state.domainSplit.domains);
+  editorSection.appendChild(ta);
+
+  const warning = document.createElement("p");
+  warning.className = "split-tunneling-warning";
+  warning.setAttribute("role", "status");
+  editorSection.appendChild(warning);
+
+  const saveBtn = document.createElement("button");
+  saveBtn.type = "button";
+  saveBtn.className = "btn btn-secondary split-tunneling-save";
+  saveBtn.textContent = "Save rules";
+  saveBtn.addEventListener("click", () => {
+    const parsed = parseDomainsInput(ta.value);
+    const mode = activeModeFromSection(editorSection);
+    applyConfig(editorSection, { mode, domains: parsed.domains });
+    if (parsed.invalid.length > 0) {
+      warning.textContent = `Ignored invalid: ${parsed.invalid.join(", ")}`;
+    }
+  });
+  editorSection.appendChild(saveBtn);
+
+  parent.appendChild(editorSection);
+}
+
 function fillFooterDiagnostics(diagRow: HTMLElement, state: TailscaleState): void {
   diagRow.replaceChildren();
   const diagLink = document.createElement("a");
@@ -623,6 +763,18 @@ export function updateConnected(root: HTMLElement, state: TailscaleState): void 
       if (routesTa.value !== next) {
         routesTa.value = next;
       }
+    }
+
+    const splitSection = view.querySelector<HTMLElement>(".split-tunneling-editor");
+    if (splitSection) {
+      const splitTa = splitSection.querySelector<HTMLTextAreaElement>(
+        ".split-tunneling-input",
+      );
+      if (splitTa && document.activeElement !== splitTa) {
+        const next = formatDomainsValue(state.domainSplit.domains);
+        if (splitTa.value !== next) splitTa.value = next;
+      }
+      setActiveMode(splitSection, state.domainSplit.mode);
     }
   }
 

--- a/packages/shared/src/popup/views/connected.ts
+++ b/packages/shared/src/popup/views/connected.ts
@@ -534,9 +534,7 @@ function renderSplitTunnelingSection(
     btn.textContent = text;
     btn.addEventListener("click", () => {
       setActiveMode(modeRow, mode);
-      const latest = getLatestState();
-      const domains = latest?.domainSplit.domains ?? state.domainSplit.domains;
-      applyConfig(editorSection, { mode, domains });
+      commit();
     });
     modeRow.appendChild(btn);
   }
@@ -562,18 +560,21 @@ function renderSplitTunnelingSection(
   warning.setAttribute("role", "status");
   editorSection.appendChild(warning);
 
+  const commit = (): void => {
+    const parsed = parseDomainsInput(ta.value);
+    const mode = activeModeFromSection(editorSection);
+    applyConfig(editorSection, { mode, domains: parsed.domains });
+    warning.textContent =
+      parsed.invalid.length > 0
+        ? `Ignored invalid: ${parsed.invalid.join(", ")}`
+        : "";
+  };
+
   const saveBtn = document.createElement("button");
   saveBtn.type = "button";
   saveBtn.className = "btn btn-secondary split-tunneling-save";
   saveBtn.textContent = "Save rules";
-  saveBtn.addEventListener("click", () => {
-    const parsed = parseDomainsInput(ta.value);
-    const mode = activeModeFromSection(editorSection);
-    applyConfig(editorSection, { mode, domains: parsed.domains });
-    if (parsed.invalid.length > 0) {
-      warning.textContent = `Ignored invalid: ${parsed.invalid.join(", ")}`;
-    }
-  });
+  saveBtn.addEventListener("click", commit);
   editorSection.appendChild(saveBtn);
 
   parent.appendChild(editorSection);

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -153,6 +153,13 @@ export interface ProfileInfo {
   name: string;
 }
 
+export type DomainSplitMode = "bypass" | "only";
+
+export interface DomainSplitConfig {
+  mode: DomainSplitMode;
+  domains: string[];
+}
+
 export interface ProfilesResult {
   current: ProfileInfo;
   profiles: ProfileInfo[];
@@ -199,6 +206,8 @@ export interface TailscaleState {
   profiles: ProfileInfo[];
 
   exitNodeSuggestion: ExitNodeSuggestion | null;
+
+  domainSplit: DomainSplitConfig;
 
   error: string | null;
   installError: boolean;
@@ -261,6 +270,7 @@ export type BackgroundMessage =
       chunkCount?: number;
     }
   | { type: "suggest-exit-node" }
+  | { type: "set-domain-split"; config: DomainSplitConfig }
   | { type: "open-admin" }
   | { type: "open-web-client" };
 

--- a/scripts/e2e/scenarios/split-tunneling.mjs
+++ b/scripts/e2e/scenarios/split-tunneling.mjs
@@ -50,6 +50,16 @@ async function waitForPacContains(page, fragment) {
   throw new Error(`PAC script never contained: ${fragment}`);
 }
 
+async function waitForPacWithout(page, fragment) {
+  const start = Date.now();
+  while (Date.now() - start < 5_000) {
+    const data = await getPacScript(page);
+    if (!data.includes(fragment)) return data;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`PAC script still contained: ${fragment}`);
+}
+
 export async function run({ openPopup }) {
   const page = await openPopup();
   try {
@@ -73,6 +83,30 @@ export async function run({ openPopup }) {
     }
     if (!pac.includes("SOCKS5 127.0.0.1:1055")) {
       throw new Error("Proxy still expected for unlisted hosts");
+    }
+
+    // Regression: typing new domains and clicking a mode button (without
+    // clicking Save) must commit both the new mode AND the typed domains,
+    // not the previously-saved domain list.
+    await page.$eval(
+      ".split-tunneling-input",
+      (el, value) => {
+        el.value = value;
+      },
+      "work.example.com",
+    );
+    await page.click('.split-tunneling-mode-btn[data-mode="only"]');
+    await waitForPacWithout(page, "teams.microsoft.com");
+    const pacAfterMode = await getPacScript(page);
+    if (!pacAfterMode.includes("work.example.com")) {
+      throw new Error(
+        "Mode click dropped the unsaved textarea entry (regression)",
+      );
+    }
+    if (pacAfterMode.includes("outlook.office.com")) {
+      throw new Error(
+        "Mode click kept stale saved domains instead of textarea contents",
+      );
     }
   } finally {
     await page.close();

--- a/scripts/e2e/scenarios/split-tunneling.mjs
+++ b/scripts/e2e/scenarios/split-tunneling.mjs
@@ -108,6 +108,31 @@ export async function run({ openPopup }) {
         "Mode click kept stale saved domains instead of textarea contents",
       );
     }
+
+    // Regression: Only mode with an empty list must route the catch-all
+    // DIRECT, not silently fall through to "everything via exit node".
+    await page.$eval(
+      ".split-tunneling-input",
+      (el) => {
+        el.value = "";
+      },
+    );
+    await clickText(page, "Save rules", "button");
+    await waitForPacWithout(page, "work.example.com");
+    const pacEmptyOnly = await getPacScript(page);
+    const catchAllSection = pacEmptyOnly
+      .split("// No subnet routes")
+      .at(-1) ?? "";
+    if (!catchAllSection.includes('return "DIRECT"')) {
+      throw new Error(
+        "Only mode with empty list should route catch-all DIRECT",
+      );
+    }
+    if (/return proxy;\s*\n\s*}$/.test(pacEmptyOnly)) {
+      throw new Error(
+        "Only mode with empty list should not fall through to proxy",
+      );
+    }
   } finally {
     await page.close();
   }

--- a/scripts/e2e/scenarios/split-tunneling.mjs
+++ b/scripts/e2e/scenarios/split-tunneling.mjs
@@ -1,0 +1,80 @@
+import {
+  clickText,
+  clickToggleForLabel,
+  expectText,
+  setInputValue,
+  waitForPopup,
+} from "../assertions.mjs";
+import { makeControl, makeRunningState } from "../fixtures.mjs";
+
+export const suite = "full";
+export const browsers = ["chrome"];
+
+export const control = () =>
+  makeControl({
+    status: makeRunningState({
+      exitNode: {
+        id: "peer-exit",
+        hostname: "exitbox",
+        location: {
+          city: "New York",
+          cityCode: "nyc",
+          country: "United States",
+          countryCode: "US",
+        },
+        online: true,
+      },
+    }),
+  });
+
+async function getPacScript(page) {
+  return page.evaluate(
+    () =>
+      new Promise((resolve, reject) => {
+        chrome.proxy.settings.get({ incognito: false }, (details) => {
+          const err = chrome.runtime.lastError;
+          if (err) reject(new Error(err.message));
+          else resolve(details.value?.pacScript?.data ?? "");
+        });
+      }),
+  );
+}
+
+async function waitForPacContains(page, fragment) {
+  const start = Date.now();
+  while (Date.now() - start < 5_000) {
+    const data = await getPacScript(page);
+    if (data.includes(fragment)) return data;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`PAC script never contained: ${fragment}`);
+}
+
+export async function run({ openPopup }) {
+  const page = await openPopup();
+  try {
+    await waitForPopup(page);
+    await expectText(page, "example.ts.net");
+
+    await clickToggleForLabel(page, "Split tunneling");
+    await setInputValue(
+      page,
+      ".split-tunneling-input",
+      "teams.microsoft.com\noutlook.office.com",
+    );
+    await clickText(page, "Save rules", "button");
+
+    const pac = await waitForPacContains(page, "teams.microsoft.com");
+    if (!pac.includes("outlook.office.com")) {
+      throw new Error("PAC missing outlook.office.com");
+    }
+    if (!pac.includes('return "DIRECT"')) {
+      throw new Error("Bypass branch missing from PAC");
+    }
+    if (!pac.includes("SOCKS5 127.0.0.1:1055")) {
+      throw new Error("Proxy still expected for unlisted hosts");
+    }
+  } finally {
+    await page.close();
+  }
+}


### PR DESCRIPTION
## What

Adds a per-domain split-tunnel inside the extension: when an exit node is selected, the user can list domains that should either **bypass** the exit node (go DIRECT from the local network) or be the **only** domains routed through it.

UI is an inline expandable section under the existing **Exit Node** row in the connected view — header toggle, mode selector (Bypass / Only), one-domain-per-line textarea, Save.

## Why

Closes #74.

Some sites (Microsoft Teams is the example in the issue, but Google, banks, and corp SSO portals do the same) flag traffic originating from VPN exit IPs as suspicious and either block the session or warn the account. Right now once you pick an exit node (e.g. a Mullvad one) **all** browser traffic goes through it — there's no escape hatch short of toggling the exit node off, which defeats the point.

## How

- New `DomainSplitConfig` (`{ mode, domains[] }`) persisted under `chrome.storage.local["domainSplitConfig"]` and threaded through `TailscaleState`.
- `ChromeProxyManager` regenerates the PAC script when the config changes; the bypass/only check is injected **after** the Tailscale-mandatory branches (`100.100.100.100`, CGNAT, MagicDNS, subnet routes) and **before** the exit-node catch-all. Mandatory Tailscale traffic always proxies regardless of the rules, so the extension never breaks itself.
- `FirefoxProxyManager.resolveProxy` applies the same logic per request and persists the config to `browser.storage.session` so it survives an SW restart.
- `sanitizeDomain` (PAC-safe allowlist) is applied at storage write, at PAC generation, and inline in the UI on Save — anything containing characters outside `[a-z0-9.-]` is dropped with an inline warning. Domain matching is suffix-based, mirroring `dnsDomainIs` (entering `microsoft.com` matches both `microsoft.com` and `*.microsoft.com`).
- Rules are inert when no exit node is selected (the catch-all is DIRECT anyway).

## Test

- [ ] Open Split tunneling, add `microsoft.com` in Bypass mode, save, pick a Mullvad exit node. Visit `https://teams.microsoft.com` — should not show as VPN-originating; visit `https://example.com` — should still come from the Mullvad IP.
- [ ] Switch the mode to Only with `work.example.com` saved. `https://work.example.com` goes through the exit, everything else goes DIRECT, but MagicDNS / Tailscale device IPs still resolve and connect.
- [ ] Reload the extension; saved rules persist.
- [ ] Paste a junk entry (`"foo bar"`, `evil"); alert("xss`); save. The entry is rejected with an inline warning and never reaches the PAC.

## Checklist

- [x] `pnpm test` (297 unit tests pass — 15 new for sanitize/storage, 10 new for PAC + Firefox routing, 4 new for background startup / onChanged / set-domain-split)
- [x] `pnpm typecheck`
- [x] `pnpm build:chrome` and `pnpm build:firefox`
- [x] `pnpm e2e:chrome --suite=full` and `pnpm e2e:firefox --suite=full` (new `split-tunneling` scenario passes; only the pre-existing `exit-nodes` flake fails — it expects a `suggest-exit-node` request that no source currently dispatches, unrelated to this change)
- [ ] Tested in Chrome (manual smoke pending)
- [ ] Tested in Firefox (manual smoke pending)
- [ ] Update README with feature inclusion

Marking draft while I finish the manual smoke pass. Happy to defer to your branch if you'd rather take it from there, I figured it'd be useful to have something to compare against.