### PR TITLE
chore: release 0.1.11

### DIFF
--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -2,7 +2,7 @@
 
 > Access your Tailscale network directly from your browser. No system VPN required.
 
-**Version:** 0.1.10 (native host) | Manifest V3
+**Version:** 0.1.11 (native host) | Manifest V3
 **Browsers:** Chrome, Firefox
 **Platforms:** macOS (amd64, arm64), Linux (amd64), Windows (amd64)
 **License:** MIT
@@ -329,7 +329,7 @@ Defined in `packages/shared/src/constants.ts`:
 | `RECONNECT_BASE_MS`     | `1000`                              | Reconnection backoff base                                 |
 | `RECONNECT_MAX_MS`      | `30000`                             | Reconnection backoff ceiling                              |
 | `ADMIN_URL`             | `https://login.tailscale.com/admin` | Tailscale admin console                                   |
-| `EXPECTED_HOST_VERSION` | `0.1.10`                            | Expected native host version (major.minor match required) |
+| `EXPECTED_HOST_VERSION` | `0.1.11`                            | Expected native host version (major.minor match required) |
 
 
 ---

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailchrome/extension",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailchrome/shared",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -5,4 +5,4 @@ export const RECONNECT_MAX_MS = 30_000;
 export const ADMIN_URL = "https://login.tailscale.com/admin";
 /** Tailchrome project on GitHub (footer, diagnostics toast). */
 export const TAILCHROME_PROJECT_URL = "https://github.com/dantraynor/tailchrome";
-export const EXPECTED_HOST_VERSION = "0.1.10";
+export const EXPECTED_HOST_VERSION = "0.1.11";

--- a/scripts/e2e/fixtures.mjs
+++ b/scripts/e2e/fixtures.mjs
@@ -202,7 +202,7 @@ export function makeControl(overrides = {}) {
   const status = overrides.status ?? makeRunningState();
   return {
     proxyPort: 1055,
-    hostVersion: "0.1.10",
+    hostVersion: "0.1.11",
     supportsNetcheck: true,
     supportsPingPeer: true,
     supportsLogin: true,

--- a/scripts/e2e/native-host.mjs
+++ b/scripts/e2e/native-host.mjs
@@ -222,7 +222,7 @@ function mockSource(baseUrl, initialControl) {
         procRunning: {
           port: control.proxyPort ?? 1055,
           pid: 1,
-          version: control.hostVersion ?? "0.1.10",
+          version: control.hostVersion ?? "0.1.11",
           error: control.startupError,
           supportsNetcheck: control.supportsNetcheck !== false,
           supportsPingPeer: control.supportsPingPeer !== false,

--- a/scripts/e2e/scenarios/connected-dashboard.mjs
+++ b/scripts/e2e/scenarios/connected-dashboard.mjs
@@ -18,7 +18,7 @@ export async function run({ openPopup }) {
     await expectText(page, "example.ts.net");
     await expectText(page, "100.64.0.1");
     await expectText(page, "browser-node");
-    await expectText(page, "Native helper 0.1.10");
+    await expectText(page, "Native helper 0.1.11");
     await expectText(page, "Network lock is enabled");
     await expectText(page, "router");
     await expectText(page, "laptop");


### PR DESCRIPTION
Maintenance release. Bumps the version to **0.1.11** across the extension, shared package, `EXPECTED_HOST_VERSION`, the docs, and the e2e version fixtures.

### What's in this release (merged since 0.1.10)

**Fixes**
- Windows: the native helper now updates itself while the browser is running. Windows file-locking on the running executable could previously leave the helper stuck on "Update Available"; the updater now swaps the old binary aside and installs the new one in place. (#86)

**Maintenance**
- Updated vitest to 4.1.0 and resolved the remaining Dependabot security alerts across the Go and npm dependencies. (#85, #82)

**Documentation**
- Moved the store listing into `docs/`. (#81)

### Verification
- `pnpm typecheck`, `pnpm test` (339 unit tests), `pnpm validate:ids`, and `pnpm validate:release-tag v0.1.11` all pass locally.

Once merged, tagging `v0.1.11` triggers the signed release build and the draft GitHub Release.