### PR TITLE
Fix Log In button when Tailscale auth URL is missing

### DIFF
--- a/host/host.go
+++ b/host/host.go
@@ -140,6 +140,8 @@ func (h *Host) handleRequest(req Request) {
 	switch req.Cmd {
 	case "init":
 		h.handleInit(req)
+	case "login":
+		h.handleLogin()
 	case "up":
 		h.handleUp()
 	case "down":
@@ -264,6 +266,19 @@ func (h *Host) handleInit(req Request) {
 		Cmd:  "init",
 		Init: &InitReply{},
 	})
+}
+
+// handleLogin requests or resumes an interactive Tailscale login flow.
+func (h *Host) handleLogin() {
+	if err := h.requireInit("login"); err != nil {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := h.lc.StartLoginInteractive(ctx); err != nil {
+		h.sendError("login", fmt.Sprintf("failed to start login: %v", err))
+	}
 }
 
 // handleUp sets WantRunning=true to bring Tailscale up.

--- a/host/main.go
+++ b/host/main.go
@@ -96,6 +96,7 @@ func main() {
 				Error:            errString(err),
 				SupportsNetcheck: false,
 				SupportsPingPeer: true,
+				SupportsLogin:    true,
 			},
 		})
 		log.Fatalf("failed to start proxy: %v", err)
@@ -109,6 +110,7 @@ func main() {
 			Version:          version,
 			SupportsNetcheck: false,
 			SupportsPingPeer: true,
+			SupportsLogin:    true,
 		},
 	})
 

--- a/host/protocol.go
+++ b/host/protocol.go
@@ -49,6 +49,7 @@ type ProcRunningReply struct {
 	Error            string `json:"error,omitempty"`
 	SupportsNetcheck bool `json:"supportsNetcheck,omitempty"`
 	SupportsPingPeer bool `json:"supportsPingPeer,omitempty"`
+	SupportsLogin    bool `json:"supportsLogin,omitempty"`
 }
 
 // InitReply is the response to an "init" command.

--- a/host/protocol.go
+++ b/host/protocol.go
@@ -68,6 +68,7 @@ type StatusUpdate struct {
 	SelfNode       *PeerInfo  `json:"selfNode,omitempty"`
 	NeedsLogin     bool       `json:"needsLogin"`
 	BrowseToURL    string     `json:"browseToURL,omitempty"`
+	AuthURL        string     `json:"authURL,omitempty"`
 	ExitNode       *PeerInfo  `json:"exitNode,omitempty"`
 	Peers          []PeerInfo `json:"peers"`
 	Prefs          *PrefsView `json:"prefs,omitempty"`

--- a/host/status.go
+++ b/host/status.go
@@ -173,12 +173,17 @@ func (h *Host) buildStatusUpdate(st *ipnstate.Status) *StatusUpdate {
 	if state == "" {
 		state = st.BackendState
 	}
+	authURL := st.AuthURL
+	if browseToURL == "" {
+		browseToURL = authURL
+	}
 
 	update := &StatusUpdate{
 		BackendState: state,
 		Running:      state == "Running",
 		NeedsLogin:   state == "NeedsLogin" || state == "NeedsMachineAuth",
 		BrowseToURL:  browseToURL,
+		AuthURL:      authURL,
 		Prefs:        prefs,
 		Health:       health,
 		Peers:        []PeerInfo{},

--- a/host/status_test.go
+++ b/host/status_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"testing"
+
+	"tailscale.com/ipn/ipnstate"
+)
+
+func TestBuildStatusUpdateUsesAuthURLFallback(t *testing.T) {
+	h := newHost(nil, nil)
+	st := &ipnstate.Status{
+		BackendState: "NeedsLogin",
+		AuthURL:      "https://login.tailscale.com/a/from-status",
+	}
+
+	update := h.buildStatusUpdate(st)
+
+	if update.BrowseToURL != st.AuthURL {
+		t.Fatalf("BrowseToURL = %q, want %q", update.BrowseToURL, st.AuthURL)
+	}
+	if update.AuthURL != st.AuthURL {
+		t.Fatalf("AuthURL = %q, want %q", update.AuthURL, st.AuthURL)
+	}
+}
+
+func TestBuildStatusUpdatePrefersCachedBrowseToURL(t *testing.T) {
+	h := newHost(nil, nil)
+	h.lastBrowseToURL = "https://login.tailscale.com/a/from-ipn"
+	st := &ipnstate.Status{
+		BackendState: "NeedsLogin",
+		AuthURL:      "https://login.tailscale.com/a/from-status",
+	}
+
+	update := h.buildStatusUpdate(st)
+
+	if update.BrowseToURL != h.lastBrowseToURL {
+		t.Fatalf("BrowseToURL = %q, want %q", update.BrowseToURL, h.lastBrowseToURL)
+	}
+	if update.AuthURL != st.AuthURL {
+		t.Fatalf("AuthURL = %q, want %q", update.AuthURL, st.AuthURL)
+	}
+}

--- a/packages/shared/src/__test__/fixtures.ts
+++ b/packages/shared/src/__test__/fixtures.ts
@@ -26,6 +26,7 @@ export function baseState(overrides: Partial<TailscaleState> = {}): TailscaleSta
     hostVersionMismatch: false,
     supportsNetcheck: false,
     supportsPingPeer: false,
+    supportsLogin: false,
     reconnecting: false,
     ...overrides,
   };

--- a/packages/shared/src/background/background.test.ts
+++ b/packages/shared/src/background/background.test.ts
@@ -567,6 +567,289 @@ describe("initBackground", () => {
       });
     });
 
+    it("handles login with tailscale.com URL", async () => {
+      await setupBackground();
+      sendNativeMessage({
+        status: {
+          backendState: "NeedsLogin",
+          running: false,
+          tailnet: null,
+          magicDNSSuffix: "",
+          selfNode: null,
+          needsLogin: true,
+          browseToURL: "https://tailscale.com/a/xyz",
+          exitNode: null,
+          peers: [],
+          prefs: null,
+          health: [],
+          error: null,
+        },
+      });
+
+      const popupPort = createPopupPort();
+      connectListeners[0]!(popupPort);
+      popupPort.onMessage._listeners[0]!({ type: "login" });
+
+      expect(chrome.tabs.create).toHaveBeenCalledWith({
+        url: "https://tailscale.com/a/xyz",
+      });
+    });
+
+    it("handles login with controlplane URL", async () => {
+      await setupBackground();
+      sendNativeMessage({
+        status: {
+          backendState: "NeedsLogin",
+          running: false,
+          tailnet: null,
+          magicDNSSuffix: "",
+          selfNode: null,
+          needsLogin: true,
+          browseToURL: "https://controlplane.tailscale.com/a/xyz",
+          exitNode: null,
+          peers: [],
+          prefs: null,
+          health: [],
+          error: null,
+        },
+      });
+
+      const popupPort = createPopupPort();
+      connectListeners[0]!(popupPort);
+      popupPort.onMessage._listeners[0]!({ type: "login" });
+
+      expect(chrome.tabs.create).toHaveBeenCalledWith({
+        url: "https://controlplane.tailscale.com/a/xyz",
+      });
+    });
+
+    it("does not open arbitrary tailscale subdomain login URLs", async () => {
+      await setupBackground();
+      sendNativeMessage({
+        status: {
+          backendState: "NeedsLogin",
+          running: false,
+          tailnet: null,
+          magicDNSSuffix: "",
+          selfNode: null,
+          needsLogin: true,
+          browseToURL: "https://example.tailscale.com/a/xyz",
+          exitNode: null,
+          peers: [],
+          prefs: null,
+          health: [],
+          error: null,
+        },
+      });
+      nativePort.postMessage.mockClear();
+
+      const popupPort = createPopupPort();
+      connectListeners[0]!(popupPort);
+      popupPort.onMessage._listeners[0]!({ type: "login" });
+
+      expect(chrome.tabs.create).not.toHaveBeenCalled();
+      expect(nativePort.postMessage).toHaveBeenCalledWith({ cmd: "login" });
+    });
+
+    it("requests a fresh login URL when none is available", async () => {
+      await setupBackground();
+      sendNativeMessage({
+        status: {
+          backendState: "NeedsLogin",
+          running: false,
+          tailnet: null,
+          magicDNSSuffix: "",
+          selfNode: null,
+          needsLogin: true,
+          browseToURL: "",
+          exitNode: null,
+          peers: [],
+          prefs: null,
+          health: [],
+          error: null,
+        },
+      });
+      nativePort.postMessage.mockClear();
+
+      const popupPort = createPopupPort();
+      connectListeners[0]!(popupPort);
+      popupPort.onMessage._listeners[0]!({ type: "login" });
+
+      expect(chrome.tabs.create).not.toHaveBeenCalled();
+      expect(nativePort.postMessage).toHaveBeenCalledWith({ cmd: "login" });
+    });
+
+    it("does not send duplicate login requests while waiting for a URL", async () => {
+      await setupBackground();
+      sendNativeMessage({
+        status: {
+          backendState: "NeedsLogin",
+          running: false,
+          tailnet: null,
+          magicDNSSuffix: "",
+          selfNode: null,
+          needsLogin: true,
+          browseToURL: "",
+          exitNode: null,
+          peers: [],
+          prefs: null,
+          health: [],
+          error: null,
+        },
+      });
+      nativePort.postMessage.mockClear();
+
+      const popupPort = createPopupPort();
+      connectListeners[0]!(popupPort);
+      popupPort.postMessage.mockClear();
+      popupPort.onMessage._listeners[0]!({ type: "login" });
+      popupPort.onMessage._listeners[0]!({ type: "login" });
+
+      expect(nativePort.postMessage).toHaveBeenCalledTimes(1);
+      expect(nativePort.postMessage).toHaveBeenCalledWith({ cmd: "login" });
+      expect(popupPort.postMessage).toHaveBeenCalledWith({
+        type: "toast",
+        message: "Still waiting for Tailscale to return a login URL.",
+        level: "info",
+        persistent: false,
+      });
+    });
+
+    it("clears pending login request after timeout", async () => {
+      await setupBackground();
+      sendNativeMessage({
+        status: {
+          backendState: "NeedsLogin",
+          running: false,
+          tailnet: null,
+          magicDNSSuffix: "",
+          selfNode: null,
+          needsLogin: true,
+          browseToURL: "",
+          exitNode: null,
+          peers: [],
+          prefs: null,
+          health: [],
+          error: null,
+        },
+      });
+      nativePort.postMessage.mockClear();
+
+      const popupPort = createPopupPort();
+      connectListeners[0]!(popupPort);
+      popupPort.postMessage.mockClear();
+      popupPort.onMessage._listeners[0]!({ type: "login" });
+
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      expect(popupPort.postMessage).toHaveBeenCalledWith({
+        type: "toast",
+        message: "Still waiting for a Tailscale login URL. Please try again.",
+        level: "error",
+        persistent: false,
+      });
+
+      nativePort.postMessage.mockClear();
+      popupPort.onMessage._listeners[0]!({ type: "login" });
+      expect(nativePort.postMessage).toHaveBeenCalledWith({ cmd: "login" });
+    });
+
+    it("opens fresh login URL returned after login request", async () => {
+      await setupBackground();
+      sendNativeMessage({
+        status: {
+          backendState: "NeedsLogin",
+          running: false,
+          tailnet: null,
+          magicDNSSuffix: "",
+          selfNode: null,
+          needsLogin: true,
+          browseToURL: "",
+          exitNode: null,
+          peers: [],
+          prefs: null,
+          health: [],
+          error: null,
+        },
+      });
+      nativePort.postMessage.mockClear();
+
+      const popupPort = createPopupPort();
+      connectListeners[0]!(popupPort);
+      popupPort.onMessage._listeners[0]!({ type: "login" });
+
+      sendNativeMessage({
+        status: {
+          backendState: "NeedsLogin",
+          running: false,
+          tailnet: null,
+          magicDNSSuffix: "",
+          selfNode: null,
+          needsLogin: true,
+          browseToURL: "https://login.tailscale.com/a/refreshed",
+          exitNode: null,
+          peers: [],
+          prefs: null,
+          health: [],
+          error: null,
+        },
+      });
+
+      expect(chrome.tabs.create).toHaveBeenCalledWith({
+        url: "https://login.tailscale.com/a/refreshed",
+      });
+    });
+
+    it("shows toast when refreshed login URL is invalid", async () => {
+      await setupBackground();
+      sendNativeMessage({
+        status: {
+          backendState: "NeedsLogin",
+          running: false,
+          tailnet: null,
+          magicDNSSuffix: "",
+          selfNode: null,
+          needsLogin: true,
+          browseToURL: "",
+          exitNode: null,
+          peers: [],
+          prefs: null,
+          health: [],
+          error: null,
+        },
+      });
+
+      const popupPort = createPopupPort();
+      connectListeners[0]!(popupPort);
+      popupPort.postMessage.mockClear();
+      popupPort.onMessage._listeners[0]!({ type: "login" });
+
+      sendNativeMessage({
+        status: {
+          backendState: "NeedsLogin",
+          running: false,
+          tailnet: null,
+          magicDNSSuffix: "",
+          selfNode: null,
+          needsLogin: true,
+          browseToURL: "https://evil.com/phish",
+          exitNode: null,
+          peers: [],
+          prefs: null,
+          health: [],
+          error: null,
+        },
+      });
+
+      expect(chrome.tabs.create).not.toHaveBeenCalled();
+      expect(popupPort.postMessage).toHaveBeenCalledWith({
+        type: "toast",
+        message: "Could not open the login URL Tailscale returned.",
+        level: "error",
+        persistent: false,
+      });
+    });
+
     it("rejects login with invalid URL", async () => {
       await setupBackground();
       sendNativeMessage({
@@ -588,11 +871,69 @@ describe("initBackground", () => {
 
       const tabCreateSpy = chrome.tabs.create as ReturnType<typeof vi.fn>;
       tabCreateSpy.mockClear();
+      nativePort.postMessage.mockClear();
 
       const popupPort = createPopupPort();
       connectListeners[0]!(popupPort);
       popupPort.onMessage._listeners[0]!({ type: "login" });
 
+      expect(chrome.tabs.create).not.toHaveBeenCalled();
+      expect(nativePort.postMessage).toHaveBeenCalledWith({ cmd: "login" });
+    });
+
+    it("shows login error toast from native host", async () => {
+      await setupBackground();
+      sendNativeMessage({
+        status: {
+          backendState: "NeedsLogin",
+          running: false,
+          tailnet: null,
+          magicDNSSuffix: "",
+          selfNode: null,
+          needsLogin: true,
+          browseToURL: "",
+          exitNode: null,
+          peers: [],
+          prefs: null,
+          health: [],
+          error: null,
+        },
+      });
+
+      const popupPort = createPopupPort();
+      connectListeners[0]!(popupPort);
+      popupPort.postMessage.mockClear();
+      popupPort.onMessage._listeners[0]!({ type: "login" });
+
+      sendNativeMessage({
+        error: { cmd: "login", message: "failed to start login: no control connection" },
+      });
+
+      expect(popupPort.postMessage).toHaveBeenCalledWith({
+        type: "toast",
+        message: "failed to start login: no control connection",
+        level: "error",
+        persistent: false,
+      });
+
+      const tabCreateSpy = chrome.tabs.create as ReturnType<typeof vi.fn>;
+      tabCreateSpy.mockClear();
+      sendNativeMessage({
+        status: {
+          backendState: "NeedsLogin",
+          running: false,
+          tailnet: null,
+          magicDNSSuffix: "",
+          selfNode: null,
+          needsLogin: true,
+          browseToURL: "https://login.tailscale.com/a/late",
+          exitNode: null,
+          peers: [],
+          prefs: null,
+          health: [],
+          error: null,
+        },
+      });
       expect(chrome.tabs.create).not.toHaveBeenCalled();
     });
 

--- a/packages/shared/src/background/background.test.ts
+++ b/packages/shared/src/background/background.test.ts
@@ -1261,6 +1261,73 @@ describe("initBackground", () => {
         })
       );
     });
+
+    it("clears pending login request when disconnected", async () => {
+      await setupBackground();
+      advertiseLoginSupport();
+      sendNativeMessage({
+        status: {
+          backendState: "NeedsLogin",
+          running: false,
+          tailnet: null,
+          magicDNSSuffix: "",
+          selfNode: null,
+          needsLogin: true,
+          browseToURL: "",
+          exitNode: null,
+          peers: [],
+          prefs: null,
+          health: [],
+          error: null,
+        },
+      });
+
+      const popupPort = createPopupPort();
+      connectListeners[0]!(popupPort);
+      popupPort.postMessage.mockClear();
+      nativePort.postMessage.mockClear();
+      popupPort.onMessage._listeners[0]!({ type: "login" });
+      expect(nativePort.postMessage).toHaveBeenCalledWith({ cmd: "login" });
+
+      nativePort.onDisconnect._listeners[0]!(nativePort);
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      expect(popupPort.postMessage).not.toHaveBeenCalledWith({
+        type: "toast",
+        message: "Still waiting for a Tailscale login URL. Please try again.",
+        level: "error",
+        persistent: false,
+      });
+
+      nativePort.postMessage.mockClear();
+      sendNativeMessage({
+        procRunning: {
+          port: 1055,
+          pid: 1234,
+          version: "0.1.9",
+          supportsLogin: true,
+        },
+      });
+      sendNativeMessage({
+        status: {
+          backendState: "NeedsLogin",
+          running: false,
+          tailnet: null,
+          magicDNSSuffix: "",
+          selfNode: null,
+          needsLogin: true,
+          browseToURL: "",
+          exitNode: null,
+          peers: [],
+          prefs: null,
+          health: [],
+          error: null,
+        },
+      });
+      popupPort.onMessage._listeners[0]!({ type: "login" });
+
+      expect(nativePort.postMessage).toHaveBeenCalledWith({ cmd: "login" });
+    });
   });
 
   describe("uiSurface wiring", () => {

--- a/packages/shared/src/background/background.test.ts
+++ b/packages/shared/src/background/background.test.ts
@@ -101,6 +101,17 @@ describe("initBackground", () => {
     nativePort.onMessage._listeners[0]!(msg);
   }
 
+  function advertiseLoginSupport() {
+    sendNativeMessage({
+      procRunning: {
+        port: 1055,
+        pid: 1234,
+        version: "0.1.9",
+        supportsLogin: true,
+      },
+    });
+  }
+
   it("returns proxy manager handle", async () => {
     const handle = await setupBackground();
     expect(handle.proxyManager).toBe(proxyManager);
@@ -131,6 +142,7 @@ describe("initBackground", () => {
           proxyEnabled: true,
           supportsNetcheck: false,
           supportsPingPeer: false,
+          supportsLogin: false,
         })
       );
     });
@@ -154,6 +166,17 @@ describe("initBackground", () => {
 
       expect(proxyManager.apply).toHaveBeenCalledWith(
         expect.objectContaining({ supportsPingPeer: true })
+      );
+    });
+
+    it("sets supportsLogin when procRunning advertises it", async () => {
+      await setupBackground();
+      sendNativeMessage({
+        procRunning: { port: 1055, pid: 1234, supportsLogin: true },
+      });
+
+      expect(proxyManager.apply).toHaveBeenCalledWith(
+        expect.objectContaining({ supportsLogin: true })
       );
     });
 
@@ -625,6 +648,7 @@ describe("initBackground", () => {
 
     it("does not open arbitrary tailscale subdomain login URLs", async () => {
       await setupBackground();
+      advertiseLoginSupport();
       sendNativeMessage({
         status: {
           backendState: "NeedsLogin",
@@ -651,8 +675,38 @@ describe("initBackground", () => {
       expect(nativePort.postMessage).toHaveBeenCalledWith({ cmd: "login" });
     });
 
+    it("does not allow alternate login URL ports", async () => {
+      await setupBackground();
+      advertiseLoginSupport();
+      sendNativeMessage({
+        status: {
+          backendState: "NeedsLogin",
+          running: false,
+          tailnet: null,
+          magicDNSSuffix: "",
+          selfNode: null,
+          needsLogin: true,
+          browseToURL: "https://login.tailscale.com:8443/a/xyz",
+          exitNode: null,
+          peers: [],
+          prefs: null,
+          health: [],
+          error: null,
+        },
+      });
+      nativePort.postMessage.mockClear();
+
+      const popupPort = createPopupPort();
+      connectListeners[0]!(popupPort);
+      popupPort.onMessage._listeners[0]!({ type: "login" });
+
+      expect(chrome.tabs.create).not.toHaveBeenCalled();
+      expect(nativePort.postMessage).toHaveBeenCalledWith({ cmd: "login" });
+    });
+
     it("requests a fresh login URL when none is available", async () => {
       await setupBackground();
+      advertiseLoginSupport();
       sendNativeMessage({
         status: {
           backendState: "NeedsLogin",
@@ -679,8 +733,46 @@ describe("initBackground", () => {
       expect(nativePort.postMessage).toHaveBeenCalledWith({ cmd: "login" });
     });
 
+    it("does not send login command when native helper lacks login support", async () => {
+      await setupBackground();
+      sendNativeMessage({
+        procRunning: { port: 1055, pid: 1234, version: "0.1.9" },
+      });
+      sendNativeMessage({
+        status: {
+          backendState: "NeedsLogin",
+          running: false,
+          tailnet: null,
+          magicDNSSuffix: "",
+          selfNode: null,
+          needsLogin: true,
+          browseToURL: "",
+          exitNode: null,
+          peers: [],
+          prefs: null,
+          health: [],
+          error: null,
+        },
+      });
+      nativePort.postMessage.mockClear();
+
+      const popupPort = createPopupPort();
+      connectListeners[0]!(popupPort);
+      popupPort.postMessage.mockClear();
+      popupPort.onMessage._listeners[0]!({ type: "login" });
+
+      expect(nativePort.postMessage).not.toHaveBeenCalled();
+      expect(popupPort.postMessage).toHaveBeenCalledWith({
+        type: "toast",
+        message: "Please update the native helper to request a fresh Tailscale login URL.",
+        level: "error",
+        persistent: false,
+      });
+    });
+
     it("does not send duplicate login requests while waiting for a URL", async () => {
       await setupBackground();
+      advertiseLoginSupport();
       sendNativeMessage({
         status: {
           backendState: "NeedsLogin",
@@ -717,6 +809,7 @@ describe("initBackground", () => {
 
     it("clears pending login request after timeout", async () => {
       await setupBackground();
+      advertiseLoginSupport();
       sendNativeMessage({
         status: {
           backendState: "NeedsLogin",
@@ -756,6 +849,7 @@ describe("initBackground", () => {
 
     it("opens fresh login URL returned after login request", async () => {
       await setupBackground();
+      advertiseLoginSupport();
       sendNativeMessage({
         status: {
           backendState: "NeedsLogin",
@@ -802,6 +896,7 @@ describe("initBackground", () => {
 
     it("shows toast when refreshed login URL is invalid", async () => {
       await setupBackground();
+      advertiseLoginSupport();
       sendNativeMessage({
         status: {
           backendState: "NeedsLogin",
@@ -852,6 +947,7 @@ describe("initBackground", () => {
 
     it("rejects login with invalid URL", async () => {
       await setupBackground();
+      advertiseLoginSupport();
       sendNativeMessage({
         status: {
           backendState: "NeedsLogin",
@@ -883,6 +979,7 @@ describe("initBackground", () => {
 
     it("shows login error toast from native host", async () => {
       await setupBackground();
+      advertiseLoginSupport();
       sendNativeMessage({
         status: {
           backendState: "NeedsLogin",

--- a/packages/shared/src/background/background.ts
+++ b/packages/shared/src/background/background.ts
@@ -308,6 +308,7 @@ export function initBackground(
   function handleNativeStateChange(connected: boolean): void {
     if (!connected) {
       exitNodeRestoreAttempted = false;
+      clearPendingLoginOpen();
     }
     store.update({
       hostConnected: connected,

--- a/packages/shared/src/background/background.ts
+++ b/packages/shared/src/background/background.ts
@@ -33,16 +33,16 @@ export interface InitBackgroundOptions {
 
 const LOGIN_OPEN_TIMEOUT_MS = 30_000;
 const LOGIN_OPEN_TIMEOUT_NAME = "login-open-timeout";
-const ALLOWED_LOGIN_HOSTS = new Set([
-  "login.tailscale.com",
-  "controlplane.tailscale.com",
-  "tailscale.com",
+const ALLOWED_LOGIN_ORIGINS = new Set([
+  "https://login.tailscale.com",
+  "https://controlplane.tailscale.com",
+  "https://tailscale.com",
 ]);
 
 function isValidLoginURL(url: string): boolean {
   try {
     const parsed = new URL(url);
-    return parsed.protocol === "https:" && ALLOWED_LOGIN_HOSTS.has(parsed.hostname);
+    return ALLOWED_LOGIN_ORIGINS.has(parsed.origin);
   } catch {
     return false;
   }
@@ -150,6 +150,7 @@ export function initBackground(
           hostVersionMismatch,
           supportsNetcheck: false,
           supportsPingPeer: false,
+          supportsLogin: false,
         });
       } else {
         store.update({
@@ -159,6 +160,7 @@ export function initBackground(
           hostVersionMismatch,
           supportsNetcheck: msg.procRunning.supportsNetcheck === true,
           supportsPingPeer: msg.procRunning.supportsPingPeer === true,
+          supportsLogin: msg.procRunning.supportsLogin === true,
         });
       }
     }
@@ -322,6 +324,7 @@ export function initBackground(
             hostVersionMismatch: false,
             supportsNetcheck: false,
             supportsPingPeer: false,
+            supportsLogin: false,
           }),
     });
   }
@@ -443,6 +446,11 @@ export function initBackground(
         }
         if (state.browseToURL && isValidLoginURL(state.browseToURL)) {
           chrome.tabs.create({ url: state.browseToURL });
+        } else if (!state.supportsLogin) {
+          sendToastToPopup(
+            "Please update the native helper to request a fresh Tailscale login URL.",
+            "error",
+          );
         } else if (!nativeHost.send({ cmd: "login" })) {
           clearPendingLoginOpen();
           sendToastToPopup(

--- a/packages/shared/src/background/background.ts
+++ b/packages/shared/src/background/background.ts
@@ -31,20 +31,26 @@ export interface InitBackgroundOptions {
   browserKind?: BrowserKind;
 }
 
-const ALLOWED_LOGIN_ORIGINS = [
-  "https://login.tailscale.com",
-  "https://controlplane.tailscale.com",
-];
+const LOGIN_OPEN_TIMEOUT_MS = 30_000;
+const LOGIN_OPEN_TIMEOUT_NAME = "login-open-timeout";
+const ALLOWED_LOGIN_HOSTS = new Set([
+  "login.tailscale.com",
+  "controlplane.tailscale.com",
+  "tailscale.com",
+]);
 
 function isValidLoginURL(url: string): boolean {
   try {
     const parsed = new URL(url);
-    return ALLOWED_LOGIN_ORIGINS.some(
-      (origin) => parsed.origin === origin
-    );
+    return parsed.protocol === "https:" && ALLOWED_LOGIN_HOSTS.has(parsed.hostname);
   } catch {
     return false;
   }
+}
+
+function loginURLFromStatus(status: NativeReply["status"]): string | null {
+  if (!status) return null;
+  return status.browseToURL || status.authURL || null;
 }
 
 /**
@@ -98,6 +104,28 @@ export function initBackground(
 
   // Track whether we've attempted to restore exit node for this connection
   let exitNodeRestoreAttempted = false;
+  let pendingLoginOpen = false;
+
+  function clearPendingLoginOpen(): void {
+    pendingLoginOpen = false;
+    timerService.clear(LOGIN_OPEN_TIMEOUT_NAME);
+  }
+
+  function startPendingLoginOpen(): void {
+    pendingLoginOpen = true;
+    timerService.setTimeout(
+      LOGIN_OPEN_TIMEOUT_NAME,
+      () => {
+        if (!pendingLoginOpen) return;
+        pendingLoginOpen = false;
+        sendToastToPopup(
+          "Still waiting for a Tailscale login URL. Please try again.",
+          "error",
+        );
+      },
+      LOGIN_OPEN_TIMEOUT_MS,
+    );
+  }
 
   store.subscribe((state: TailscaleState) => {
     proxyManager.apply(state);
@@ -156,6 +184,21 @@ export function initBackground(
     // Status update
     if (msg.status) {
       store.applyStatusUpdate(msg.status);
+      const loginURL = loginURLFromStatus(msg.status);
+      if (pendingLoginOpen) {
+        if (loginURL && isValidLoginURL(loginURL)) {
+          clearPendingLoginOpen();
+          chrome.tabs.create({ url: loginURL });
+        } else if (loginURL) {
+          clearPendingLoginOpen();
+          sendToastToPopup(
+            "Could not open the login URL Tailscale returned.",
+            "error",
+          );
+        } else if (msg.status.backendState === "Running") {
+          clearPendingLoginOpen();
+        }
+      }
 
       // Restore saved exit node after reconnection
       if (
@@ -246,6 +289,9 @@ export function initBackground(
           `[Background] Native error for cmd="${msg.error.cmd}":`,
           msg.error.message
         );
+        if (msg.error.cmd === "login") {
+          clearPendingLoginOpen();
+        }
         store.update({
           error: msg.error.message,
           ...(msg.error.cmd === "set-exit-node"
@@ -391,8 +437,20 @@ export function initBackground(
       }
 
       case "login": {
+        if (pendingLoginOpen) {
+          sendToastToPopup("Still waiting for Tailscale to return a login URL.", "info");
+          break;
+        }
         if (state.browseToURL && isValidLoginURL(state.browseToURL)) {
           chrome.tabs.create({ url: state.browseToURL });
+        } else if (!nativeHost.send({ cmd: "login" })) {
+          clearPendingLoginOpen();
+          sendToastToPopup(
+            "Could not request a Tailscale login URL. Please check that the native host is installed.",
+            "error",
+          );
+        } else {
+          startPendingLoginOpen();
         }
         break;
       }

--- a/packages/shared/src/background/state-store.test.ts
+++ b/packages/shared/src/background/state-store.test.ts
@@ -280,5 +280,29 @@ describe("StateStore", () => {
         expect.objectContaining({ backendState: "NeedsLogin" })
       );
     });
+
+    it("falls back to authURL when browseToURL is empty", () => {
+      const store = new StateStore();
+
+      store.applyStatusUpdate({
+        backendState: "NeedsLogin",
+        running: false,
+        tailnet: null,
+        magicDNSSuffix: "",
+        selfNode: null,
+        needsLogin: true,
+        browseToURL: "",
+        authURL: "https://login.tailscale.com/a/from-status",
+        exitNode: null,
+        peers: [],
+        prefs: null,
+        health: [],
+        error: null,
+      });
+
+      expect(store.getState().browseToURL).toBe(
+        "https://login.tailscale.com/a/from-status"
+      );
+    });
   });
 });

--- a/packages/shared/src/background/state-store.ts
+++ b/packages/shared/src/background/state-store.ts
@@ -76,7 +76,7 @@ export class StateStore {
       })),
       exitNode: status.exitNode ?? null,
       magicDNSSuffix: status.magicDNSSuffix,
-      browseToURL: status.browseToURL,
+      browseToURL: status.browseToURL || status.authURL || null,
       prefs: status.prefs,
       health: status.health ?? [],
       error: status.error,

--- a/packages/shared/src/background/state-store.ts
+++ b/packages/shared/src/background/state-store.ts
@@ -27,6 +27,7 @@ const DEFAULT_STATE: TailscaleState = {
   hostVersionMismatch: false,
   supportsNetcheck: false,
   supportsPingPeer: false,
+  supportsLogin: false,
   reconnecting: false,
 };
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -49,6 +49,8 @@ export interface NativeReply {
     supportsNetcheck?: boolean;
     /** When true, the native host handles `ping-peer` (omitted on older helpers). */
     supportsPingPeer?: boolean;
+    /** When true, the native host handles the `login` command (omitted on older helpers). */
+    supportsLogin?: boolean;
   };
   init?: { error?: string };
   pong?: Record<string, never>;
@@ -210,6 +212,8 @@ export interface TailscaleState {
   supportsNetcheck: boolean;
   /** True when the connected native helper advertises `supportsPingPeer` in procRunning. */
   supportsPingPeer: boolean;
+  /** True when the connected native helper advertises the `login` command in procRunning. */
+  supportsLogin: boolean;
   /** True when the native host disconnected and reconnection is being attempted. */
   reconnecting: boolean;
 }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -12,6 +12,7 @@ export type BackendState =
 
 export type NativeRequest =
   | { cmd: "init"; initID: string }
+  | { cmd: "login" }
   | { cmd: "up" }
   | { cmd: "down" }
   | { cmd: "get-status" }
@@ -69,6 +70,7 @@ export interface StatusUpdate {
   selfNode: SelfNode | null;
   needsLogin: boolean;
   browseToURL: string;
+  authURL?: string;
   exitNode: ExitNodeInfo | null;
   peers: PeerInfo[];
   prefs: TailscalePrefs | null;

--- a/scripts/e2e/fixtures.mjs
+++ b/scripts/e2e/fixtures.mjs
@@ -205,6 +205,7 @@ export function makeControl(overrides = {}) {
     hostVersion: "0.1.9",
     supportsNetcheck: true,
     supportsPingPeer: true,
+    supportsLogin: true,
     status,
     profiles: makeProfiles(),
     exitNodeSuggestion: {

--- a/scripts/e2e/native-host.mjs
+++ b/scripts/e2e/native-host.mjs
@@ -239,6 +239,7 @@ function mockSource(baseUrl) {
             error: c.startupError,
             supportsNetcheck: c.supportsNetcheck !== false,
             supportsPingPeer: c.supportsPingPeer !== false,
+            supportsLogin: c.supportsLogin !== false,
           },
         });
       });

--- a/scripts/e2e/native-host.mjs
+++ b/scripts/e2e/native-host.mjs
@@ -146,6 +146,16 @@ function mockSource(baseUrl) {
         return c.status ? { status: c.status } : null;
       case "list-profiles":
         return { profiles: c.profiles ?? defaultProfiles() };
+      case "login":
+        if (c.loginError) {
+          return {
+            error: {
+              cmd: "login",
+              message: c.loginError,
+            },
+          };
+        }
+        return c.loginStatus ? { status: c.loginStatus } : null;
       case "suggest-exit-node":
         if (c.suggestExitNodeError) {
           return {

--- a/scripts/e2e/scenarios/login-and-links.mjs
+++ b/scripts/e2e/scenarios/login-and-links.mjs
@@ -1,4 +1,10 @@
-import { clickText, clickToggleForLabel, expectText, waitForPopup } from "../assertions.mjs";
+import {
+  clickText,
+  clickToggleForLabel,
+  expectText,
+  waitForPopup,
+  waitForRequest,
+} from "../assertions.mjs";
 import { makeControl, makeNeedsLoginState } from "../fixtures.mjs";
 
 export const suite = "full";
@@ -40,6 +46,30 @@ export const cases = [
           .targets()
           .some((target) => target.url().startsWith("https://example.com/phishing"));
         if (opened) throw new Error("Invalid login URL was opened");
+      } finally {
+        await page.close();
+      }
+    },
+  },
+  {
+    name: "login requests fresh URL when current state has none",
+    control: () =>
+      makeControl({
+        status: makeNeedsLoginState({ browseToURL: "" }),
+        loginStatus: makeNeedsLoginState({
+          browseToURL: "https://login.tailscale.com/a/refreshed",
+        }),
+      }),
+    run: async ({ browser, openPopup, nativeHost }) => {
+      const page = await openPopup();
+      try {
+        await waitForPopup(page);
+        const targetPromise = browser.waitForTarget((target) =>
+          target.url().startsWith("https://login.tailscale.com/a/refreshed"),
+        );
+        await clickText(page, "Log In", "button");
+        await waitForRequest(nativeHost, "login");
+        await targetPromise;
       } finally {
         await page.close();
       }


### PR DESCRIPTION
## What

Fixes the `NeedsLogin` flow so the popup’s **Log In** button no longer silently no-ops when Tailchrome does not already have a usable cached login URL.

When the cached URL is missing or invalid, the extension now asks the native helper to request a fresh Tailscale login URL, then opens that URL when it arrives in status.

## Why

Closes #75.

The screenshots show Tailchrome successfully rendering the login-required view, but clicking **Log In** does not open a browser tab. The issue was that the popup depended on a cached IPN-bus `BrowseToURL`; if Tailchrome entered `NeedsLogin` without that cached URL, the button could appear active while having nothing valid to open.

## How

- Added a native `login` command that calls `StartLoginInteractive()` to request or resume an interactive Tailscale login flow.
- Surface `ipnstate.Status.AuthURL` as a fallback when no cached `BrowseToURL` is available.
- Store `browseToURL` from either `BrowseToURL` or `AuthURL`, so the popup can recover from older or partial status updates.
- Updated the background login handler to:
  - open an existing valid login URL immediately
  - request a fresh login URL when the current URL is missing or invalid
  - track a pending login request and open the returned URL when it arrives
  - avoid duplicate native login requests while waiting
  - clear pending state on success, invalid URL, login error, timeout, or a transition to `Running`
- Tightened login URL validation to explicit Tailscale login hosts: `login.tailscale.com`, `controlplane.tailscale.com`, and `tailscale.com`.
- Added a user-visible timeout toast if no login URL arrives after 30 seconds.

## Test

- [ ] Install the built extension and helper fresh on Chrome.
- [ ] Open Tailchrome in a state that shows **Log in to Tailscale**.
- [ ] Click **Log In** when a valid cached login URL is already present — a Tailscale login tab should open immediately.
- [ ] Click **Log In** when no cached login URL is present — Tailchrome should request a fresh URL from the native helper and open it when returned.
- [ ] Click **Log In** repeatedly while waiting — only one native login request should be sent, and the popup should show that it is still waiting.
- [ ] If no URL is returned after 30 seconds, the popup should show a timeout toast and allow retry.
- [ ] Confirm arbitrary non-login URLs are not opened.

## Checklist

- [x] `go test ./...`
- [x] `pnpm --filter @tailchrome/shared exec vitest run src/background/background.test.ts src/background/state-store.test.ts`
- [x] `pnpm --filter @tailchrome/shared exec tsc --noEmit`
- [x] `pnpm e2e --suite=full --grep="login requests fresh URL"`
- [ ] Manual Chrome smoke test
- [ ] Manual Windows helper smoke test
- [ ] Update issue after release is available

Marking draft while I finish manual smoke testing.