### PR TITLE
fix: accept approved subnet routes in browser node

### DIFF
--- a/host/host.go
+++ b/host/host.go
@@ -338,6 +338,15 @@ func (h *Host) handleRequest(req Request) {
 	}
 }
 
+func startupPrefs() *ipn.MaskedPrefs {
+	return &ipn.MaskedPrefs{
+		Prefs: ipn.Prefs{
+			RouteAll: true,
+		},
+		RouteAllSet: true,
+	}
+}
+
 // handleInit initializes (or reuses) a tsnet.Server for the given browser profile.
 func (h *Host) handleInit(req Request) {
 	if !validInitID.MatchString(req.InitID) {
@@ -421,6 +430,21 @@ func (h *Host) handleInit(req Request) {
 		h.send(Reply{
 			Cmd:  "init",
 			Init: &InitReply{Error: fmt.Sprintf("failed to get local client: %v", err)},
+		})
+		server.Close()
+		return
+	}
+
+	// tsnet does not accept subnet routes by default. Tailchrome's proxy rules
+	// are built from accepted PrimaryRoutes, so enable route acceptance before
+	// publishing the first status update.
+	prefsCtx, prefsCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	_, err = lc.EditPrefs(prefsCtx, startupPrefs())
+	prefsCancel()
+	if err != nil {
+		h.send(Reply{
+			Cmd:  "init",
+			Init: &InitReply{Error: fmt.Sprintf("failed to accept subnet routes: %v", err)},
 		})
 		server.Close()
 		return

--- a/host/prefs_test.go
+++ b/host/prefs_test.go
@@ -9,6 +9,16 @@ import (
 	"tailscale.com/ipn"
 )
 
+func TestStartupPrefsAcceptSubnetRoutes(t *testing.T) {
+	mp := startupPrefs()
+	if !mp.RouteAllSet {
+		t.Fatal("startup prefs must explicitly set RouteAll")
+	}
+	if !mp.Prefs.RouteAll {
+		t.Fatal("startup prefs must accept subnet routes")
+	}
+}
+
 func TestMaskedPrefsForUpdatePreservesExitNodeAdvertising(t *testing.T) {
 	current := &ipn.Prefs{
 		AdvertiseRoutes: []netip.Prefix{netip.MustParsePrefix("10.10.0.0/16")},


### PR DESCRIPTION
## Summary

- enable `RouteAll` in the Tailchrome tsnet node during initialization
- make approved subnet routes appear as peer `PrimaryRoutes`
- allow the existing PAC/proxy logic to detect and route those subnets
- add a regression test for the startup preference

## Problem

Tailchrome advertises subnet-router support and its proxy manager builds rules from peers' `PrimaryRoutes`. However, the tsnet browser node does not currently enable route acceptance. Approved subnet routes therefore do not appear on subnet-router peers, and requests to those networks bypass Tailchrome's local proxy.

This was reproduced with an approved subnet router advertising:

- `10.1.0.0/16`
- `10.2.0.0/15`
- `10.4.0.0/16`

The router appeared online in Tailchrome, but without its subnets, and the browser could not reach hosts in those networks.

## Verification

- `go test ./...`
- `go vet ./...`
- `pnpm test` — 477 tests passed
- `pnpm typecheck`
- `pnpm build` — Chrome and Firefox builds passed
