### PR TITLE
fix(deps): update adm-zip to 0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
       "undici": "^7.28.0",
       "esbuild": "^0.28.1",
       "js-yaml": "^4.2.0",
-      "shell-quote": "^1.8.4"
+      "shell-quote": "^1.8.4",
+      "adm-zip": "^0.6.0"
     }
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,7 @@ overrides:
   esbuild: ^0.28.1
   js-yaml: ^4.2.0
   shell-quote: ^1.8.4
+  adm-zip: ^0.6.0
 
 importers:
 
@@ -639,9 +640,9 @@ packages:
       safe-compare:
         optional: true
 
-  adm-zip@0.5.17:
-    resolution: {integrity: sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==}
-    engines: {node: '>=12.0'}
+  adm-zip@0.6.0:
+    resolution: {integrity: sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==}
+    engines: {node: '>=14.0'}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -3017,7 +3018,7 @@ snapshots:
       upath: 2.0.1
       yauzl: 3.2.1
 
-  adm-zip@0.5.17: {}
+  adm-zip@0.6.0: {}
 
   agent-base@7.1.4: {}
 
@@ -3634,7 +3635,7 @@ snapshots:
 
   firefox-profile@4.7.0:
     dependencies:
-      adm-zip: 0.5.17
+      adm-zip: 0.6.0
       fs-extra: 11.3.4
       ini: 4.1.3
       minimist: 1.2.8


### PR DESCRIPTION
## What

Overrides the transitive `adm-zip` dependency to `^0.6.0` and refreshes the pnpm lockfile.

## Why

Updates the vulnerable `0.5.17` resolution to the patched release for CVE-2026-39244. This prevents crafted ZIP inputs from forcing excessive memory allocation in archive-processing tooling.

## How to Test

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build:chrome`
- [x] `pnpm review:firefox`

## Checklist

- [x] Tested in Chrome (`pnpm build:chrome`)
- [x] Tested in Firefox (`pnpm review:firefox`)
- [x] Updated README if needed (not applicable)
