### PR TITLE
Show Tailscale machine names instead of OS hostnames

### DIFF
--- a/packages/extension/src/background/chrome-proxy-manager.test.ts
+++ b/packages/extension/src/background/chrome-proxy-manager.test.ts
@@ -89,6 +89,7 @@ describe("ChromeProxyManager", () => {
         exitNode: {
           id: "exit1",
           hostname: "exit-node",
+          dnsName: "exit-node.example.ts.net.",
           location: null,
           online: true,
         },
@@ -170,6 +171,7 @@ describe("ChromeProxyManager", () => {
           exitNode: {
             id: "exit1",
             hostname: "exit",
+            dnsName: "exit.example.ts.net.",
             location: null,
             online: true,
           },
@@ -207,6 +209,7 @@ describe("ChromeProxyManager", () => {
         exitNode: {
           id: "exit1",
           hostname: "exit",
+          dnsName: "exit.example.ts.net.",
           location: null,
           online: true,
         },

--- a/packages/extension/src/background/firefox-proxy-manager.test.ts
+++ b/packages/extension/src/background/firefox-proxy-manager.test.ts
@@ -140,6 +140,7 @@ describe("FirefoxProxyManager", () => {
         exitNode: {
           id: "exit1",
           hostname: "exit",
+          dnsName: "exit.example.ts.net.",
           location: null,
           online: true,
         },

--- a/packages/shared/src/background/background.test.ts
+++ b/packages/shared/src/background/background.test.ts
@@ -1227,7 +1227,7 @@ describe("initBackground", () => {
           selfNode: null,
           needsLogin: false,
           browseToURL: "",
-          exitNode: { id: "current-exit", hostname: "exit", location: null, online: true },
+          exitNode: { id: "current-exit", hostname: "exit", dnsName: "exit.example.ts.net.", location: null, online: true },
           peers: [],
           prefs: null,
           health: [],

--- a/packages/shared/src/background/badge-manager.test.ts
+++ b/packages/shared/src/background/badge-manager.test.ts
@@ -32,7 +32,7 @@ describe("BadgeManager", () => {
       const mgr = new BadgeManager();
       mgr.update(
         baseState({
-          exitNode: { id: "exit1", hostname: "exit-node", location: null, online: true },
+          exitNode: { id: "exit1", hostname: "exit-node", dnsName: "exit-node.example.ts.net.", location: null, online: true },
         })
       );
 

--- a/packages/shared/src/background/state-store.test.ts
+++ b/packages/shared/src/background/state-store.test.ts
@@ -246,7 +246,7 @@ describe("StateStore", () => {
         selfNode: null,
         needsLogin: false,
         browseToURL: "",
-        exitNode: { id: "node123", hostname: "nyc", location: null, online: true },
+        exitNode: { id: "node123", hostname: "nyc", dnsName: "nyc.example.ts.net.", location: null, online: true },
         peers: [],
         prefs: null,
         health: [],

--- a/packages/shared/src/popup/components/peer-item.test.ts
+++ b/packages/shared/src/popup/components/peer-item.test.ts
@@ -1,6 +1,7 @@
+// @vitest-environment happy-dom
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { makePeer } from "../../__test__/fixtures";
-import { formatRelativeTime, peerDisplayKey } from "./peer-item";
+import { createPeerItem, formatRelativeTime, peerDisplayKey, updatePeerItemText } from "./peer-item";
 
 describe("formatRelativeTime", () => {
   beforeEach(() => {
@@ -106,5 +107,49 @@ describe("peerDisplayKey", () => {
   it("is stable for identical peers", () => {
     const p = makePeer();
     expect(peerDisplayKey(p)).toBe(peerDisplayKey(p));
+  });
+});
+
+describe("createPeerItem", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("shows the machine name from the DNS name", () => {
+    const peer = makePeer({
+      hostname: "os-host",
+      dnsName: "renamed-laptop.example.ts.net.",
+    });
+
+    const item = createPeerItem(peer, false, false);
+
+    expect(item.querySelector(".peer-name")?.textContent).toBe("renamed-laptop");
+  });
+
+  it("SSH action uses the new machine name after an in-place rename update", () => {
+    const tabsCreate = vi
+      .spyOn(chrome.tabs, "create")
+      .mockImplementation(() => Promise.resolve());
+    const peer = makePeer({
+      hostname: "os-host",
+      dnsName: "old-name.example.ts.net.",
+      sshHost: true,
+      online: true,
+    });
+
+    const item = createPeerItem(peer, false, true);
+    updatePeerItemText(item, { ...peer, dnsName: "new-name.example.ts.net." });
+
+    expect(item.querySelector(".peer-name")?.textContent).toBe("new-name");
+
+    const sshBtn = Array.from(
+      item.querySelectorAll<HTMLButtonElement>(".peer-action-btn"),
+    ).find((btn) => btn.textContent === "SSH");
+    expect(sshBtn).toBeDefined();
+    sshBtn!.click();
+
+    expect(tabsCreate).toHaveBeenCalledWith({
+      url: "http://100.100.100.100/ssh/new-name",
+    });
   });
 });

--- a/packages/shared/src/popup/components/peer-item.test.ts
+++ b/packages/shared/src/popup/components/peer-item.test.ts
@@ -1,7 +1,13 @@
 // @vitest-environment happy-dom
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { makePeer } from "../../__test__/fixtures";
-import { createPeerItem, formatRelativeTime, peerDisplayKey, updatePeerItemText } from "./peer-item";
+import {
+  createPeerItem,
+  formatRelativeTime,
+  peerActionsKey,
+  peerDisplayKey,
+  updatePeerItemText,
+} from "./peer-item";
 
 describe("formatRelativeTime", () => {
   beforeEach(() => {
@@ -110,6 +116,26 @@ describe("peerDisplayKey", () => {
   });
 });
 
+describe("peerActionsKey", () => {
+  it("is stable across a pure rename", () => {
+    const peer = makePeer({ dnsName: "a.example.ts.net.", online: true });
+    expect(peerActionsKey({ ...peer, dnsName: "b.example.ts.net." }, false, false)).toBe(
+      peerActionsKey(peer, false, false),
+    );
+  });
+
+  it("changes when a field that adds or removes an action changes", () => {
+    const peer = makePeer({ dnsName: "a.example.ts.net.", online: true, taildropTarget: false });
+    const base = peerActionsKey(peer, false, false);
+
+    expect(peerActionsKey({ ...peer, online: false }, false, false)).not.toBe(base);
+    expect(peerActionsKey({ ...peer, dnsName: "" }, false, false)).not.toBe(base);
+    expect(peerActionsKey({ ...peer, taildropTarget: true }, false, false)).not.toBe(base);
+    expect(peerActionsKey(peer, true, false)).not.toBe(base);
+    expect(peerActionsKey({ ...peer, sshHost: true }, false, true)).not.toBe(base);
+  });
+});
+
 describe("createPeerItem", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -150,6 +176,68 @@ describe("createPeerItem", () => {
 
     expect(tabsCreate).toHaveBeenCalledWith({
       url: "http://100.100.100.100/ssh/new-name",
+    });
+  });
+
+  it("Open and Copy DNS use the new DNS name after an in-place rename update", () => {
+    const tabsCreate = vi
+      .spyOn(chrome.tabs, "create")
+      .mockImplementation(() => Promise.resolve());
+    const writeText = vi.fn(() => Promise.resolve());
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+    const peer = makePeer({
+      hostname: "os-host",
+      dnsName: "old-name.example.ts.net.",
+      online: true,
+    });
+
+    const item = createPeerItem(peer, false, false);
+    updatePeerItemText(item, { ...peer, dnsName: "new-name.example.ts.net." });
+
+    const buttons = Array.from(
+      item.querySelectorAll<HTMLButtonElement>(".peer-action-btn"),
+    );
+    buttons.find((btn) => btn.textContent === "Copy DNS")!.click();
+    buttons.find((btn) => btn.textContent === "Open")!.click();
+
+    expect(writeText).toHaveBeenCalledWith("new-name.example.ts.net");
+    expect(tabsCreate).toHaveBeenCalledWith({
+      url: "http://new-name.example.ts.net/",
+    });
+  });
+
+  it("Send File toast uses the new machine name after an in-place rename update", async () => {
+    const peer = makePeer({
+      hostname: "os-host",
+      dnsName: "old-name.example.ts.net.",
+      taildropTarget: true,
+      online: true,
+    });
+
+    const item = createPeerItem(peer, false, false);
+    updatePeerItemText(item, { ...peer, dnsName: "new-name.example.ts.net." });
+
+    const sendBtn = Array.from(
+      item.querySelectorAll<HTMLButtonElement>(".peer-action-btn"),
+    ).find((btn) => btn.textContent === "Send File");
+    expect(sendBtn).toBeDefined();
+    sendBtn!.click();
+
+    const input = document.querySelector<HTMLInputElement>('input[type="file"]');
+    expect(input).not.toBeNull();
+    Object.defineProperty(input!, "files", {
+      value: [new File(["hello"], "notes.txt", { type: "text/plain" })],
+      configurable: true,
+    });
+    input!.dispatchEvent(new Event("change"));
+
+    await vi.waitFor(() => {
+      expect(document.querySelector(".toast")?.textContent).toBe(
+        'Sending "notes.txt" to new-name...',
+      );
     });
   });
 });

--- a/packages/shared/src/popup/components/peer-item.ts
+++ b/packages/shared/src/popup/components/peer-item.ts
@@ -1,5 +1,5 @@
 import type { PeerInfo } from "../../types";
-import { copyToClipboard, formatBytes, machineName, showToast } from "../utils";
+import { copyToClipboard, formatBytes, machineName, shortDNSName, showToast } from "../utils";
 import { sendMessage } from "../popup";
 import { getCustomUrl, setCustomUrl, clearCustomUrl, resolveOpenUrl } from "../custom-urls";
 import { iconForOS } from "../icons";
@@ -45,20 +45,48 @@ export function peerDisplayKey(peer: PeerInfo): string {
 }
 
 /**
+ * Returns a string key encoding which action buttons a peer's expanded panel
+ * contains. Buttons are only created in createPeerItem, so when this key
+ * changes the item must be rebuilt rather than updated in place.
+ */
+export function peerActionsKey(
+  peer: PeerInfo,
+  supportsPingPeer: boolean,
+  showPeerSSH: boolean,
+): string {
+  const firstIP = peer.tailscaleIPs[0] ?? "";
+  const openTarget = peer.online ? shortDNSName(peer) || firstIP : "";
+  return [
+    firstIP ? "1" : "0", // Copy IP
+    peer.dnsName ? "1" : "0", // Copy DNS
+    openTarget ? "1" : "0", // Open + custom URL editor
+    supportsPingPeer && peer.online && firstIP ? "1" : "0", // Ping
+    showPeerSSH && peer.sshHost && peer.online ? "1" : "0", // SSH
+    peer.taildropTarget && peer.online ? "1" : "0", // Send File
+  ].join("");
+}
+
+/**
  * Updates the visible text content of an existing peer item container in place.
  * Preserves expansion state and event listeners.
  */
 export function updatePeerItemText(container: HTMLElement, peer: PeerInfo): void {
-  container.dataset.machineName = machineName(peer);
+  const displayName = machineName(peer);
+  const firstIP = peer.tailscaleIPs[0] ?? "";
+  const shortDNS = shortDNSName(peer);
+
+  container.dataset.machineName = displayName;
+  container.dataset.shortDns = shortDNS;
+  container.dataset.openTarget = peer.online ? shortDNS || firstIP : "";
 
   const nameEl = container.querySelector(".peer-name");
-  if (nameEl) nameEl.textContent = machineName(peer);
+  if (nameEl) nameEl.textContent = displayName;
 
   const rowEl = container.querySelector(".peer-item");
   if (rowEl) {
     rowEl.setAttribute(
       "aria-label",
-      `${machineName(peer)}, ${peer.online ? "online" : "offline"}`,
+      `${displayName}, ${peer.online ? "online" : "offline"}`,
     );
   }
 
@@ -75,8 +103,7 @@ export function updatePeerItemText(container: HTMLElement, peer: PeerInfo): void
 
   const ipEl = container.querySelector(".peer-ip");
   if (ipEl) {
-    const firstIP = peer.tailscaleIPs[0];
-    ipEl.textContent = firstIP ?? "";
+    ipEl.textContent = firstIP;
   }
 
   const det = container.querySelector(".peer-details");
@@ -85,8 +112,11 @@ export function updatePeerItemText(container: HTMLElement, peer: PeerInfo): void
   }
 
   container.dataset.displayKey = peerDisplayKey(peer);
-  container.dataset.sshActionShown =
-    container.dataset.showPeerSsh === "1" && peer.sshHost && peer.online ? "1" : "0";
+  container.dataset.actionsKey = peerActionsKey(
+    peer,
+    container.dataset.hostPingCap === "1",
+    container.dataset.showPeerSsh === "1",
+  );
 }
 
 function buildPeerDetailsText(peer: PeerInfo): string {
@@ -116,18 +146,25 @@ export function createPeerItem(
   showPeerSSH: boolean,
 ): HTMLElement {
   const displayName = machineName(peer);
+  const firstIP = peer.tailscaleIPs[0] ?? "";
+  const shortDNS = shortDNSName(peer);
+  const initialOpenTarget = peer.online ? shortDNS || firstIP : "";
 
   const container = document.createElement("div");
   container.className = "peer-item-container";
   container.dataset.peerId = peer.id;
   container.dataset.machineName = displayName;
-  // Action handlers read the dataset instead of closing over displayName:
+  container.dataset.shortDns = shortDNS;
+  container.dataset.openTarget = initialOpenTarget;
+  // Action handlers read the dataset instead of closing over display fields:
   // updatePeerItemText refreshes cached DOM in place, so a rename would
-  // otherwise leave the handlers pointing at the old machine name.
+  // otherwise leave the handlers pointing at the old machine/DNS name.
   const currentName = () => container.dataset.machineName || displayName;
+  const currentShortDNS = () => container.dataset.shortDns || "";
+  const currentOpenTarget = () => container.dataset.openTarget || "";
   container.dataset.hostPingCap = supportsPingPeer ? "1" : "0";
   container.dataset.showPeerSsh = showPeerSSH ? "1" : "0";
-  container.dataset.sshActionShown = showPeerSSH && peer.sshHost && peer.online ? "1" : "0";
+  container.dataset.actionsKey = peerActionsKey(peer, supportsPingPeer, showPeerSSH);
   container.dataset.displayKey = peerDisplayKey(peer);
 
   const row = document.createElement("div");
@@ -176,9 +213,7 @@ export function createPeerItem(
   // Address display
   const ip = document.createElement("div");
   ip.className = "peer-ip";
-  const firstIP = peer.tailscaleIPs[0];
-  const shortDNS = peer.dnsName ? peer.dnsName.replace(/\.$/, "") : "";
-  ip.textContent = firstIP ?? "";
+  ip.textContent = firstIP;
 
   row.appendChild(icon);
   row.appendChild(info);
@@ -201,25 +236,24 @@ export function createPeerItem(
   }
 
   if (peer.dnsName) {
-    const shortDNS = peer.dnsName.replace(/\.$/, "");
     actions.appendChild(createActionButton("Copy DNS", () => {
-      copyToClipboard(shortDNS);
-      showToast("Copied " + shortDNS);
+      const dns = currentShortDNS();
+      if (!dns) return;
+      copyToClipboard(dns);
+      showToast("Copied " + dns);
     }));
   }
 
   // Track openTarget for use in custom URL editor
-  let openTarget: string | undefined;
   let openBtn: HTMLElement | null = null;
 
-  if (peer.online) {
-    openTarget = shortDNS || firstIP || undefined;
-    if (openTarget) {
-      openBtn = createActionButton(openButtonLabel(getCustomUrl(peer.id)), () => {
-        chrome.tabs.create({ url: resolveOpenUrl(openTarget!, getCustomUrl(peer.id)) });
-      });
-      actions.appendChild(openBtn);
-    }
+  if (initialOpenTarget) {
+    openBtn = createActionButton(openButtonLabel(getCustomUrl(peer.id)), () => {
+      const target = currentOpenTarget();
+      if (!target) return;
+      chrome.tabs.create({ url: resolveOpenUrl(target, getCustomUrl(peer.id)) });
+    });
+    actions.appendChild(openBtn);
   }
 
   if (supportsPingPeer && peer.online && firstIP) {
@@ -237,13 +271,13 @@ export function createPeerItem(
 
   if (peer.taildropTarget && peer.online) {
     actions.appendChild(createActionButton("Send File", () => {
-      openFilePicker(peer);
+      openFilePicker(peer, currentName);
     }));
   }
 
   // Custom URL editor (inline, hidden by default)
   let editRow: HTMLElement | null = null;
-  if (peer.online && openTarget) {
+  if (initialOpenTarget) {
     const existingUrl = getCustomUrl(peer.id) || "";
 
     editRow = document.createElement("div");
@@ -349,7 +383,7 @@ function uint8ToBase64(u8: Uint8Array): string {
   return btoa(binary);
 }
 
-function openFilePicker(peer: PeerInfo): void {
+function openFilePicker(peer: PeerInfo, displayName: () => string): void {
   const input = document.createElement("input");
   input.type = "file";
   input.style.display = "none";
@@ -390,7 +424,7 @@ function openFilePicker(peer: PeerInfo): void {
           size: file.size,
           dataBase64: base64,
         });
-        showToast(`Sending "${file.name}" to ${machineName(peer)}...`);
+        showToast(`Sending "${file.name}" to ${displayName()}...`);
       };
       reader.onerror = () => {
         showToast("Failed to read file", "error");

--- a/packages/shared/src/popup/components/peer-item.ts
+++ b/packages/shared/src/popup/components/peer-item.ts
@@ -49,8 +49,18 @@ export function peerDisplayKey(peer: PeerInfo): string {
  * Preserves expansion state and event listeners.
  */
 export function updatePeerItemText(container: HTMLElement, peer: PeerInfo): void {
+  container.dataset.machineName = machineName(peer);
+
   const nameEl = container.querySelector(".peer-name");
   if (nameEl) nameEl.textContent = machineName(peer);
+
+  const rowEl = container.querySelector(".peer-item");
+  if (rowEl) {
+    rowEl.setAttribute(
+      "aria-label",
+      `${machineName(peer)}, ${peer.online ? "online" : "offline"}`,
+    );
+  }
 
   const metaEl = container.querySelector(".peer-meta");
   if (metaEl) {
@@ -110,6 +120,11 @@ export function createPeerItem(
   const container = document.createElement("div");
   container.className = "peer-item-container";
   container.dataset.peerId = peer.id;
+  container.dataset.machineName = displayName;
+  // Action handlers read the dataset instead of closing over displayName:
+  // updatePeerItemText refreshes cached DOM in place, so a rename would
+  // otherwise leave the handlers pointing at the old machine name.
+  const currentName = () => container.dataset.machineName || displayName;
   container.dataset.hostPingCap = supportsPingPeer ? "1" : "0";
   container.dataset.showPeerSsh = showPeerSSH ? "1" : "0";
   container.dataset.sshActionShown = showPeerSSH && peer.sshHost && peer.online ? "1" : "0";
@@ -210,13 +225,13 @@ export function createPeerItem(
   if (supportsPingPeer && peer.online && firstIP) {
     actions.appendChild(createActionButton("Ping", () => {
       sendMessage({ type: "ping-peer", nodeID: peer.id });
-      showToast(`Pinging ${displayName}\u2026`, "info");
+      showToast(`Pinging ${currentName()}\u2026`, "info");
     }));
   }
 
   if (showPeerSSH && peer.sshHost && peer.online) {
     actions.appendChild(createActionButton("SSH", () => {
-      chrome.tabs.create({ url: `http://100.100.100.100/ssh/${displayName}` });
+      chrome.tabs.create({ url: `http://100.100.100.100/ssh/${currentName()}` });
     }));
   }
 
@@ -251,7 +266,7 @@ export function createPeerItem(
       input.value = "";
       clearBtn.style.display = "none";
       if (openBtn) openBtn.textContent = openButtonLabel(undefined);
-      showToast(`Custom URL cleared for ${displayName}`);
+      showToast(`Custom URL cleared for ${currentName()}`);
     });
 
     const saveBtn = document.createElement("button");
@@ -264,7 +279,7 @@ export function createPeerItem(
         await setCustomUrl(peer.id, val);
         clearBtn.style.display = "";
         if (openBtn) openBtn.textContent = openButtonLabel(val);
-        showToast(`Custom URL saved for ${displayName}`);
+        showToast(`Custom URL saved for ${currentName()}`);
       }
     });
 

--- a/packages/shared/src/popup/components/peer-item.ts
+++ b/packages/shared/src/popup/components/peer-item.ts
@@ -1,5 +1,5 @@
 import type { PeerInfo } from "../../types";
-import { copyToClipboard, formatBytes, showToast } from "../utils";
+import { copyToClipboard, formatBytes, machineName, showToast } from "../utils";
 import { sendMessage } from "../popup";
 import { getCustomUrl, setCustomUrl, clearCustomUrl, resolveOpenUrl } from "../custom-urls";
 import { iconForOS } from "../icons";
@@ -50,7 +50,7 @@ export function peerDisplayKey(peer: PeerInfo): string {
  */
 export function updatePeerItemText(container: HTMLElement, peer: PeerInfo): void {
   const nameEl = container.querySelector(".peer-name");
-  if (nameEl) nameEl.textContent = peer.hostname;
+  if (nameEl) nameEl.textContent = machineName(peer);
 
   const metaEl = container.querySelector(".peer-meta");
   if (metaEl) {
@@ -105,6 +105,8 @@ export function createPeerItem(
   supportsPingPeer: boolean,
   showPeerSSH: boolean,
 ): HTMLElement {
+  const displayName = machineName(peer);
+
   const container = document.createElement("div");
   container.className = "peer-item-container";
   container.dataset.peerId = peer.id;
@@ -117,7 +119,7 @@ export function createPeerItem(
   row.className = "peer-item";
   row.setAttribute("role", "button");
   row.setAttribute("tabindex", "0");
-  row.setAttribute("aria-label", `${peer.hostname}, ${peer.online ? "online" : "offline"}`);
+  row.setAttribute("aria-label", `${displayName}, ${peer.online ? "online" : "offline"}`);
 
   // OS icon
   const icon = document.createElement("div");
@@ -133,7 +135,7 @@ export function createPeerItem(
 
   const name = document.createElement("div");
   name.className = "peer-name";
-  name.textContent = peer.hostname;
+  name.textContent = displayName;
 
   const meta = document.createElement("div");
   meta.className = "peer-meta";
@@ -208,13 +210,13 @@ export function createPeerItem(
   if (supportsPingPeer && peer.online && firstIP) {
     actions.appendChild(createActionButton("Ping", () => {
       sendMessage({ type: "ping-peer", nodeID: peer.id });
-      showToast(`Pinging ${peer.hostname}\u2026`, "info");
+      showToast(`Pinging ${displayName}\u2026`, "info");
     }));
   }
 
   if (showPeerSSH && peer.sshHost && peer.online) {
     actions.appendChild(createActionButton("SSH", () => {
-      chrome.tabs.create({ url: `http://100.100.100.100/ssh/${peer.hostname}` });
+      chrome.tabs.create({ url: `http://100.100.100.100/ssh/${displayName}` });
     }));
   }
 
@@ -249,7 +251,7 @@ export function createPeerItem(
       input.value = "";
       clearBtn.style.display = "none";
       if (openBtn) openBtn.textContent = openButtonLabel(undefined);
-      showToast(`Custom URL cleared for ${peer.hostname}`);
+      showToast(`Custom URL cleared for ${displayName}`);
     });
 
     const saveBtn = document.createElement("button");
@@ -262,7 +264,7 @@ export function createPeerItem(
         await setCustomUrl(peer.id, val);
         clearBtn.style.display = "";
         if (openBtn) openBtn.textContent = openButtonLabel(val);
-        showToast(`Custom URL saved for ${peer.hostname}`);
+        showToast(`Custom URL saved for ${displayName}`);
       }
     });
 
@@ -373,7 +375,7 @@ function openFilePicker(peer: PeerInfo): void {
           size: file.size,
           dataBase64: base64,
         });
-        showToast(`Sending "${file.name}" to ${peer.hostname}...`);
+        showToast(`Sending "${file.name}" to ${machineName(peer)}...`);
       };
       reader.onerror = () => {
         showToast("Failed to read file", "error");

--- a/packages/shared/src/popup/components/peer-list.test.ts
+++ b/packages/shared/src/popup/components/peer-list.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach } from "vitest";
+import { makePeer } from "../../__test__/fixtures";
+import { renderPeerList, updatePeerList } from "./peer-list";
+
+function actionLabels(container: HTMLElement): string[] {
+  return Array.from(
+    container.querySelectorAll<HTMLButtonElement>(".peer-action-btn"),
+  ).map((btn) => btn.textContent ?? "");
+}
+
+describe("updatePeerList", () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+  });
+
+  it("updates a renamed peer in place, preserving the element", () => {
+    const peer = makePeer({ dnsName: "old-name.example.ts.net.", online: true });
+    renderPeerList(container, [peer], false, false);
+    const before = container.querySelector(".peer-item-container");
+
+    updatePeerList(container, [{ ...peer, dnsName: "new-name.example.ts.net." }], false, false);
+
+    const after = container.querySelector(".peer-item-container");
+    expect(after).toBe(before);
+    expect(after?.querySelector(".peer-name")?.textContent).toBe("new-name");
+  });
+
+  it("rebuilds the item so the Open button appears when a peer comes online", () => {
+    const peer = makePeer({ online: false, lastSeen: null });
+    renderPeerList(container, [peer], false, false);
+    expect(actionLabels(container)).not.toContain("Open");
+
+    updatePeerList(container, [{ ...peer, online: true }], false, false);
+
+    expect(actionLabels(container)).toContain("Open");
+  });
+
+  it("rebuilds the item so the Open button disappears when a peer goes offline", () => {
+    const peer = makePeer({ online: true });
+    renderPeerList(container, [peer], false, false);
+    expect(actionLabels(container)).toContain("Open");
+
+    updatePeerList(container, [{ ...peer, online: false, lastSeen: null }], false, false);
+
+    expect(actionLabels(container)).not.toContain("Open");
+  });
+
+  it("rebuilds the item so Copy DNS appears when a DNS name shows up later", () => {
+    const peer = makePeer({ dnsName: "", online: true });
+    renderPeerList(container, [peer], false, false);
+    expect(actionLabels(container)).not.toContain("Copy DNS");
+
+    updatePeerList(container, [{ ...peer, dnsName: "router.example.ts.net." }], false, false);
+
+    expect(actionLabels(container)).toContain("Copy DNS");
+  });
+});

--- a/packages/shared/src/popup/components/peer-list.ts
+++ b/packages/shared/src/popup/components/peer-list.ts
@@ -1,6 +1,6 @@
 import type { PeerInfo } from "../../types";
 import { addListKeyboardNav } from "../utils";
-import { createPeerItem, peerDisplayKey, updatePeerItemText } from "./peer-item";
+import { createPeerItem, peerActionsKey, peerDisplayKey, updatePeerItemText } from "./peer-item";
 import { iconSearch } from "../icons";
 
 /**
@@ -86,13 +86,12 @@ function renderPeerSection(
     if (cached) {
       const oldKey = cached.dataset.displayKey ?? "";
       const newKey = peerDisplayKey(peer);
-      const oldSshAction = cached.dataset.sshActionShown ?? "0";
-      const newSshAction =
-        showPeerSSH && peer.sshHost && peer.online ? "1" : "0";
+      const oldActions = cached.dataset.actionsKey ?? "";
+      const newActions = peerActionsKey(peer, supportsPingPeer, showPeerSSH);
 
-      if (oldKey === newKey && oldSshAction === newSshAction) {
+      if (oldKey === newKey && oldActions === newActions) {
         list.appendChild(cached);
-      } else if (oldKey !== newKey && oldSshAction === newSshAction) {
+      } else if (oldKey !== newKey && oldActions === newActions) {
         updatePeerItemText(cached, peer);
         list.appendChild(cached);
       } else {

--- a/packages/shared/src/popup/utils.test.ts
+++ b/packages/shared/src/popup/utils.test.ts
@@ -5,6 +5,7 @@ import {
   formatKeyExpiryLocal,
   formatLocationLabel,
   machineName,
+  shortDNSName,
 } from "./utils";
 
 describe("detectPlatform", () => {
@@ -175,5 +176,20 @@ describe("machineName", () => {
 
   it("falls back to the hostname when the DNS name is missing", () => {
     expect(machineName({ hostname: "johns-macbook" })).toBe("johns-macbook");
+  });
+});
+
+describe("shortDNSName", () => {
+  it("strips the trailing dot", () => {
+    expect(shortDNSName({ dnsName: "laptop.example.ts.net." })).toBe("laptop.example.ts.net");
+  });
+
+  it("returns DNS names without a trailing dot unchanged", () => {
+    expect(shortDNSName({ dnsName: "laptop.example.ts.net" })).toBe("laptop.example.ts.net");
+  });
+
+  it("returns an empty string when the DNS name is empty or missing", () => {
+    expect(shortDNSName({ dnsName: "" })).toBe("");
+    expect(shortDNSName({})).toBe("");
   });
 });

--- a/packages/shared/src/popup/utils.test.ts
+++ b/packages/shared/src/popup/utils.test.ts
@@ -4,6 +4,7 @@ import {
   formatBytes,
   formatKeyExpiryLocal,
   formatLocationLabel,
+  machineName,
 } from "./utils";
 
 describe("detectPlatform", () => {
@@ -152,5 +153,27 @@ describe("formatLocationLabel", () => {
         "countryCode",
       ),
     ).toBe("Frankfurt, DE");
+  });
+});
+
+describe("machineName", () => {
+  it("uses the first label of the DNS name over the OS hostname", () => {
+    expect(
+      machineName({ dnsName: "renamed-laptop.example.ts.net.", hostname: "johns-macbook" }),
+    ).toBe("renamed-laptop");
+  });
+
+  it("handles DNS names without a trailing dot", () => {
+    expect(
+      machineName({ dnsName: "renamed-laptop.example.ts.net", hostname: "johns-macbook" }),
+    ).toBe("renamed-laptop");
+  });
+
+  it("falls back to the hostname when the DNS name is empty", () => {
+    expect(machineName({ dnsName: "", hostname: "johns-macbook" })).toBe("johns-macbook");
+  });
+
+  it("falls back to the hostname when the DNS name is missing", () => {
+    expect(machineName({ hostname: "johns-macbook" })).toBe("johns-macbook");
   });
 });

--- a/packages/shared/src/popup/utils.ts
+++ b/packages/shared/src/popup/utils.ts
@@ -212,6 +212,14 @@ export function machineName(node: { dnsName?: string | null; hostname: string })
 }
 
 /**
+ * Returns the node's full MagicDNS name without the trailing dot, or ""
+ * when no DNS name is available.
+ */
+export function shortDNSName(node: { dnsName?: string | null }): string {
+  return node.dnsName ? node.dnsName.replace(/\.$/, "") : "";
+}
+
+/**
  * Formats a geographic label from native-host location data.
  * Location fields are omitted from JSON when empty, so handle partial objects.
  */

--- a/packages/shared/src/popup/utils.ts
+++ b/packages/shared/src/popup/utils.ts
@@ -202,6 +202,16 @@ function nonEmpty(value: string | null | undefined): string | null {
 }
 
 /**
+ * Returns the node's Tailscale machine name — the first label of its MagicDNS
+ * name — which reflects renames made in the admin console. Falls back to the
+ * OS hostname when no DNS name is available (e.g. MagicDNS disabled).
+ */
+export function machineName(node: { dnsName?: string | null; hostname: string }): string {
+  const firstLabel = node.dnsName?.split(".")[0]?.trim();
+  return firstLabel || node.hostname;
+}
+
+/**
  * Formats a geographic label from native-host location data.
  * Location fields are omitted from JSON when empty, so handle partial objects.
  */

--- a/packages/shared/src/popup/views/connected.ts
+++ b/packages/shared/src/popup/views/connected.ts
@@ -4,7 +4,7 @@ import { renderHeader } from "../components/header";
 import { renderPeerList, updatePeerList, filterPeers } from "../components/peer-list";
 import { peersForDeviceList } from "../peer-filters";
 import { renderHealthWarnings } from "../components/health-warnings";
-import { createCopyButton, formatKeyExpiryLocal, formatLocationLabel } from "../utils";
+import { createCopyButton, formatKeyExpiryLocal, formatLocationLabel, machineName } from "../utils";
 import { sendMessage, enterSubView, leaveSubView, getLatestState } from "../popup";
 import { createToggle } from "../components/toggle-switch";
 import { renderExitNodes } from "./exit-nodes";
@@ -97,7 +97,7 @@ export function renderConnected(root: HTMLElement, state: TailscaleState): void 
     hostnameRow.className = "status-bar-row";
     const hostname = document.createElement("span");
     hostname.className = "status-bar-hostname";
-    hostname.textContent = state.selfNode.hostname;
+    hostname.textContent = machineName(state.selfNode);
     hostnameRow.appendChild(hostname);
     statusBar.appendChild(hostnameRow);
 
@@ -133,7 +133,7 @@ export function renderConnected(root: HTMLElement, state: TailscaleState): void 
   if (state.exitNode) {
     exitValue.textContent = formatLocationLabel(
       state.exitNode.location,
-      state.exitNode.hostname,
+      machineName(state.exitNode),
       "countryCode",
     );
   } else {
@@ -598,7 +598,7 @@ function exitNodeDisplayText(state: TailscaleState): string {
   if (state.exitNode) {
     return formatLocationLabel(
       state.exitNode.location,
-      state.exitNode.hostname,
+      machineName(state.exitNode),
       "countryCode",
     );
   }
@@ -655,7 +655,7 @@ export function updateConnected(root: HTMLElement, state: TailscaleState): void 
 
   const hostnameEl = view.querySelector(".status-bar-hostname");
   if (hostnameEl) {
-    const newHostname = state.selfNode?.hostname ?? "";
+    const newHostname = state.selfNode ? machineName(state.selfNode) : "";
     if (hostnameEl.textContent !== newHostname) {
       hostnameEl.textContent = newHostname;
     }

--- a/packages/shared/src/popup/views/exit-nodes.test.ts
+++ b/packages/shared/src/popup/views/exit-nodes.test.ts
@@ -248,6 +248,7 @@ describe("selectRecommendedMullvadExitNode", () => {
         exitNode: {
           id: "new-york-b",
           hostname: "us-nyc-wg-002",
+          dnsName: "us-nyc-wg-002.mullvad.ts.net.",
           location: selectedSameCity.location,
           online: true,
         },
@@ -282,6 +283,7 @@ describe("selectRecommendedMullvadExitNode", () => {
         exitNode: {
           id: "new-york",
           hostname: "us-nyc-wg-001",
+          dnsName: "us-nyc-wg-001.mullvad.ts.net.",
           location: recommended.location,
           online: true,
         },

--- a/packages/shared/src/popup/views/exit-nodes.ts
+++ b/packages/shared/src/popup/views/exit-nodes.ts
@@ -1,5 +1,5 @@
 import type { TailscaleState, PeerInfo } from "../../types";
-import { addListKeyboardNav, formatLocationLabel } from "../utils";
+import { addListKeyboardNav, formatLocationLabel, machineName } from "../utils";
 import { sendMessage } from "../popup";
 import { iconArrowLeft } from "../icons";
 import { isMullvadExitNodePeer } from "../peer-filters";
@@ -163,6 +163,7 @@ function filterExitNodes(nodes: PeerInfo[], query: string): PeerInfo[] {
   if (!query) return nodes;
   const lower = query.toLowerCase();
   return nodes.filter((n) =>
+    machineName(n).toLowerCase().includes(lower) ||
     n.hostname.toLowerCase().includes(lower) ||
     (n.location?.city && n.location.city.toLowerCase().includes(lower)) ||
     (n.location?.country && n.location.country.toLowerCase().includes(lower)) ||
@@ -201,7 +202,7 @@ function renderExitNodeList(
 
     const suggestLabel = formatLocationLabel(
       recommendedMullvad.location,
-      recommendedMullvad.hostname,
+      machineName(recommendedMullvad),
     );
     const isSelected =
       selectedExitNodeID === recommendedMullvad.id ||
@@ -320,7 +321,7 @@ function renderFlatSection(
   const selectedExitNodeID = effectiveSelectedExitNodeID(state);
 
   for (const node of nodes) {
-    const nodeLabel = formatLocationLabel(node.location, node.hostname);
+    const nodeLabel = formatLocationLabel(node.location, machineName(node));
     const isSelected = selectedExitNodeID === node.id;
     const row = createExitNodeRow(nodeLabel, node, isSelected, () =>
       selectExitNode(node.id)
@@ -574,13 +575,13 @@ function groupMullvadByCountry(nodes: PeerInfo[]): MullvadCountryGroup[] {
     if (!loc) continue;
     const cc = locationPart(loc.countryCode) ?? locationPart(loc.country) ?? node.id;
     const cityKey =
-      locationPart(loc.cityCode) ?? locationPart(loc.city) ?? node.hostname;
+      locationPart(loc.cityCode) ?? locationPart(loc.city) ?? machineName(node);
 
     countryNames.set(
       cc,
       locationPart(loc.country) ?? locationPart(loc.countryCode) ?? "Unknown",
     );
-    cityNames.set(cityKey, locationPart(loc.city) ?? node.hostname);
+    cityNames.set(cityKey, locationPart(loc.city) ?? machineName(node));
 
     if (!countryMap.has(cc)) countryMap.set(cc, new Map());
     const cityMap = countryMap.get(cc)!;
@@ -660,8 +661,8 @@ function compareRecommendedMullvadExitNodes(
   const priority = (b.location?.priority ?? 0) - (a.location?.priority ?? 0);
   if (priority !== 0) return priority;
 
-  return formatLocationLabel(a.location, a.hostname).localeCompare(
-    formatLocationLabel(b.location, b.hostname),
+  return formatLocationLabel(a.location, machineName(a)).localeCompare(
+    formatLocationLabel(b.location, machineName(b)),
   );
 }
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -130,8 +130,7 @@ export interface PeerLocation {
 export interface ExitNodeInfo {
   id: string;
   hostname: string;
-  /** The host sends a full PeerInfo here; optional for older payloads. */
-  dnsName?: string;
+  dnsName: string;
   location: PeerLocation | null;
   online: boolean;
 }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -130,6 +130,8 @@ export interface PeerLocation {
 export interface ExitNodeInfo {
   id: string;
   hostname: string;
+  /** The host sends a full PeerInfo here; optional for older payloads. */
+  dnsName?: string;
   location: PeerLocation | null;
   online: boolean;
 }


### PR DESCRIPTION
## What

Device names in the popup now show the Tailscale machine name (the first label of the MagicDNS name) instead of the OS hostname, matching the official Tailscale clients. Applies to the peer list, the self node in the status bar, exit node labels, and peer action toasts. The web SSH link also uses the machine name now, since that's the name MagicDNS resolves.

Falls back to the OS hostname when no DNS name is available (e.g. MagicDNS disabled), so nothing changes for tailnets without renamed machines.

## Why

Closes #89

## How to Test

- [ ] Rename a machine in the Tailscale admin console, open the popup, and confirm the device list shows the new name (official clients show the same name)
- [ ] Confirm the self node name in the status bar matches the machine name
- [ ] Pick an exit node without location info and confirm its label uses the machine name