### PR TITLE
Pin nFPM in release packaging and allow Go toolchain download

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,7 +184,11 @@ jobs:
         with:
           name: build-output
       - name: Install nFPM
-        run: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest
+        # Pinned: @latest can require a newer Go than the repo toolchain;
+        # GOTOOLCHAIN=auto lets go fetch the toolchain nfpm needs.
+        env:
+          GOTOOLCHAIN: auto
+        run: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.47.0
       - name: Build Linux packages
         run: VERSION="$RELEASE_TAG" ./packaging/linux/build-packages.sh
       - name: Upload Linux packages


### PR DESCRIPTION
The v0.1.12 release run failed in `package-linux`: `go install nfpm@latest` resolved to v2.47.0, which requires Go >= 1.26.4, while the job runs the repo-pinned Go 1.25.5 with `GOTOOLCHAIN=local` (set by setup-go).

- Pin nfpm to v2.47.0 (same version verified locally against `packaging/linux/build-packages.sh`; produces the expected `.deb`/`.rpm`).
- Set `GOTOOLCHAIN=auto` on the install step only, so `go install` can fetch the toolchain nfpm needs without affecting the host build.

The macOS notarization failure in the same run is unrelated (expired Apple Developer Program agreement) and is handled outside the repo.