### PR TITLE
chore: release 0.1.12

### DIFF
--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -2,7 +2,7 @@
 
 > Access your Tailscale network directly from your browser. No system VPN required.
 
-**Version:** 0.1.11 (native host) | Manifest V3
+**Version:** 0.1.12 (native host) | Manifest V3
 **Browsers:** Chrome, Firefox
 **Platforms:** macOS (amd64, arm64), Linux (amd64), Windows (amd64)
 **License:** MIT
@@ -329,7 +329,7 @@ Defined in `packages/shared/src/constants.ts`:
 | `RECONNECT_BASE_MS`     | `1000`                              | Reconnection backoff base                                 |
 | `RECONNECT_MAX_MS`      | `30000`                             | Reconnection backoff ceiling                              |
 | `ADMIN_URL`             | `https://login.tailscale.com/admin` | Tailscale admin console                                   |
-| `EXPECTED_HOST_VERSION` | `0.1.11`                            | Expected native host version (major.minor match required) |
+| `EXPECTED_HOST_VERSION` | `0.1.12`                            | Expected native host version (major.minor match required) |
 
 
 ---

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailchrome/extension",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailchrome/shared",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "private": true,
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -5,4 +5,4 @@ export const RECONNECT_MAX_MS = 30_000;
 export const ADMIN_URL = "https://login.tailscale.com/admin";
 /** Tailchrome project on GitHub (footer, diagnostics toast). */
 export const TAILCHROME_PROJECT_URL = "https://github.com/dantraynor/tailchrome";
-export const EXPECTED_HOST_VERSION = "0.1.11";
+export const EXPECTED_HOST_VERSION = "0.1.12";

--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -23,7 +23,7 @@ dotnet tool install --global wix --version 6.0.2
 Then build from the repository root:
 
 ```powershell
-.\packaging\windows\build-msi.ps1 -Version v0.1.11
+.\packaging\windows\build-msi.ps1 -Version v0.1.12
 ```
 
 The release workflow may sign the MSI when Windows signing secrets are configured. Unsigned local builds still work for manual testing.

--- a/scripts/e2e/fixtures.mjs
+++ b/scripts/e2e/fixtures.mjs
@@ -202,7 +202,7 @@ export function makeControl(overrides = {}) {
   const status = overrides.status ?? makeRunningState();
   return {
     proxyPort: 1055,
-    hostVersion: "0.1.11",
+    hostVersion: "0.1.12",
     supportsNetcheck: true,
     supportsPingPeer: true,
     supportsLogin: true,

--- a/scripts/e2e/native-host.mjs
+++ b/scripts/e2e/native-host.mjs
@@ -222,7 +222,7 @@ function mockSource(baseUrl, initialControl) {
         procRunning: {
           port: control.proxyPort ?? 1055,
           pid: 1,
-          version: control.hostVersion ?? "0.1.11",
+          version: control.hostVersion ?? "0.1.12",
           error: control.startupError,
           supportsNetcheck: control.supportsNetcheck !== false,
           supportsPingPeer: control.supportsPingPeer !== false,

--- a/scripts/e2e/scenarios/connected-dashboard.mjs
+++ b/scripts/e2e/scenarios/connected-dashboard.mjs
@@ -18,7 +18,7 @@ export async function run({ openPopup }) {
     await expectText(page, "example.ts.net");
     await expectText(page, "100.64.0.1");
     await expectText(page, "browser-node");
-    await expectText(page, "Native helper 0.1.11");
+    await expectText(page, "Native helper 0.1.12");
     await expectText(page, "Network lock is enabled");
     await expectText(page, "router");
     await expectText(page, "laptop");


### PR DESCRIPTION
Maintenance release. Bumps the version to **0.1.12** across the extension, shared package, `EXPECTED_HOST_VERSION`, the docs, and the e2e version fixtures.

### What's in this release (merged since 0.1.11)

**Features**
- Ships OS-native installers for the native helper — a signed and notarized macOS `.pkg`, a per-user Windows `.msi`, and Linux `.deb`/`.rpm` packages — with matching release packaging jobs and Makefile targets. The popup's install and update flow now offers the platform installer first, with the raw binary available behind an advanced fallback, and download handling schedules background native-host discovery retries that will not interrupt a live connection. Uninstalling the helper now also removes the staged runtime binary instead of leaving it behind. (#93)

**Fixes**
- The background service worker in the Chrome and Firefox builds now registers a `runtime.onStartup` listener. Previously the background only initialized once the popup was opened, so "Auto-connect on start" had no effect until the popup was opened after a fresh browser launch; the tailnet now reconnects at browser startup without opening the popup. (#92)
- Device names shown in the popup now use the Tailscale machine name (the first label of the MagicDNS name) instead of the OS hostname, matching the official Tailscale clients. This applies to the peer list, the self node in the status bar, exit node labels, peer action toasts, and the web SSH link, and falls back to the OS hostname when no MagicDNS name is available. (#91)

**Maintenance**
- Added shared workspace settings covering setup, local run, archive cleanup, and review guidance. (#88)
- Stopped tracking the local workspace settings file in git. (#94)

### Verification
- `pnpm typecheck`, `pnpm test` (376 unit tests), `pnpm validate:ids`, `pnpm review:firefox`, and `pnpm validate:release-tag v0.1.12` all pass locally.
- Full Puppeteer e2e suites pass locally: Chrome 20/20 scenarios, Firefox 14/14 scenarios.
- `go vet` and `go test` pass in `host/`; `make host-all` cross-compiles all four binaries; the macOS `.pkg` (unsigned) and Linux `.deb`/`.rpm` packaging scripts produce installable packages locally.

Once merged, tagging `v0.1.12` triggers the signed release build and the draft GitHub Release.
