### PR TITLE
Ship OS-native helper installers and a package-first install flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,9 @@ permissions:
 #   APPLE_API_KEY_ID             - App Store Connect API key ID
 #   APPLE_API_ISSUER_ID          - App Store Connect API issuer UUID
 #   APPLE_API_KEY_P8             - contents of the AuthKey_*.p8 file
+# Optional repository secrets:
+#   WINDOWS_CODESIGN_P12_BASE64  - base64-encoded Windows code-signing .p12/.pfx
+#   WINDOWS_CODESIGN_PASSWORD    - password for the Windows signing certificate
 
 jobs:
   build:
@@ -162,8 +165,93 @@ jobs:
             dist/tailscale-browser-ext-darwin-amd64
             dist/tailscale-browser-ext-darwin-arm64
 
+  package-linux:
+    needs: build
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref }}
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: host/go.mod
+          cache-dependency-path: host/go.sum
+      - name: Download build artifacts
+        uses: actions/download-artifact@v6
+        with:
+          name: build-output
+      - name: Install nFPM
+        run: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest
+      - name: Build Linux packages
+        run: VERSION="$RELEASE_TAG" ./packaging/linux/build-packages.sh
+      - name: Upload Linux packages
+        uses: actions/upload-artifact@v6
+        with:
+          name: linux-packages
+          retention-days: 1
+          path: |
+            dist/tailchrome-helper-linux-amd64.deb
+            dist/tailchrome-helper-linux-x86_64.rpm
+
+  package-windows:
+    needs: build
+    runs-on: windows-latest
+    env:
+      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref }}
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: "8.0.x"
+      - name: Download build artifacts
+        uses: actions/download-artifact@v6
+        with:
+          name: build-output
+      - name: Install WiX
+        run: dotnet tool install --global wix --version 6.0.2
+      - name: Build Windows MSI
+        shell: pwsh
+        run: .\packaging\windows\build-msi.ps1 -Version "$env:RELEASE_TAG"
+      - name: Sign Windows MSI
+        shell: pwsh
+        env:
+          WINDOWS_CODESIGN_P12_BASE64: ${{ secrets.WINDOWS_CODESIGN_P12_BASE64 }}
+          WINDOWS_CODESIGN_PASSWORD: ${{ secrets.WINDOWS_CODESIGN_PASSWORD }}
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:WINDOWS_CODESIGN_P12_BASE64)) {
+            Write-Host "Skipping Windows signing; WINDOWS_CODESIGN_P12_BASE64 is not configured."
+            exit 0
+          }
+          $certPath = Join-Path $env:RUNNER_TEMP "tailchrome-windows-codesign.p12"
+          [IO.File]::WriteAllBytes($certPath, [Convert]::FromBase64String($env:WINDOWS_CODESIGN_P12_BASE64))
+          $signtool = Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\bin" -Recurse -Filter signtool.exe |
+            Where-Object { $_.FullName -match "\\x64\\signtool.exe$" } |
+            Select-Object -First 1
+          if (-not $signtool) {
+            throw "signtool.exe not found"
+          }
+          & $signtool.FullName sign `
+            /fd SHA256 `
+            /tr http://timestamp.digicert.com `
+            /td SHA256 `
+            /f $certPath `
+            /p "$env:WINDOWS_CODESIGN_PASSWORD" `
+            dist\tailchrome-helper-windows-x64.msi
+      - name: Upload Windows MSI
+        uses: actions/upload-artifact@v6
+        with:
+          name: windows-msi
+          retention-days: 1
+          path: dist/tailchrome-helper-windows-x64.msi
+
   release:
-    needs: [build, sign-macos]
+    needs: [build, sign-macos, package-linux, package-windows]
     runs-on: ubuntu-latest
     env:
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}
@@ -181,6 +269,18 @@ jobs:
           name: signed-darwin
           path: signed-darwin
 
+      - name: Download Linux packages
+        uses: actions/download-artifact@v6
+        with:
+          name: linux-packages
+          path: linux-packages
+
+      - name: Download Windows MSI
+        uses: actions/download-artifact@v6
+        with:
+          name: windows-msi
+          path: windows-msi
+
       - name: Collect release assets
         run: |
           set -euo pipefail
@@ -191,6 +291,9 @@ jobs:
           # — they extract straight into signed-darwin/.
           cp signed-darwin/tailscale-browser-ext-darwin-amd64 release/
           cp signed-darwin/tailscale-browser-ext-darwin-arm64 release/
+          cp linux-packages/tailchrome-helper-linux-amd64.deb release/
+          cp linux-packages/tailchrome-helper-linux-x86_64.rpm release/
+          cp windows-msi/tailchrome-helper-windows-x64.msi release/
           # build-output uploads paths under both dist/ and packages/, so it
           # has no common ancestor and the artifact preserves the full paths.
           cp dist/tailscale-browser-ext-linux-amd64 release/

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev
 TS_VERSION = $(shell cd host && go list -m -f '{{.Version}}' tailscale.com 2>/dev/null | sed 's/^v//')
 LDFLAGS = -ldflags "-X main.version=$(VERSION) -X tailscale.com/version.shortStamp=$(TS_VERSION) -X tailscale.com/version.longStamp=$(TS_VERSION)"
 
-.PHONY: all extension extension-chrome extension-firefox host host-all macos-pkg clean dev zip zip-chrome zip-firefox
+.PHONY: all extension extension-chrome extension-firefox host host-all macos-pkg windows-msi linux-packages clean dev zip zip-chrome zip-firefox
 
 all: extension host
 
@@ -30,6 +30,14 @@ host-all:
 # macOS only: universal .pkg installer (requires lipo, pkgbuild)
 macos-pkg:
 	./packaging/macos/build-pkg.sh
+
+# Windows only: per-user .msi installer (requires WiX)
+windows-msi:
+	pwsh ./packaging/windows/build-msi.ps1
+
+# Linux only: .deb and .rpm installers (requires nFPM)
+linux-packages:
+	./packaging/linux/build-packages.sh
 
 zip: zip-chrome zip-firefox
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The same UI renders in either surface.
 ## Install
 
 1. Get the extension from the [Chrome Web Store](https://chromewebstore.google.com/detail/tailchrome/bhfeceecialgilpedkoflminjgcjljll) (also installs in Brave, Edge, Vivaldi, Opera, and — on macOS — Arc) or [Firefox Add-ons](https://addons.mozilla.org/en-US/firefox/addon/tailchrome/)
-2. Install the native helper from the [latest release](https://github.com/dantraynor/tailchrome/releases/latest) — on macOS, download and open **`tailchrome-helper-macos.pkg`**; on other platforms, download the binary and run it. The helper auto-installs the native messaging manifest into every supported browser it detects on your machine.
+2. Install the native helper from the [latest release](https://github.com/dantraynor/tailchrome/releases/latest) — **`tailchrome-helper-macos.pkg`** on macOS, **`tailchrome-helper-windows-x64.msi`** on Windows, or the **`.deb`/`.rpm`** package on Linux. Raw binaries remain available for advanced/manual installs.
 3. Log in to your Tailscale account
 
 ## Development

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -51,7 +51,7 @@ make host-all            # All platform binaries
 make dev                 # Chrome watch mode (WXT)
 ```
 
-Extension builds go to `packages/extension/.output/`. Native host binaries go to `dist/`.
+Extension builds go to `packages/extension/.output/`. Native host binaries and helper installers go to `dist/`.
 
 See [puppeteer-testing-suite.md](puppeteer-testing-suite.md) for the end-to-end harness layout.
 
@@ -62,5 +62,5 @@ Include your browser, OS, extension version, and steps to reproduce.
 ## Release Pipeline
 
 - PRs run extension typecheck/tests, Chrome build, the full Firefox review gate, and native host builds via GitHub Actions
-- Tagged releases build all artifacts (extension zips, host binaries, macOS `.pkg` installer) and attach them to the GitHub Release
+- Tagged releases build all artifacts (extension zips, host binaries, macOS `.pkg`, Windows `.msi`, and Linux `.deb`/`.rpm` installers) and attach them to the GitHub Release
 - Store publication uses GitHub Actions with manual environment approvals for Chrome Web Store and Firefox AMO submission

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -376,7 +376,7 @@ The proxy uses Tailscale's `proxymux.SplitSOCKSAndHTTP()` to multiplex a single 
 
 ### Auto-Installation
 
-When the host binary is run in a terminal (detected via `term.IsTerminal`), it auto-detects installed browsers and installs native messaging manifests for Chrome and/or Firefox. The binary copies itself to `~/.local/share/tailscale-browser-ext/` (or platform equivalent) and writes JSON manifests to the browser's native messaging host directory.
+When the raw host binary is run in a terminal (detected via `term.IsTerminal`), it auto-detects installed browsers and installs native messaging manifests for Chrome-family browsers and Firefox. The binary copies itself to the per-user helper directory (`~/.local/share/tailscale/browser-ext/`, `~/Library/Application Support/Tailscale/BrowserExt/`, or `%LOCALAPPDATA%\Tailscale\BrowserExt\`) and writes JSON manifests to each browser's native messaging host location.
 
 ---
 
@@ -549,21 +549,27 @@ The popup is a vanilla TypeScript UI (no framework) rendered into the extension 
 **Chrome:**
 
 1. Install from the [Chrome Web Store](https://chromewebstore.google.com/detail/tailchrome/bhfeceecialgilpedkoflminjgcjljll)
-2. **macOS:** Download **`tailchrome-helper-macos.pkg`** from [GitHub Releases](https://github.com/dantraynor/tailchrome/releases/latest), install it, then open **Tailchrome Helper** once from Applications. **Other platforms:** click the extension icon and follow the prompts to install the native host.
+2. Install the native helper from [GitHub Releases](https://github.com/dantraynor/tailchrome/releases/latest): **`tailchrome-helper-macos.pkg`** on macOS, **`tailchrome-helper-windows-x64.msi`** on Windows, or the **`.deb`/`.rpm`** package on Linux.
 3. Log in to your Tailscale account
 
 **Firefox:**
 
-1. Install from [GitHub Releases](https://github.com/dantraynor/tailchrome/releases/latest)
-2. **macOS:** use the same **`tailchrome-helper-macos.pkg`** and **Tailchrome Helper** step as Chrome. **Other platforms:** click the extension icon and follow the prompts to install the native host from GitHub Releases
+1. Install from [Firefox Add-ons](https://addons.mozilla.org/en-US/firefox/addon/tailchrome/) or the matching [GitHub Release](https://github.com/dantraynor/tailchrome/releases/latest)
+2. Install the same native helper package used for Chrome: **`.pkg`** on macOS, **`.msi`** on Windows, or **`.deb`/`.rpm`** on Linux.
 3. Log in to your Tailscale account
 
 ### Native Host Installation
 
-The native host binary auto-installs when run interactively in a terminal, or non-interactively via **`tailscale-browser-ext -install-now`** (used by the macOS Helper app):
+The installer packages are the primary path:
+
+- **macOS:** `tailchrome-helper-macos.pkg` installs a universal binary and runs `tailscale-browser-ext -install-now` for the logged-in user during package postinstall. `Tailchrome Helper.app` remains in `/Applications` as a repair/re-run fallback.
+- **Windows:** `tailchrome-helper-windows-x64.msi` installs a staged helper under `%LOCALAPPDATA%\Tailscale\BrowserExt\installer\` and runs it with `-install-now`, which writes HKCU native messaging registrations.
+- **Linux:** `.deb` and `.rpm` packages install `/usr/lib/tailchrome/tailscale-browser-ext` plus system-wide manifests for Chrome, Chromium, Edge, and Firefox. The raw binary fallback remains available for per-user registration in additional Chromium-family browsers.
+
+The raw native host binary remains available for advanced/manual installs. When run interactively in a terminal, or non-interactively via **`tailscale-browser-ext -install-now`**, it:
 
 - Detects installed browsers and writes per-browser manifests for the whole Chromium family (Chrome stable/beta/canary/dev, Chromium, Brave, Edge, Vivaldi, Opera, Arc on macOS) plus Firefox
-- Copies itself to `~/.local/share/tailscale-browser-ext/` (Linux), `~/Library/Application Support/Tailscale/BrowserExt/` (macOS), or `%LOCALAPPDATA%\tailscale-browser-ext\` (Windows)
+- Copies itself to `~/.local/share/tailscale/browser-ext/` (Linux), `~/Library/Application Support/Tailscale/BrowserExt/` (macOS), or `%LOCALAPPDATA%\Tailscale\BrowserExt\` (Windows)
 - Reports per-browser install status so unsupported or missing browsers are skipped cleanly
 - Manual install: `./tailscale-browser-ext --install C<extensionID>` (Chromium-family) or `--install F<extensionID>` (Firefox)
 - Uninstall: `./tailscale-browser-ext --uninstall` removes manifests from every browser it installed into
@@ -752,14 +758,17 @@ Four parallel jobs:
 
 ### Release (`release.yml`) -- Runs on `v`* Tags or Manual Dispatch
 
-Single job that:
+The release workflow:
 
 1. Validates extension IDs and release tag
 2. Builds `chrome.zip`, `firefox.zip`, `firefox-sources.zip`
 3. Builds host binaries for all platforms
 4. **Verifies Firefox source ZIP**: extracts sources, rebuilds from scratch, `diff -qr` against original to ensure reproducibility
-5. Generates `SHA256SUMS.txt` for all release assets
-6. Creates/updates GitHub Release with all assets
+5. Signs/notarizes macOS binaries
+6. Builds Linux `.deb`/`.rpm` packages with nFPM and the Windows `.msi` with WiX
+7. Generates `SHA256SUMS.txt` for the main release assets
+8. Creates/updates GitHub Release with all assets
+9. Builds, signs, and notarizes the macOS `.pkg` in a follow-up job and uploads it to the release with its own `.sha256` checksum
 
 ### Publish (`publish.yml`) -- Manual Dispatch Only
 

--- a/docs/FEATURE_PARITY.md
+++ b/docs/FEATURE_PARITY.md
@@ -155,7 +155,7 @@ Last updated: 2026-05-26
 | Dark mode              | Yes           | Yes        | Follows browser/system theme via CSS                                                                                                               |
 | Keyboard navigation    | Yes           | Yes        | Arrow keys in peer list                                                                                                                            |
 | Search                 | Yes           | Yes        | Peer search in popup                                                                                                                               |
-| Auto-update            | Yes           | Partial    | Extension auto-updates via Chrome Web Store; native host requires manual update (extension detects version mismatch and shows "needs-update" view) |
+| Auto-update            | Yes           | Partial    | Extension auto-updates via Chrome Web Store; native host updates use the platform helper installer when the extension shows "needs-update" |
 | Cross-platform         | Yes           | Yes        | Extension: Chrome + Firefox. Host: macOS (amd64/arm64), Linux (amd64), Windows (amd64)                                                             |
 
 
@@ -198,4 +198,3 @@ These gaps exist for fundamental reasons:
 3. **Browser sandbox** -- the extension cannot modify system DNS, routing tables, or network configuration. All networking goes through the SOCKS5/HTTP proxy, which means split DNS and custom nameserver configuration are not feasible from the browser alone.
 4. **tsnet scope** -- the native host runs a `tsnet.Server`, which is a userspace Tailscale node. It does not have the full feature surface of `tailscaled` (the system daemon). Features like Serve, Funnel, and network lock require daemon-level integration that `tsnet` does not expose.
 5. **UI surface area** -- the popup is constrained to a small window. Some features (subnet route advertisement, SSH server toggle, detailed peer stats) are omitted from the UI to keep it focused, even though the underlying protocol and host may support them.
-

--- a/docs/STORE_LISTING.md
+++ b/docs/STORE_LISTING.md
@@ -28,7 +28,7 @@ Tailchrome uses a lightweight native helper app that runs a full Tailscale node 
 
 **Getting started:**
 1. Install the extension
-2. Download and run the helper app (one-time setup, ~30 seconds)
+2. Download and run the helper installer (one-time setup, ~30 seconds)
 3. Log in to your Tailscale account
 4. Toggle the switch to connect
 
@@ -64,7 +64,7 @@ Tailchrome connects Firefox to your Tailscale tailnet without a system VPN. Each
 - Shields Up mode
 
 **Setup:**
-Install the extension, download the helper app, and log in. The helper app is a small native program that runs a Tailscale node per browser profile. Setup takes about 30 seconds.
+Install the extension, download the helper installer, and log in. The helper app is a small native program that runs a Tailscale node per browser profile. Setup takes about 30 seconds.
 
 **How it works:**
 A native messaging host runs locally and manages Tailscale connections per profile. Only Firefox traffic is routed through your tailnet. Your system networking is never modified.

--- a/docs/firefox-amo-launch.md
+++ b/docs/firefox-amo-launch.md
@@ -37,7 +37,7 @@ Features:
 - Taildrop
 - multiple profiles
 
-Tailchrome requires a separate native helper downloaded from GitHub Releases. The helper installs the Firefox native messaging manifest and runs the local Tailscale proxy used by the extension.
+Tailchrome requires a separate native helper downloaded from GitHub Releases. The helper installer registers the Firefox native messaging manifest and installs the local Tailscale proxy used by the extension.
 
 ### Privacy Disclosure Notes
 
@@ -69,7 +69,7 @@ Upload from the matching GitHub Release:
 
 Use this wording in reviewer notes and any store responses:
 
-Tailchrome's Firefox add-on package does not contain native binaries. The separate helper is downloaded from GitHub Releases, installed locally by the user, and registered through Firefox native messaging so the extension can run a Tailscale node for the current browser profile.
+Tailchrome's Firefox add-on package does not contain native binaries. The separate helper installer is downloaded from GitHub Releases, installed locally by the user, and registered through Firefox native messaging so the extension can run a Tailscale node for the current browser profile.
 
 ## Reviewer Account Checklist
 

--- a/docs/firefox-amo-review-notes.md
+++ b/docs/firefox-amo-review-notes.md
@@ -62,8 +62,8 @@ Tailchrome does not include analytics or advertising trackers. These categories 
 The extension requires the separate native helper to demonstrate full functionality. Reviewer steps:
 
 1. Install the signed Firefox extension build.
-2. Download the helper binary from the matching GitHub Release asset for the current OS.
-3. Run the helper once to install the native messaging manifest.
+2. Download the helper installer from the matching GitHub Release asset for the current OS.
+3. Run the installer to register the native messaging manifest.
 4. Re-open the extension popup and sign in using the disposable reviewer account provided with the submission.
 
 The popup includes optional split-tunneling controls under the Exit Node row and an optional "Auto-connect on start" toggle in quick settings. Both settings are off or empty by default and are stored locally.

--- a/docs/firefox-smoke-test.md
+++ b/docs/firefox-smoke-test.md
@@ -4,17 +4,17 @@
 
 Run the full checklist on:
 
-| OS | Firefox | Helper binary |
+| OS | Firefox | Helper installer |
 | --- | --- | --- |
-| macOS 14+ | 140+ stable | `tailscale-browser-ext-darwin-arm64` or `tailscale-browser-ext-darwin-amd64` |
-| Windows 11 | 140+ stable | `tailscale-browser-ext-windows-amd64.exe` |
-| Ubuntu 24.04+ | 140+ stable | `tailscale-browser-ext-linux-amd64` |
+| macOS 14+ | 140+ stable | `tailchrome-helper-macos.pkg` |
+| Windows 11 | 140+ stable | `tailchrome-helper-windows-x64.msi` |
+| Ubuntu 24.04+ | 140+ stable | `tailchrome-helper-linux-amd64.deb` |
 
 ## Preconditions
 
 - Fresh Firefox profile
 - Matching signed Firefox extension build
-- Matching helper binary from the same GitHub Release
+- Matching helper installer from the same GitHub Release
 - Disposable Tailscale reviewer account
 - Test tailnet with MagicDNS peer, subnet route, exit node, and Taildrop target
 
@@ -26,7 +26,7 @@ Steps:
 
 1. Open the popup immediately after installing the extension.
 2. Confirm the setup-required view appears.
-3. Download and run the helper for the current OS.
+3. Download and run the helper installer for the current OS.
 4. Re-open the popup.
 
 Pass:
@@ -133,7 +133,7 @@ Pass:
 
 Steps:
 
-1. Install an older helper binary than the extension expects.
+1. Install an older helper package than the extension expects.
 2. Open the popup.
 
 Pass:

--- a/host/install.go
+++ b/host/install.go
@@ -158,7 +158,8 @@ func installFirefox(extensionID string) error {
 	return platformPostInstallFirefox(manifestPath)
 }
 
-// uninstall removes the native messaging host manifest files.
+// uninstall removes the native messaging host manifest files and the
+// installed helper binary.
 func uninstall() error {
 	var firstErr error
 
@@ -182,7 +183,25 @@ func uninstall() error {
 		firstErr = err
 	}
 
+	// Remove the runtime binary staged by installBinary. The OS packages track
+	// only their own payload copy, so nothing else cleans this one up.
+	if err := os.Remove(installedBinaryPath()); err != nil && !os.IsNotExist(err) {
+		if firstErr == nil {
+			firstErr = fmt.Errorf("failed to remove installed binary: %w", err)
+		}
+	}
+
 	return firstErr
+}
+
+// installedBinaryPath returns the destination path installBinary copies the
+// helper to.
+func installedBinaryPath() string {
+	binaryName := "tailscale-browser-ext"
+	if runtime.GOOS == "windows" {
+		binaryName += ".exe"
+	}
+	return filepath.Join(binaryInstallDir(), binaryName)
 }
 
 // installBinary copies the current binary to the install directory and returns
@@ -197,16 +216,10 @@ func installBinary() (string, error) {
 		return "", fmt.Errorf("failed to resolve executable path: %w", err)
 	}
 
-	installDir := binaryInstallDir()
-	if err := os.MkdirAll(installDir, 0755); err != nil {
+	destPath := installedBinaryPath()
+	if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
 		return "", fmt.Errorf("failed to create install dir: %w", err)
 	}
-
-	binaryName := "tailscale-browser-ext"
-	if runtime.GOOS == "windows" {
-		binaryName += ".exe"
-	}
-	destPath := filepath.Join(installDir, binaryName)
 
 	if exe == destPath {
 		return destPath, nil

--- a/host/install_test.go
+++ b/host/install_test.go
@@ -159,6 +159,26 @@ func TestUninstallRemovesAllChromiumManifests(t *testing.T) {
 	}
 }
 
+func TestUninstallRemovesInstalledBinary(t *testing.T) {
+	setupTempHome(t)
+
+	binPath := installedBinaryPath()
+	if err := os.MkdirAll(filepath.Dir(binPath), 0755); err != nil {
+		t.Fatalf("failed to create install dir: %v", err)
+	}
+	if err := os.WriteFile(binPath, []byte("helper"), 0755); err != nil {
+		t.Fatalf("failed to stage binary: %v", err)
+	}
+
+	if err := uninstall(); err != nil {
+		t.Fatalf("uninstall failed: %v", err)
+	}
+
+	if _, err := os.Stat(binPath); !os.IsNotExist(err) {
+		t.Errorf("post-uninstall: installed binary still exists at %s (err=%v)", binPath, err)
+	}
+}
+
 func TestUninstallIsIdempotent(t *testing.T) {
 	setupTempHome(t)
 	if err := uninstall(); err != nil {

--- a/packages/shared/src/background/background.test.ts
+++ b/packages/shared/src/background/background.test.ts
@@ -337,6 +337,57 @@ describe("initBackground", () => {
       expect(otherPort.postMessage).not.toHaveBeenCalled();
     });
 
+    it("polls the native host after the popup requests install retries", async () => {
+      await setupBackground();
+
+      const popupPort = createPopupPort();
+      connectListeners[0]!(popupPort);
+
+      // Helper is missing: the connect attempt reported an install error.
+      sendNativeMessage({ error: { cmd: "connect", message: "install_error" } });
+
+      popupPort.onMessage._listeners[0]!({ type: "retry-native-host" });
+      expect(chrome.runtime.connectNative).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(nativePort.disconnect).toHaveBeenCalled();
+      expect(chrome.runtime.connectNative).toHaveBeenCalledTimes(2);
+
+      // Later retries keep polling while the helper is still missing.
+      await vi.advanceTimersByTimeAsync(28_000);
+      expect(chrome.runtime.connectNative).toHaveBeenCalledTimes(6);
+    });
+
+    it("does not bounce a connected native host on install retry requests", async () => {
+      await setupBackground();
+      advertiseLoginSupport();
+
+      const popupPort = createPopupPort();
+      connectListeners[0]!(popupPort);
+
+      popupPort.onMessage._listeners[0]!({ type: "retry-native-host" });
+      await vi.advanceTimersByTimeAsync(31_000);
+
+      expect(nativePort.disconnect).not.toHaveBeenCalled();
+      expect(chrome.runtime.connectNative).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not bounce a connected host that only needs a helper update", async () => {
+      await setupBackground();
+      // Helper connects but reports an outdated version: needs-update state.
+      sendNativeMessage({
+        procRunning: { port: 1055, pid: 1234, version: "0.0.1", supportsLogin: true },
+      });
+
+      const popupPort = createPopupPort();
+      connectListeners[0]!(popupPort);
+      popupPort.onMessage._listeners[0]!({ type: "retry-native-host" });
+      await vi.advanceTimersByTimeAsync(31_000);
+
+      expect(nativePort.disconnect).not.toHaveBeenCalled();
+      expect(chrome.runtime.connectNative).toHaveBeenCalledTimes(1);
+    });
+
     it("broadcasts state changes to connected popups", async () => {
       await setupBackground();
 

--- a/packages/shared/src/background/background.ts
+++ b/packages/shared/src/background/background.ts
@@ -83,6 +83,9 @@ function isVersionMismatch(hostVersion: string | null): boolean {
 const NATIVE_HOST_UNREACHABLE =
   "Could not reach Tailscale service. Please check that the native host is installed.";
 
+/** Poll schedule for native-host discovery after the user starts an installer. */
+const INSTALL_RETRY_DELAYS_MS = [2_000, 5_000, 10_000, 20_000, 30_000];
+
 function domainSplitEquals(
   a: { mode: string; domains: string[] },
   b: { mode: string; domains: string[] },
@@ -457,15 +460,39 @@ export function initBackground(
       });
   }
 
+  /**
+   * Polls native-host discovery after the user starts an installer. Each
+   * attempt is skipped once the helper is connected: connect() tears down a
+   * live port, and the browser then respawns the helper, so retrying a
+   * healthy connection would bounce the Tailscale node.
+   */
+  function scheduleInstallRetries(): void {
+    INSTALL_RETRY_DELAYS_MS.forEach((delay, i) => {
+      timerService.setTimeout(`install-retry-${i}`, () => {
+        const state = store.getState();
+        if (state.hostConnected) return;
+        if (!state.installError && !state.hostVersionMismatch) return;
+        nativeHost.connect().catch(() => {
+          // The installer may still be running; later retries or the
+          // built-in backoff loop pick up the helper once registration lands.
+        });
+      }, delay);
+    });
+  }
+
   chrome.runtime.onConnect.addListener((port: chrome.runtime.Port) => {
     if (port.name !== "popup") return;
 
     popupPorts.add(port);
 
     // If we're in install error or version mismatch state, retry the native
-    // host connection in case the user just installed or updated the helper
+    // host connection in case the user just installed or updated the helper.
+    // Skip while a port is live: connect() would bounce a working host.
     const currentState = store.getState();
-    if (currentState.installError || currentState.hostVersionMismatch) {
+    if (
+      !currentState.hostConnected &&
+      (currentState.installError || currentState.hostVersionMismatch)
+    ) {
       nativeHost.connect().catch(() => {
         // Still in error state, popup will show needs-install or needs-update
       });
@@ -551,6 +578,11 @@ export function initBackground(
 
       case "logout": {
         nativeHost.send({ cmd: "logout" });
+        break;
+      }
+
+      case "retry-native-host": {
+        scheduleInstallRetries();
         break;
       }
 

--- a/packages/shared/src/popup/styles/components.css
+++ b/packages/shared/src/popup/styles/components.css
@@ -1280,13 +1280,16 @@ button.setting-row {
 }
 
 /* ==============================
-   macOS .pkg CTA (needs-install)
+   Installer CTA (needs-install/update)
    ============================== */
 
 .install-pkg-cta {
   width: 100%;
   max-width: 280px;
   margin: 0 auto var(--space-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
 }
 
 .install-pkg-cta .btn {
@@ -1387,6 +1390,12 @@ button.setting-row {
 .install-advanced-section {
   width: 100%;
   margin-top: var(--space-sm);
+}
+
+.install-advanced-section > .btn {
+  width: 100%;
+  box-sizing: border-box;
+  margin-bottom: var(--space-sm);
 }
 
 .install-advanced-section.hidden {

--- a/packages/shared/src/popup/views/install-helpers.test.ts
+++ b/packages/shared/src/popup/views/install-helpers.test.ts
@@ -1,0 +1,172 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  buildDownloadURL,
+  installerDownloads,
+  renderInstallFlow,
+  requestNativeHostRetries,
+} from "./install-helpers";
+import { sendMessage } from "../popup";
+import { detectPlatform } from "../utils";
+
+vi.mock("../popup", () => ({
+  sendMessage: vi.fn(),
+}));
+
+vi.mock("../utils", () => ({
+  copyToClipboard: vi.fn(),
+  detectPlatform: vi.fn(() => "windows"),
+  showToast: vi.fn(),
+}));
+
+describe("installerDownloads", () => {
+  it("returns the macOS package asset", () => {
+    expect(installerDownloads("macos")).toEqual([
+      {
+        filename: "tailchrome-helper-macos.pkg",
+        label: "Download macOS installer (.pkg)",
+        url: "https://github.com/dantraynor/tailchrome/releases/latest/download/tailchrome-helper-macos.pkg",
+      },
+    ]);
+  });
+
+  it("returns the Windows MSI asset", () => {
+    expect(installerDownloads("windows")).toEqual([
+      {
+        filename: "tailchrome-helper-windows-x64.msi",
+        label: "Download Windows installer (.msi)",
+        url: "https://github.com/dantraynor/tailchrome/releases/latest/download/tailchrome-helper-windows-x64.msi",
+      },
+    ]);
+  });
+
+  it("returns both Linux package assets", () => {
+    expect(installerDownloads("linux")).toEqual([
+      {
+        filename: "tailchrome-helper-linux-amd64.deb",
+        label: "Download .deb (Debian/Ubuntu)",
+        url: "https://github.com/dantraynor/tailchrome/releases/latest/download/tailchrome-helper-linux-amd64.deb",
+      },
+      {
+        filename: "tailchrome-helper-linux-x86_64.rpm",
+        label: "Download .rpm (Fedora/RHEL)",
+        url: "https://github.com/dantraynor/tailchrome/releases/latest/download/tailchrome-helper-linux-x86_64.rpm",
+      },
+    ]);
+  });
+
+  it("falls back to the release page for unknown platforms", () => {
+    expect(installerDownloads("unknown")).toEqual([
+      {
+        filename: null,
+        label: "Open latest release",
+        url: "https://github.com/dantraynor/tailchrome/releases/latest",
+      },
+    ]);
+  });
+
+  it("keeps raw binary downloads available as a fallback", () => {
+    expect(buildDownloadURL("windows")).toBe(
+      "https://github.com/dantraynor/tailchrome/releases/latest/download/tailscale-browser-ext-windows-amd64.exe",
+    );
+    expect(buildDownloadURL("linux")).toBe(
+      "https://github.com/dantraynor/tailchrome/releases/latest/download/tailscale-browser-ext-linux-amd64",
+    );
+  });
+});
+
+describe("requestNativeHostRetries", () => {
+  beforeEach(() => {
+    vi.mocked(sendMessage).mockClear();
+  });
+
+  it("immediately asks the background worker to poll native-host discovery", () => {
+    requestNativeHostRetries();
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledWith({ type: "retry-native-host" });
+  });
+});
+
+describe("renderInstallFlow", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.mocked(detectPlatform).mockReturnValue("windows");
+    vi.mocked(sendMessage).mockClear();
+    chrome.tabs.create = vi.fn().mockResolvedValue(undefined) as unknown as typeof chrome.tabs.create;
+    document.body.textContent = "";
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it.each(["install", "update"] as const)(
+    "requests native-host retries from the %s view installer button",
+    (mode) => {
+      const root = document.createElement("div");
+      document.body.appendChild(root);
+
+      renderInstallFlow(root, { mode, hostVersion: "0.1.0" });
+
+      root.querySelector<HTMLAnchorElement>(".install-pkg-cta a")?.click();
+
+      // The retry request must go out synchronously in the click handler:
+      // opening the download tab closes the popup surface right after.
+      expect(sendMessage).toHaveBeenCalledWith({ type: "retry-native-host" });
+      expect(chrome.tabs.create).toHaveBeenCalledWith({
+        url: "https://github.com/dantraynor/tailchrome/releases/latest/download/tailchrome-helper-windows-x64.msi",
+      });
+    },
+  );
+
+  it("renders both Linux package links with install commands", () => {
+    vi.mocked(detectPlatform).mockReturnValue("linux");
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+
+    renderInstallFlow(root, { mode: "install", hostVersion: "0.1.0" });
+
+    const links = [...root.querySelectorAll<HTMLAnchorElement>(".install-pkg-cta a")];
+    expect(links.map((link) => link.href)).toEqual([
+      "https://github.com/dantraynor/tailchrome/releases/latest/download/tailchrome-helper-linux-amd64.deb",
+      "https://github.com/dantraynor/tailchrome/releases/latest/download/tailchrome-helper-linux-x86_64.rpm",
+    ]);
+    expect(root.textContent).toContain("sudo apt install");
+    expect(root.textContent).toContain("sudo dnf install");
+  });
+
+  it("links to the releases page on unknown platforms", () => {
+    vi.mocked(detectPlatform).mockReturnValue("unknown");
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+
+    renderInstallFlow(root, { mode: "install", hostVersion: "0.1.0" });
+
+    const links = [...root.querySelectorAll<HTMLAnchorElement>(".install-pkg-cta a")];
+    expect(links.map((link) => link.href)).toEqual([
+      "https://github.com/dantraynor/tailchrome/releases/latest",
+    ]);
+  });
+
+  it("reveals the raw binary fallback and requests retries from its download link", () => {
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+
+    renderInstallFlow(root, { mode: "install", hostVersion: "0.1.0" });
+
+    const toggle = root.querySelector<HTMLButtonElement>(".install-advanced-toggle")!;
+    const section = root.querySelector<HTMLElement>(".install-advanced-section")!;
+    expect(section.classList.contains("hidden")).toBe(true);
+
+    toggle.click();
+    expect(section.classList.contains("hidden")).toBe(false);
+    expect(toggle.textContent).toBe("Hide raw binary fallback");
+
+    section.querySelector<HTMLAnchorElement>("a")!.click();
+    expect(sendMessage).toHaveBeenCalledWith({ type: "retry-native-host" });
+    expect(chrome.tabs.create).toHaveBeenCalledWith({
+      url: "https://github.com/dantraynor/tailchrome/releases/latest/download/tailscale-browser-ext-windows-amd64.exe",
+    });
+  });
+});

--- a/packages/shared/src/popup/views/install-helpers.ts
+++ b/packages/shared/src/popup/views/install-helpers.ts
@@ -2,14 +2,75 @@ import { copyToClipboard, showToast, detectPlatform } from "../utils";
 import { EXPECTED_HOST_VERSION } from "../../constants";
 import { iconPackage, iconRefresh } from "../icons";
 import { renderUiSurfaceFooter } from "../components/ui-surface-row";
+import { sendMessage } from "../popup";
 
-type Platform = "macos" | "linux" | "windows" | "unknown";
+export type Platform = "macos" | "linux" | "windows" | "unknown";
+
+export interface InstallerDownload {
+  filename: string | null;
+  label: string;
+  url: string;
+}
 
 const RELEASE_BASE =
   "https://github.com/dantraynor/tailchrome/releases/latest/download";
+const RELEASE_PAGE = "https://github.com/dantraynor/tailchrome/releases/latest";
+
+function releaseAssetURL(filename: string): string {
+  return `${RELEASE_BASE}/${filename}`;
+}
 
 /**
- * Returns the filename of the native host binary for the detected platform.
+ * Returns package-first installer downloads for the detected platform.
+ */
+export function installerDownloads(platform: Platform): InstallerDownload[] {
+  if (platform === "macos") {
+    const filename = "tailchrome-helper-macos.pkg";
+    return [
+      {
+        filename,
+        label: "Download macOS installer (.pkg)",
+        url: releaseAssetURL(filename),
+      },
+    ];
+  }
+  if (platform === "windows") {
+    const filename = "tailchrome-helper-windows-x64.msi";
+    return [
+      {
+        filename,
+        label: "Download Windows installer (.msi)",
+        url: releaseAssetURL(filename),
+      },
+    ];
+  }
+  if (platform === "linux") {
+    const deb = "tailchrome-helper-linux-amd64.deb";
+    const rpm = "tailchrome-helper-linux-x86_64.rpm";
+    return [
+      {
+        filename: deb,
+        label: "Download .deb (Debian/Ubuntu)",
+        url: releaseAssetURL(deb),
+      },
+      {
+        filename: rpm,
+        label: "Download .rpm (Fedora/RHEL)",
+        url: releaseAssetURL(rpm),
+      },
+    ];
+  }
+  return [
+    {
+      filename: null,
+      label: "Open latest release",
+      url: RELEASE_PAGE,
+    },
+  ];
+}
+
+/**
+ * Returns the filename of the raw native host binary for advanced fallback use.
  */
 export function binaryFilename(platform: Platform): string | null {
   if (platform === "windows") {
@@ -26,20 +87,19 @@ export function binaryFilename(platform: Platform): string | null {
 }
 
 /**
- * Returns the download URL for the native host binary for the detected platform.
- * Falls back to the releases page if platform is unknown.
+ * Returns the download URL for the raw native host binary.
  */
 export function buildDownloadURL(platform: Platform): string {
   const filename = binaryFilename(platform);
   if (filename) {
-    return `${RELEASE_BASE}/${filename}`;
+    return releaseAssetURL(filename);
   }
-  return "https://github.com/dantraynor/tailchrome/releases/latest";
+  return RELEASE_PAGE;
 }
 
 /**
- * Returns the simple terminal command to run after downloading.
- * The binary auto-installs with the hardcoded extension ID -- no flags needed.
+ * Returns the command to run after downloading the raw binary fallback.
+ * The binary auto-installs with the hardcoded extension IDs.
  */
 export function buildRunCommand(platform: Platform): string | null {
   const filename = binaryFilename(platform);
@@ -49,8 +109,17 @@ export function buildRunCommand(platform: Platform): string | null {
   if (platform === "windows") {
     return `cd %USERPROFILE%\\Downloads && .\\${filename}`;
   }
-  // macOS/Linux: need chmod +x since browser downloads don't preserve exec bit
   return `chmod +x ~/Downloads/${filename} && ~/Downloads/${filename}`;
+}
+
+/**
+ * Asks the background service worker to poll native-host discovery after the
+ * user starts an installer. The background owns the retry timers: opening the
+ * download tab closes the popup surface, which would destroy any timers
+ * scheduled in this document before they fire.
+ */
+export function requestNativeHostRetries(): void {
+  sendMessage({ type: "retry-native-host" });
 }
 
 /**
@@ -83,7 +152,6 @@ export function renderInstallFlow(
   const content = document.createElement("div");
   content.className = "centered-view";
 
-  // Icon
   const icon = document.createElement("div");
   icon.className = "centered-view-icon";
   const iconEl = document.createElement("span");
@@ -91,12 +159,10 @@ export function renderInstallFlow(
   iconEl.appendChild(opts.mode === "install" ? iconPackage() : iconRefresh());
   icon.appendChild(iconEl);
 
-  // Title
   const title = document.createElement("h2");
   title.className = "centered-view-title";
   title.textContent = opts.mode === "install" ? "Quick Setup" : "Update Available";
 
-  // Subtitle
   const description = document.createElement("p");
   description.className = "centered-view-text";
   description.textContent =
@@ -108,7 +174,6 @@ export function renderInstallFlow(
   content.appendChild(title);
   content.appendChild(description);
 
-  // Version info (update mode only)
   if (opts.mode === "update") {
     const versionInfo = document.createElement("p");
     versionInfo.className = "centered-view-text version-info";
@@ -118,200 +183,166 @@ export function renderInstallFlow(
   }
 
   const platform = detectPlatform();
-
-  if (platform === "macos" && opts.mode === "install") {
-    const pkgUrl = `${RELEASE_BASE}/tailchrome-helper-macos.pkg`;
-    const cta = document.createElement("div");
-    cta.className = "install-pkg-cta";
-    const pkgLink = document.createElement("a");
-    pkgLink.className = "btn btn-primary btn-link";
-    pkgLink.href = pkgUrl;
-    pkgLink.rel = "noopener";
-    pkgLink.textContent = "Download macOS installer (.pkg)";
-    pkgLink.addEventListener("click", (e) => {
-      e.preventDefault();
-      chrome.tabs.create({ url: pkgUrl });
-    });
-    cta.appendChild(pkgLink);
-    content.appendChild(cta);
-    const pkgHint = document.createElement("p");
-    pkgHint.className = "centered-view-text install-pkg-hint";
-    pkgHint.textContent =
-      "Open the downloaded package, then launch Tailchrome Helper from Applications once. Come back here when done.";
-    content.appendChild(pkgHint);
-  }
-
-  const downloadURL = buildDownloadURL(platform);
-  const filename = binaryFilename(platform);
+  const downloads = installerDownloads(platform);
+  const filename = downloads[0]?.filename ?? null;
   const runCmd = buildRunCommand(platform);
 
-  // Steps container
   const steps = document.createElement("div");
   steps.className = "install-steps";
 
   const step1 = createStep("1");
   step1.label.textContent =
-    platform === "macos" && opts.mode === "install"
-      ? "Alternative: raw binary (advanced)"
-      : "Download the helper app";
+    platform === "unknown"
+      ? "Download the helper app"
+      : "Download the helper installer";
 
-  const downloadBtn = document.createElement("a");
-  downloadBtn.className = "btn btn-primary btn-link";
-  downloadBtn.href = downloadURL;
-  downloadBtn.target = "_blank";
-  downloadBtn.rel = "noopener";
-
-  if (opts.mode === "update") {
-    downloadBtn.textContent = "Download Update";
-  } else if (platform === "unknown") {
-    downloadBtn.textContent = "Download";
-  } else {
-    downloadBtn.textContent = `Download for ${platformLabel(platform)}`;
+  const cta = document.createElement("div");
+  cta.className = "install-pkg-cta";
+  for (const download of downloads) {
+    cta.appendChild(createDownloadButton(download));
   }
-
-  // After clicking download, update button to hint at next step
-  downloadBtn.addEventListener("click", () => {
-    setTimeout(() => {
-      downloadBtn.textContent = "Downloaded? Continue below \u2193";
-      downloadBtn.classList.remove("btn-primary");
-      downloadBtn.classList.add("btn-secondary");
-    }, 500);
-  });
-
   step1.content.appendChild(step1.label);
-  step1.content.appendChild(downloadBtn);
+  step1.content.appendChild(cta);
   steps.appendChild(step1.root);
 
-  if (platform === "unknown") {
-    const step2 = createStep("2");
-    step2.label.textContent = "Run the downloaded file";
-    const body = document.createElement("div");
-    body.className = "install-step-body";
-    body.textContent = "Open the downloaded file to complete setup.";
-    step2.content.appendChild(step2.label);
-    step2.content.appendChild(body);
-    steps.appendChild(step2.root);
-  } else if (platform === "windows") {
-    const step2 = createStep("2");
-    step2.label.textContent = "Open the downloaded file";
+  const step2 = createStep("2");
+  step2.label.textContent =
+    platform === "unknown" ? "Open the downloaded file" : "Run the installer";
+  step2.content.appendChild(step2.label);
+  step2.content.appendChild(createInstallInstructions(platform, filename, opts.mode));
+  steps.appendChild(step2.root);
 
-    const body = document.createElement("div");
-    body.className = "install-step-body";
-    body.appendChild(document.createTextNode("Find "));
-    const strong = document.createElement("strong");
-    strong.textContent = filename ?? "the downloaded file";
-    body.appendChild(strong);
-    body.appendChild(
-      document.createTextNode(" in your Downloads folder and double-click it."),
-    );
-
-    const hint = document.createElement("div");
-    hint.className = "install-step-hint";
-    hint.textContent =
-      'You can close the window after it says "installed successfully".';
-
-    step2.content.appendChild(step2.label);
-    step2.content.appendChild(body);
-    step2.content.appendChild(hint);
-
-    // When updating, the previous helper may still be running and connected, so
-    // the popup can keep showing "Update Available" until the browser respawns
-    // the host. Tell the user how to force that.
-    if (opts.mode === "update") {
-      const restartHint = document.createElement("div");
-      restartHint.className = "install-step-hint";
-      restartHint.textContent =
-        'If it still says "Update Available" after that, fully quit your browser (not just the window) and reopen it.';
-      step2.content.appendChild(restartHint);
-    }
-
-    steps.appendChild(step2.root);
-  } else {
-    // macOS / Linux: need terminal
-    const step2 = createStep("2");
-    step2.label.textContent = "Run the installer";
-
-    const body = document.createElement("div");
-    body.className = "install-step-body";
-
-    if (platform === "macos") {
-      body.appendChild(document.createTextNode("Open Terminal (press "));
-      const kbd1 = document.createElement("strong");
-      kbd1.textContent = "Cmd + Space";
-      body.appendChild(kbd1);
-      body.appendChild(document.createTextNode(", type "));
-      const kbd2 = document.createElement("strong");
-      kbd2.textContent = "Terminal";
-      body.appendChild(kbd2);
-      body.appendChild(
-        document.createTextNode(", press Enter), then paste this command:"),
-      );
-    } else {
-      body.textContent = "Open a terminal and paste this command:";
-    }
-
-    step2.content.appendChild(step2.label);
-    step2.content.appendChild(body);
-
-    if (runCmd) {
-      step2.content.appendChild(createCodeBlock(runCmd));
-    }
-
-    const hint = document.createElement("div");
-    hint.className = "install-step-hint";
-    hint.textContent =
-      platform === "macos"
-        ? 'No admin password needed. Close Terminal after it says "installed successfully".'
-        : "No sudo needed.";
-    step2.content.appendChild(hint);
-
-    if (platform === "macos") {
-      const gatekeeper = document.createElement("div");
-      gatekeeper.className = "install-step-hint";
-      gatekeeper.textContent =
-        "If macOS says the helper can’t be checked for malware: Control-click the file in Finder → Open, confirm Open. Or System Settings → Privacy & Security → Open Anyway. Then run the Terminal command again if needed.";
-      step2.content.appendChild(gatekeeper);
-    }
-
-    steps.appendChild(step2.root);
-
-    const step3 = createStep("3");
-    step3.label.textContent = "Finish";
-    const doneBody = document.createElement("div");
-    doneBody.className = "install-step-body";
-    doneBody.textContent =
-      "Click this extension’s toolbar icon again. We’ll connect to the helper automatically.";
-    step3.content.appendChild(step3.label);
-    step3.content.appendChild(doneBody);
-    steps.appendChild(step3.root);
-  }
+  const step3 = createStep("3");
+  step3.label.textContent = "Finish";
+  const doneBody = document.createElement("div");
+  doneBody.className = "install-step-body";
+  doneBody.textContent =
+    "Leave this popup open or reopen it after setup. Tailchrome will connect automatically.";
+  step3.content.appendChild(step3.label);
+  step3.content.appendChild(doneBody);
+  steps.appendChild(step3.root);
 
   content.appendChild(steps);
 
-  // Advanced toggle for power users (Windows only -- macOS/Linux already show the command)
-  if (platform === "windows" && runCmd) {
-    const advancedToggle = document.createElement("button");
-    advancedToggle.className = "install-advanced-toggle";
-    advancedToggle.textContent = "Show terminal command";
-
-    const advancedSection = document.createElement("div");
-    advancedSection.className = "install-advanced-section hidden";
-    advancedSection.appendChild(createCodeBlock(runCmd));
-
-    advancedToggle.addEventListener("click", () => {
-      const isHidden = advancedSection.classList.toggle("hidden");
-      advancedToggle.textContent = isHidden
-        ? "Show terminal command"
-        : "Hide terminal command";
-    });
-
-    content.appendChild(advancedToggle);
-    content.appendChild(advancedSection);
+  if (runCmd) {
+    content.appendChild(createRawBinaryFallback(platform, runCmd));
   }
 
   view.appendChild(content);
   renderUiSurfaceFooter(view);
   root.appendChild(view);
+}
+
+function createDownloadButton(download: InstallerDownload): HTMLElement {
+  const link = document.createElement("a");
+  link.className = "btn btn-primary btn-link";
+  link.href = download.url;
+  link.target = "_blank";
+  link.rel = "noopener";
+  link.textContent = download.label;
+  link.addEventListener("click", (e) => {
+    e.preventDefault();
+    requestNativeHostRetries();
+    chrome.tabs.create({ url: download.url });
+    setTimeout(() => {
+      link.textContent = "Downloaded? Run it next";
+      link.classList.remove("btn-primary");
+      link.classList.add("btn-secondary");
+    }, 500);
+  });
+  return link;
+}
+
+function createInstallInstructions(
+  platform: Platform,
+  filename: string | null,
+  mode: "install" | "update",
+): HTMLElement {
+  const wrapper = document.createElement("div");
+
+  const body = document.createElement("div");
+  body.className = "install-step-body";
+
+  if (platform === "macos") {
+    body.textContent =
+      "Open the downloaded package and complete the installer. Setup runs automatically when the package finishes.";
+  } else if (platform === "windows") {
+    body.appendChild(document.createTextNode("Find "));
+    const strong = document.createElement("strong");
+    strong.textContent = filename ?? "the downloaded installer";
+    body.appendChild(strong);
+    body.appendChild(
+      document.createTextNode(" in your Downloads folder and double-click it."),
+    );
+  } else if (platform === "linux") {
+    body.textContent =
+      "Install the package with your system installer, or use one of these commands:";
+  } else {
+    body.textContent = "Open the downloaded file to complete setup.";
+  }
+
+  wrapper.appendChild(body);
+
+  if (platform === "linux") {
+    wrapper.appendChild(createCodeBlock("sudo apt install ~/Downloads/tailchrome-helper-linux-amd64.deb"));
+    wrapper.appendChild(createCodeBlock("sudo dnf install ~/Downloads/tailchrome-helper-linux-x86_64.rpm"));
+  }
+
+  const hint = document.createElement("div");
+  hint.className = "install-step-hint";
+  if (platform === "macos") {
+    hint.textContent =
+      "If setup needs repair later, open Tailchrome Helper from Applications.";
+  } else if (platform === "windows" && mode === "update") {
+    hint.textContent =
+      'If it still says "Update Available" after setup, fully quit your browser and reopen it.';
+  } else if (platform === "linux") {
+    hint.textContent =
+      "The package registers system-wide browser manifests for Chrome, Chromium, Edge, and Firefox.";
+  } else {
+    hint.textContent =
+      `The ${platformLabel(platform)} helper registers itself with supported browsers.`;
+  }
+  wrapper.appendChild(hint);
+
+  return wrapper;
+}
+
+function createRawBinaryFallback(platform: Platform, runCmd: string): HTMLElement {
+  const container = document.createElement("div");
+
+  const advancedToggle = document.createElement("button");
+  advancedToggle.className = "install-advanced-toggle";
+  advancedToggle.textContent = "Show raw binary fallback";
+
+  const advancedSection = document.createElement("div");
+  advancedSection.className = "install-advanced-section hidden";
+
+  const download = document.createElement("a");
+  download.className = "btn btn-secondary btn-link";
+  download.href = buildDownloadURL(platform);
+  download.target = "_blank";
+  download.rel = "noopener";
+  download.textContent = "Download raw helper binary";
+  download.addEventListener("click", (e) => {
+    e.preventDefault();
+    requestNativeHostRetries();
+    chrome.tabs.create({ url: download.href });
+  });
+
+  advancedSection.appendChild(download);
+  advancedSection.appendChild(createCodeBlock(runCmd));
+
+  advancedToggle.addEventListener("click", () => {
+    const isHidden = advancedSection.classList.toggle("hidden");
+    advancedToggle.textContent = isHidden
+      ? "Show raw binary fallback"
+      : "Hide raw binary fallback";
+  });
+
+  container.appendChild(advancedToggle);
+  container.appendChild(advancedSection);
+  return container;
 }
 
 /**
@@ -375,20 +406,16 @@ function createCodeBlock(command: string): HTMLElement {
  * UA string, so we also check the platform string.
  */
 function detectArch(): "arm64" | "amd64" {
-  // Chromium exposes architecture as a low-entropy hint
   const uaData = (navigator as unknown as { userAgentData?: { architecture?: string } }).userAgentData;
   if (uaData?.architecture === "arm") {
     return "arm64";
   }
 
-  // Check platform (works in Firefox — "MacIntel" even on ARM, but "aarch64" on Linux ARM)
   const platform = navigator.platform?.toLowerCase() ?? "";
   if (platform.includes("aarch64") || platform.includes("arm")) {
     return "arm64";
   }
 
-  // On macOS, check if running under Rosetta by looking for Apple Silicon indicators
-  // navigator.platform is "MacIntel" on both Intel and ARM Macs, so use GL renderer
   try {
     const canvas = document.createElement("canvas");
     const gl = canvas.getContext("webgl");
@@ -397,13 +424,12 @@ function detectArch(): "arm64" | "amd64" {
       if (debugInfo) {
         const renderer = gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL);
         if (typeof renderer === "string" && renderer.includes("Apple")) {
-          // Apple GPU = Apple Silicon (Intel Macs use AMD/Intel GPUs)
           return "arm64";
         }
       }
     }
   } catch {
-    // Canvas not available in some contexts, fall through
+    // Canvas may be unavailable in test or restricted extension contexts.
   }
 
   return "amd64";

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -256,6 +256,7 @@ export type BackgroundMessage =
   | { type: "toggle" }
   | { type: "login" }
   | { type: "logout" }
+  | { type: "retry-native-host" }
   | { type: "set-exit-node"; nodeID: string }
   | { type: "clear-exit-node" }
   | SetPrefMessage

--- a/packaging/linux/README.md
+++ b/packaging/linux/README.md
@@ -1,0 +1,30 @@
+# Linux Helper packages (.deb/.rpm)
+
+`build-packages.sh` produces:
+
+- `dist/tailchrome-helper-linux-amd64.deb`
+- `dist/tailchrome-helper-linux-x86_64.rpm`
+
+The packages install the helper binary at `/usr/lib/tailchrome/tailscale-browser-ext` and system-wide native messaging manifests for:
+
+- Chrome: `/etc/opt/chrome/native-messaging-hosts/`
+- Chromium: `/etc/chromium/native-messaging-hosts/`
+- Edge: `/etc/opt/edge/native-messaging-hosts/`
+- Firefox: `/usr/lib/mozilla/native-messaging-hosts/` (the .rpm additionally installs to `/usr/lib64/mozilla/native-messaging-hosts/`, where Fedora/RHEL Firefox builds look)
+
+For additional Chromium-family browsers that do not support these system manifest locations, use the raw helper binary fallback from the release page. The raw binary runs `-install-now` for the current user and writes per-user manifests.
+
+## Build
+
+Install nFPM first:
+
+```bash
+go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest
+```
+
+Then build from the repository root:
+
+```bash
+make host-all
+./packaging/linux/build-packages.sh
+```

--- a/packaging/linux/build-packages.sh
+++ b/packaging/linux/build-packages.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+VERSION="${VERSION:-$(git describe --tags --always 2>/dev/null || echo dev)}"
+VERSION_PKG="${VERSION#v}"
+VERSION_PKG="${VERSION_PKG%%-*}"
+if [[ -z "$VERSION_PKG" || "$VERSION_PKG" == "dev" ]]; then
+  VERSION_PKG="0.0.0"
+fi
+
+NFPM="${NFPM:-}"
+if [[ -z "$NFPM" ]] && command -v nfpm >/dev/null 2>&1; then
+  NFPM="$(command -v nfpm)"
+fi
+if [[ -z "$NFPM" ]] && command -v go >/dev/null 2>&1; then
+  GOPATH="$(go env GOPATH 2>/dev/null || true)"
+  if [[ -n "$GOPATH" && -x "$GOPATH/bin/nfpm" ]]; then
+    NFPM="$GOPATH/bin/nfpm"
+  fi
+fi
+if [[ -z "$NFPM" || ! -x "$NFPM" ]]; then
+  echo "nFPM is required. Install it with: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest" >&2
+  exit 1
+fi
+
+if [[ ! -f "$ROOT/dist/tailscale-browser-ext-linux-amd64" ]]; then
+  echo "Missing dist/tailscale-browser-ext-linux-amd64. Run make host-all first." >&2
+  exit 1
+fi
+
+mkdir -p "$ROOT/dist"
+
+echo "Building Linux packages (version $VERSION_PKG)..."
+VERSION="$VERSION_PKG" "$NFPM" package \
+  -f "$ROOT/packaging/linux/nfpm.yaml" \
+  -p deb \
+  -t "$ROOT/dist/tailchrome-helper-linux-amd64.deb"
+
+VERSION="$VERSION_PKG" "$NFPM" package \
+  -f "$ROOT/packaging/linux/nfpm.yaml" \
+  -p rpm \
+  -t "$ROOT/dist/tailchrome-helper-linux-x86_64.rpm"
+
+echo "Done:"
+echo "  $ROOT/dist/tailchrome-helper-linux-amd64.deb"
+echo "  $ROOT/dist/tailchrome-helper-linux-x86_64.rpm"

--- a/packaging/linux/native-messaging/com.tailscale.browserext.chrome.json
+++ b/packaging/linux/native-messaging/com.tailscale.browserext.chrome.json
@@ -1,0 +1,9 @@
+{
+  "name": "com.tailscale.browserext.chrome",
+  "description": "Tailscale Browser Extension Native Messaging Host",
+  "path": "/usr/lib/tailchrome/tailscale-browser-ext",
+  "type": "stdio",
+  "allowed_origins": [
+    "chrome-extension://bhfeceecialgilpedkoflminjgcjljll/"
+  ]
+}

--- a/packaging/linux/native-messaging/com.tailscale.browserext.firefox.json
+++ b/packaging/linux/native-messaging/com.tailscale.browserext.firefox.json
@@ -1,0 +1,9 @@
+{
+  "name": "com.tailscale.browserext.firefox",
+  "description": "Tailscale Browser Extension Native Messaging Host",
+  "path": "/usr/lib/tailchrome/tailscale-browser-ext",
+  "type": "stdio",
+  "allowed_extensions": [
+    "tailchrome@tesseras.org"
+  ]
+}

--- a/packaging/linux/nfpm.yaml
+++ b/packaging/linux/nfpm.yaml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=https://nfpm.goreleaser.com/schema.json
+name: tailchrome-helper
+arch: amd64
+platform: linux
+version: ${VERSION}
+version_schema: semver
+section: net
+priority: optional
+maintainer: Daniel Traynor
+description: Native helper for the Tailchrome browser extension.
+vendor: Tesseras
+homepage: https://github.com/dantraynor/tailchrome
+license: MIT
+contents:
+  - src: dist/tailscale-browser-ext-linux-amd64
+    dst: /usr/lib/tailchrome/tailscale-browser-ext
+    file_info:
+      mode: 0755
+  - src: packaging/linux/native-messaging/com.tailscale.browserext.chrome.json
+    dst: /etc/opt/chrome/native-messaging-hosts/com.tailscale.browserext.chrome.json
+    file_info:
+      mode: 0644
+  - src: packaging/linux/native-messaging/com.tailscale.browserext.chrome.json
+    dst: /etc/chromium/native-messaging-hosts/com.tailscale.browserext.chrome.json
+    file_info:
+      mode: 0644
+  - src: packaging/linux/native-messaging/com.tailscale.browserext.chrome.json
+    dst: /etc/opt/edge/native-messaging-hosts/com.tailscale.browserext.chrome.json
+    file_info:
+      mode: 0644
+  - src: packaging/linux/native-messaging/com.tailscale.browserext.firefox.json
+    dst: /usr/lib/mozilla/native-messaging-hosts/com.tailscale.browserext.firefox.json
+    file_info:
+      mode: 0644
+  # Fedora/RHEL Firefox builds use libdir /usr/lib64 and only read system-wide
+  # manifests from there.
+  - src: packaging/linux/native-messaging/com.tailscale.browserext.firefox.json
+    dst: /usr/lib64/mozilla/native-messaging-hosts/com.tailscale.browserext.firefox.json
+    file_info:
+      mode: 0644
+    packager: rpm
+rpm:
+  group: Applications/Internet

--- a/packaging/macos/README.md
+++ b/packaging/macos/README.md
@@ -4,8 +4,9 @@ The script `build-pkg.sh` produces `dist/tailchrome-helper-macos.pkg`, which ins
 
 1. **Universal** `tailscale-browser-ext` at  
    `/Library/Application Support/Tailscale/BrowserExt/tailscale-browser-ext`
-2. **Tailchrome Helper** in `/Applications` — a small app the user opens once; it runs  
-   `tailscale-browser-ext -install-now` to register Chrome/Firefox native messaging for the **current user** (no Terminal).
+2. **Tailchrome Helper** in `/Applications` — a repair/re-run fallback app.
+
+The package postinstall script runs `tailscale-browser-ext -install-now` for the logged-in console user, so normal installs do not require opening the app manually.
 
 ## Unsigned builds
 
@@ -43,4 +44,4 @@ Store Apple credentials in GitHub Actions secrets for automated release; do not 
 
 ## GitHub Actions
 
-The release workflow runs `build-pkg.sh` on `macos-latest` and uploads the `.pkg` to the GitHub Release. Add repository secrets and wire optional signing/notarization steps when you are ready.
+The release workflow runs `build-pkg.sh` on `macos-latest`, signs and notarizes the package with the configured Apple secrets, and uploads the `.pkg` to the GitHub Release.

--- a/packaging/macos/build-pkg.sh
+++ b/packaging/macos/build-pkg.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Build tailscale-browser-ext as a universal macOS binary, then a flat .pkg that installs:
 #   - /Library/Application Support/Tailscale/BrowserExt/tailscale-browser-ext
-#   - /Applications/Tailchrome Helper.app  (runs -install-now for the logged-in user)
+#   - /Applications/Tailchrome Helper.app  (repair/re-run fallback)
+# and runs a postinstall script that registers native messaging for the logged-in user.
 #
 # Usage: from repo root, ./packaging/macos/build-pkg.sh
 # Optional: VERSION=1.2.3 ./packaging/macos/build-pkg.sh
@@ -10,6 +11,7 @@
 #   packaging/macos/sign-component.sh  (see packaging/macos/README.md)
 
 set -euo pipefail
+export COPYFILE_DISABLE=1
 
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 cd "$ROOT"
@@ -30,7 +32,7 @@ STAGE="$ROOT/packaging/macos/.pkg-stage-$$"
 cleanup() { rm -rf "$STAGE"; }
 trap cleanup EXIT
 
-mkdir -p "$DIST_DIR" "$STAGE/pkgroot/Library/Application Support/Tailscale/BrowserExt" "$STAGE/pkgroot/Applications"
+mkdir -p "$DIST_DIR" "$STAGE/pkgroot/Library/Application Support/Tailscale/BrowserExt" "$STAGE/pkgroot/Applications" "$STAGE/scripts"
 
 echo "Building universal binary (version $VERSION)..."
 (
@@ -47,6 +49,10 @@ echo "Staging Tailchrome Helper.app..."
 cp -R "$ROOT/packaging/macos/TailchromeHelper.app" "$STAGE/pkgroot/Applications/Tailchrome Helper.app"
 chmod 755 "$STAGE/pkgroot/Applications/Tailchrome Helper.app/Contents/MacOS/tailchrome-helper"
 
+echo "Staging postinstall script..."
+cp "$ROOT/packaging/macos/scripts/postinstall" "$STAGE/scripts/postinstall"
+chmod 755 "$STAGE/scripts/postinstall"
+
 # Optional: Developer ID signing (requires Apple Developer Program)
 if [[ -n "${MACOS_SIGN_APPLICATION_IDENTITY:-}" ]]; then
   echo "Signing binaries with: $MACOS_SIGN_APPLICATION_IDENTITY"
@@ -55,6 +61,18 @@ if [[ -n "${MACOS_SIGN_APPLICATION_IDENTITY:-}" ]]; then
   codesign --force --options runtime --timestamp --deep --sign "$MACOS_SIGN_APPLICATION_IDENTITY" \
     "$STAGE/pkgroot/Applications/Tailchrome Helper.app"
 fi
+
+# Avoid packaging AppleDouble sidecar files when local files have extended
+# attributes or resource forks. Run after signing too, because signing tools can
+# touch extended attributes.
+if command -v xattr >/dev/null 2>&1; then
+  xattr -cr "$STAGE/pkgroot" "$STAGE/scripts"
+fi
+if command -v dot_clean >/dev/null 2>&1; then
+  dot_clean -m "$STAGE/pkgroot"
+  dot_clean -m "$STAGE/scripts"
+fi
+find "$STAGE/pkgroot" "$STAGE/scripts" -name '._*' -type f -delete
 
 PKG_PATH="$DIST_DIR/$OUT_NAME"
 echo "Writing $PKG_PATH ..."
@@ -72,6 +90,11 @@ pkgbuild \
   --install-location / \
   --ownership recommended \
   --component-plist "$STAGE/component.plist" \
+  --scripts "$STAGE/scripts" \
+  --filter '\.DS_Store$' \
+  --filter '(^|/)\.svn($|/)' \
+  --filter '(^|/)CVS($|/)' \
+  --filter '(^|/)\._[^/]*$' \
   "$PKG_PATH"
 
 if [[ -n "${MACOS_SIGN_INSTALLER_IDENTITY:-}" ]]; then

--- a/packaging/macos/scripts/postinstall
+++ b/packaging/macos/scripts/postinstall
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euo pipefail
+
+BIN="/Library/Application Support/Tailscale/BrowserExt/tailscale-browser-ext"
+
+if [[ ! -x "$BIN" ]]; then
+  echo "Tailchrome helper binary is missing or not executable: $BIN" >&2
+  exit 1
+fi
+
+console_user="$(/usr/bin/stat -f "%Su" /dev/console 2>/dev/null || true)"
+if [[ -z "$console_user" || "$console_user" == "root" || "$console_user" == "_mbsetupuser" ]]; then
+  echo "No logged-in console user found; skipping per-user native messaging registration."
+  exit 0
+fi
+
+uid="$(/usr/bin/id -u "$console_user")"
+home_dir="$(/usr/bin/dscl . -read "/Users/$console_user" NFSHomeDirectory 2>/dev/null | /usr/bin/awk '{print $2}' || true)"
+if [[ -z "$home_dir" || ! -d "$home_dir" ]]; then
+  home_dir="$(eval echo "~$console_user")"
+fi
+
+echo "Registering Tailchrome native messaging hosts for $console_user..."
+/bin/launchctl asuser "$uid" /usr/bin/sudo -u "$console_user" \
+  /usr/bin/env HOME="$home_dir" "$BIN" -install-now
+
+exit 0

--- a/packaging/windows/Product.wxs
+++ b/packaging/windows/Product.wxs
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package
+    Name="Tailchrome Helper"
+    Manufacturer="Tesseras"
+    Version="$(var.Version)"
+    UpgradeCode="4ADE97ED-5BE9-43D2-B426-AAD1C67CEFF8"
+    Scope="perUser">
+    <MajorUpgrade DowngradeErrorMessage="A newer version of Tailchrome Helper is already installed." />
+    <MediaTemplate EmbedCab="yes" />
+
+    <StandardDirectory Id="LocalAppDataFolder">
+      <Directory Id="TailscaleFolder" Name="Tailscale">
+        <Directory Id="BrowserExtFolder" Name="BrowserExt">
+          <Directory Id="InstallerFolder" Name="installer">
+            <Component
+              Id="HelperBinary"
+              Guid="C4D395ED-654A-4339-B3CC-2AF419E273E7">
+              <File
+                Id="HelperExe"
+                Source="$(var.HelperExe)"
+                Name="tailscale-browser-ext.exe"
+                KeyPath="yes" />
+            </Component>
+          </Directory>
+        </Directory>
+      </Directory>
+    </StandardDirectory>
+
+    <Feature Id="MainFeature" Title="Tailchrome Helper" Level="1">
+      <ComponentRef Id="HelperBinary" />
+    </Feature>
+
+    <CustomAction
+      Id="InstallNativeHost"
+      FileRef="HelperExe"
+      ExeCommand="-install-now"
+      Execute="deferred"
+      Impersonate="yes"
+      Return="check" />
+
+    <!-- The MSI only tracks the staged exe; -install-now writes the runtime
+         copy and HKCU registrations outside the MSI's file/registry tables,
+         so uninstall must deregister them explicitly. Skipped during major
+         upgrades, where the new version rewrites the registrations anyway. -->
+    <CustomAction
+      Id="UninstallNativeHost"
+      FileRef="HelperExe"
+      ExeCommand="-uninstall"
+      Execute="deferred"
+      Impersonate="yes"
+      Return="ignore" />
+
+    <InstallExecuteSequence>
+      <Custom Action="InstallNativeHost" After="InstallFiles" Condition="NOT REMOVE" />
+      <Custom Action="UninstallNativeHost" Before="RemoveFiles" Condition="REMOVE=&quot;ALL&quot; AND NOT UPGRADINGPRODUCTCODE" />
+    </InstallExecuteSequence>
+  </Package>
+</Wix>

--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -1,0 +1,29 @@
+# Windows Helper installer (.msi)
+
+`build-msi.ps1` produces `dist/tailchrome-helper-windows-x64.msi`.
+
+The MSI is per-user. It installs a staged helper executable at:
+
+```text
+%LOCALAPPDATA%\Tailscale\BrowserExt\installer\tailscale-browser-ext.exe
+```
+
+After files are installed, the MSI runs that staged executable with `-install-now`. The Go installer then copies the browser-launched helper to `%LOCALAPPDATA%\Tailscale\BrowserExt\tailscale-browser-ext.exe` and writes HKCU native messaging registrations for supported Chromium-family browsers and Firefox.
+
+On uninstall, the MSI runs the staged executable with `-uninstall` to remove those manifests and HKCU registrations. The runtime copy of the exe stays on disk (a browser may still be running it) but is inert once deregistered. Major upgrades skip this step; the new version rewrites the registrations instead.
+
+## Build
+
+Install WiX first:
+
+```powershell
+dotnet tool install --global wix --version 6.0.2
+```
+
+Then build from the repository root:
+
+```powershell
+.\packaging\windows\build-msi.ps1 -Version v0.1.11
+```
+
+The release workflow may sign the MSI when Windows signing secrets are configured. Unsigned local builds still work for manual testing.

--- a/packaging/windows/build-msi.ps1
+++ b/packaging/windows/build-msi.ps1
@@ -1,0 +1,45 @@
+param(
+  [string]$Version = "",
+  [string]$HelperExe = "",
+  [string]$OutPath = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+$Root = Resolve-Path (Join-Path $PSScriptRoot "..\..")
+if ([string]::IsNullOrWhiteSpace($Version)) {
+  $Version = (git -C $Root describe --tags --always 2>$null)
+  if ([string]::IsNullOrWhiteSpace($Version)) {
+    $Version = "dev"
+  }
+}
+
+$VersionMsi = $Version.TrimStart("v").Split("-")[0]
+if ($VersionMsi -notmatch "^\d+\.\d+\.\d+$") {
+  $VersionMsi = "0.0.0"
+}
+
+if ([string]::IsNullOrWhiteSpace($HelperExe)) {
+  $HelperExe = Join-Path $Root "dist\tailscale-browser-ext-windows-amd64.exe"
+}
+$HelperExe = Resolve-Path $HelperExe
+
+if ([string]::IsNullOrWhiteSpace($OutPath)) {
+  $OutPath = Join-Path $Root "dist\tailchrome-helper-windows-x64.msi"
+}
+New-Item -ItemType Directory -Force -Path (Split-Path -Parent $OutPath) | Out-Null
+
+if (-not (Get-Command wix -ErrorAction SilentlyContinue)) {
+  throw "WiX is required. Install it with: dotnet tool install --global wix --version 6.0.2"
+}
+
+$Wxs = Join-Path $PSScriptRoot "Product.wxs"
+Write-Host "Building Windows MSI $OutPath (version $VersionMsi)..."
+wix build `
+  -arch x64 `
+  -d "Version=$VersionMsi" `
+  -d "HelperExe=$HelperExe" `
+  $Wxs `
+  -out $OutPath
+
+Write-Host "Done: $OutPath"


### PR DESCRIPTION
## What

Ships the native-messaging helper as OS-native installers — a signed/notarized macOS `.pkg`, a per-user Windows `.msi` (WiX), and Linux `.deb`/`.rpm` (nfpm) — with new release-workflow packaging jobs, Makefile targets, and docs to match. The popup install/update flow now offers the platform installer first (raw binary behind an advanced fallback), and downloads schedule background native-host discovery retries that are guarded so a live host connection is never bounced. Helper uninstall now also removes the staged runtime binary instead of orphaning it.

## Why

Installing the helper previously meant downloading a raw binary and running it by hand; native packages make install and update a double-click and register browser manifests reliably.

## How to Test

- [ ] `pnpm -r test && pnpm -r typecheck`, and `go test ./...` in `host/`
- [ ] `make macos-pkg` / `make windows-msi` / `make linux-packages` produce installers whose filenames match the popup's download links
- [ ] Install a package, open the popup: the needs-install view offers the installer and connects after setup without restarting the browser
- [ ] With a connected but outdated helper, click Download and confirm the existing connection is not dropped while the old helper keeps running