### PR TITLE
Add verified Linux ARM64 helper releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,15 +7,26 @@ permissions:
   contents: read
   pull-requests: read
 
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Most jobs do not launch a browser. The e2e launcher installs its browser
+  # explicitly, so dependency installation never needs Puppeteer's postinstall
+  # download.
+  PUPPETEER_SKIP_DOWNLOAD: "1"
+
 jobs:
   changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       host: ${{ steps.filter.outputs.host }}
       packaging: ${{ steps.filter.outputs.packaging }}
     steps:
-      - uses: actions/checkout@v5
-      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: filter
         with:
           filters: |
@@ -25,30 +36,38 @@ jobs:
             packaging:
               - 'host/**'
               - 'packaging/**'
+              - 'scripts/install.sh'
+              - 'scripts/install.test.sh'
               - 'Makefile'
               - '.github/workflows/ci.yml'
               - '.github/workflows/release.yml'
 
   extension-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 22
           package-manager-cache: false
       - run: corepack enable
       - run: pnpm install --frozen-lockfile
+      - run: pnpm audit --audit-level high
       - run: pnpm validate:ids
       - run: pnpm typecheck
       - run: pnpm test
+      - name: Test installer shell script
+        run: bash scripts/install.test.sh
+      - name: Lint installer shell script
+        run: shellcheck scripts/install.sh scripts/install.test.sh
 
   e2e-chrome:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 22
           package-manager-cache: false
@@ -58,43 +77,48 @@ jobs:
 
   build-chrome:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 22
           package-manager-cache: false
       - run: corepack enable
       - run: pnpm install --frozen-lockfile
       - run: pnpm build:chrome
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: chrome-build
+          overwrite: true
           path: packages/extension/.output/chrome-mv3/
 
   review-firefox:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 22
           package-manager-cache: false
       - run: corepack enable
       - run: pnpm install --frozen-lockfile
       - run: pnpm review:firefox
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: firefox-build
+          overwrite: true
           path: packages/extension/.output/firefox-mv3/
 
   host-build:
     needs: changes
     if: needs.changes.outputs.host == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: host/go.mod
           cache-dependency-path: host/go.sum
@@ -105,18 +129,20 @@ jobs:
       - run: go test -race ./...
         working-directory: host
       - run: make host
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: host-binary
+          overwrite: true
           path: dist/tailscale-browser-ext
 
   host-windows-tests:
     needs: changes
     if: needs.changes.outputs.host == 'true'
     runs-on: windows-latest
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: host/go.mod
           cache-dependency-path: host/go.sum
@@ -127,9 +153,10 @@ jobs:
     needs: changes
     if: needs.changes.outputs.packaging == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: host/go.mod
           cache-dependency-path: host/go.sum
@@ -137,5 +164,16 @@ jobs:
         env:
           GOTOOLCHAIN: auto
         run: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.47.0
-      - run: make host-linux-amd64
+      - name: Build and inspect raw Linux helpers
+        run: |
+          set -euo pipefail
+          make host-linux-amd64 host-linux-arm64
+          file dist/tailscale-browser-ext-linux-amd64 |
+            tee /dev/stderr |
+            grep -Eq 'x86-64|x86_64'
+          file dist/tailscale-browser-ext-linux-arm64 |
+            tee /dev/stderr |
+            grep -Eq 'ARM aarch64|ARM64'
+          go version -m dist/tailscale-browser-ext-linux-amd64
+          go version -m dist/tailscale-browser-ext-linux-arm64
       - run: VERSION=0.0.0 ./packaging/linux/build-packages.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,14 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: release-${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}
+  cancel-in-progress: false
+
+env:
+  # Release validation does not launch a browser.
+  PUPPETEER_SKIP_DOWNLOAD: "1"
+
 # Required repository secrets:
 #   APPLE_CERTIFICATE_P12        - base64-encoded Developer ID Application .p12
 #   APPLE_CERTIFICATE_PASSWORD   - password for the .p12
@@ -27,19 +35,20 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref }}
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 22
           package-manager-cache: false
       - run: corepack enable
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: host/go.mod
           cache-dependency-path: host/go.sum
@@ -50,6 +59,8 @@ jobs:
       - run: pnpm validate:release-tag "$RELEASE_TAG"
       - run: pnpm typecheck
       - run: pnpm test
+      - name: Test installer shell script
+        run: bash scripts/install.test.sh
       - run: go test -race ./...
         working-directory: host
       - run: go vet ./...
@@ -74,14 +85,16 @@ jobs:
           diff -qr "$ORIGINAL_DIR" "$REBUILT_DIR"
           popd >/dev/null
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: build-output
+          overwrite: true
           retention-days: 1
           path: |
             dist/tailscale-browser-ext-darwin-amd64
             dist/tailscale-browser-ext-darwin-arm64
             dist/tailscale-browser-ext-linux-amd64
+            dist/tailscale-browser-ext-linux-arm64
             dist/tailscale-browser-ext-windows-amd64.exe
             packages/extension/.output/chrome.zip
             packages/extension/.output/firefox.zip
@@ -90,11 +103,12 @@ jobs:
   sign-macos:
     needs: build
     runs-on: macos-latest
+    timeout-minutes: 45
     env:
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: build-output
 
@@ -163,9 +177,10 @@ jobs:
           done
 
       - name: Upload signed Darwin binaries
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: signed-darwin
+          overwrite: true
           retention-days: 1
           path: |
             dist/tailscale-browser-ext-darwin-amd64
@@ -174,19 +189,20 @@ jobs:
   package-linux:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     env:
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref }}
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: host/go.mod
           cache-dependency-path: host/go.sum
       - name: Download build artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: build-output
       - name: Install nFPM
@@ -198,9 +214,10 @@ jobs:
       - name: Build Linux packages
         run: VERSION="$RELEASE_TAG" ./packaging/linux/build-packages.sh
       - name: Upload Linux packages
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: linux-packages
+          overwrite: true
           retention-days: 1
           path: |
             dist/tailchrome-helper-linux-amd64.deb
@@ -209,18 +226,19 @@ jobs:
   package-windows:
     needs: build
     runs-on: windows-latest
+    timeout-minutes: 30
     env:
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref }}
-      - uses: actions/setup-dotnet@v5
+      - uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           dotnet-version: "8.0.x"
       - name: Download build artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: build-output
       - name: Install WiX
@@ -254,43 +272,55 @@ jobs:
             /p "$env:WINDOWS_CODESIGN_PASSWORD" `
             dist\tailchrome-helper-windows-x64.msi
       - name: Upload Windows MSI
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: windows-msi
+          overwrite: true
           retention-days: 1
           path: dist/tailchrome-helper-windows-x64.msi
 
   release:
-    needs: [build, sign-macos, package-linux, package-windows]
+    needs: [build, sign-macos, package-linux, package-windows, package-macos]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
       id-token: write
       attestations: write
     env:
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}
-      # gh resolves repo via git remote; this job has no checkout (artifacts only).
       GH_REPO: ${{ github.repository }}
     steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref }}
+
       - name: Download build artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: build-output
 
       - name: Download signed Darwin binaries
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: signed-darwin
           path: signed-darwin
 
+      - name: Download signed macOS package
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          name: signed-macos-package
+          path: signed-macos-package
+
       - name: Download Linux packages
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: linux-packages
           path: linux-packages
 
       - name: Download Windows MSI
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: windows-msi
           path: windows-msi
@@ -305,21 +335,27 @@ jobs:
           # — they extract straight into signed-darwin/.
           cp signed-darwin/tailscale-browser-ext-darwin-amd64 release/
           cp signed-darwin/tailscale-browser-ext-darwin-arm64 release/
+          cp signed-macos-package/tailchrome-helper-macos.pkg release/
           cp linux-packages/tailchrome-helper-linux-amd64.deb release/
           cp linux-packages/tailchrome-helper-linux-x86_64.rpm release/
           cp windows-msi/tailchrome-helper-windows-x64.msi release/
           # build-output uploads paths under both dist/ and packages/, so it
           # has no common ancestor and the artifact preserves the full paths.
           cp dist/tailscale-browser-ext-linux-amd64 release/
+          cp dist/tailscale-browser-ext-linux-arm64 release/
           cp dist/tailscale-browser-ext-windows-amd64.exe release/
           cp packages/extension/.output/chrome.zip release/
           cp packages/extension/.output/firefox.zip release/
           cp packages/extension/.output/firefox-sources.zip release/
+          install -m 0755 scripts/install.sh release/tailchrome-install.sh
           cd release
-          sha256sum $(ls -1 | sort) > SHA256SUMS.txt
+          find . -maxdepth 1 -type f ! -name SHA256SUMS.txt -printf '%f\n' |
+            LC_ALL=C sort |
+            xargs sha256sum > SHA256SUMS.txt
+          sha256sum --check SHA256SUMS.txt
 
       - name: Generate release artifact provenance
-        uses: actions/attest@v4
+        uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4.2.0
         with:
           subject-path: release/*
 
@@ -344,28 +380,23 @@ jobs:
             echo
             echo "Release: $(gh release view "$RELEASE_TAG" --json url --jq '.url')"
             echo
-            echo "The macOS installer job uploads \`tailchrome-helper-macos.pkg\` separately."
-            echo
             echo '```'
             ls -1 release | sort
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
-  release-macos-pkg:
-    needs: release
+  package-macos:
+    needs: build
     runs-on: macos-latest
-    permissions:
-      contents: write
-      id-token: write
-      attestations: write
+    timeout-minutes: 45
     env:
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref }}
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: host/go.mod
           cache-dependency-path: host/go.sum
@@ -425,23 +456,13 @@ jobs:
         run: |
           pkgutil --check-signature dist/tailchrome-helper-macos.pkg
 
-      - name: SHA256 of macOS package
-        run: (cd dist && shasum -a 256 tailchrome-helper-macos.pkg | tee tailchrome-helper-macos.pkg.sha256)
-
-      - name: Generate macOS package provenance
-        uses: actions/attest@v4
+      - name: Upload signed macOS package
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
-          subject-path: dist/tailchrome-helper-macos.pkg
-
-      - name: Upload macOS assets to release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          gh release upload "$RELEASE_TAG" \
-            dist/tailchrome-helper-macos.pkg \
-            dist/tailchrome-helper-macos.pkg.sha256 \
-            --clobber
+          name: signed-macos-package
+          overwrite: true
+          retention-days: 1
+          path: dist/tailchrome-helper-macos.pkg
 
       - name: macOS release summary
         run: |
@@ -449,6 +470,6 @@ jobs:
             echo "## macOS installer"
             echo
             echo '```'
-            cat dist/tailchrome-helper-macos.pkg.sha256
+            shasum -a 256 dist/tailchrome-helper-macos.pkg
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev
 TS_VERSION = $(shell cd host && go list -m -f '{{.Version}}' tailscale.com 2>/dev/null | sed 's/^v//')
 LDFLAGS = -ldflags "-X main.version=$(VERSION) -X tailscale.com/version.shortStamp=$(TS_VERSION) -X tailscale.com/version.longStamp=$(TS_VERSION)"
 
-.PHONY: all extension extension-chrome extension-firefox host host-linux-amd64 host-all macos-pkg windows-msi linux-packages clean dev zip zip-chrome zip-firefox
+.PHONY: all extension extension-chrome extension-firefox host host-linux-amd64 host-linux-arm64 host-all macos-pkg windows-msi linux-packages clean dev zip zip-chrome zip-firefox
 
 all: extension host
 
@@ -24,10 +24,14 @@ host:
 host-linux-amd64:
 	cd host && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build $(LDFLAGS) -o ../dist/tailscale-browser-ext-linux-amd64 .
 
+host-linux-arm64:
+	cd host && GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build $(LDFLAGS) -o ../dist/tailscale-browser-ext-linux-arm64 .
+
 host-all:
 	cd host && GOOS=darwin  GOARCH=amd64 CGO_ENABLED=0 go build $(LDFLAGS) -o ../dist/tailscale-browser-ext-darwin-amd64 .
 	cd host && GOOS=darwin  GOARCH=arm64 CGO_ENABLED=0 go build $(LDFLAGS) -o ../dist/tailscale-browser-ext-darwin-arm64 .
 	cd host && GOOS=linux   GOARCH=amd64 CGO_ENABLED=0 go build $(LDFLAGS) -o ../dist/tailscale-browser-ext-linux-amd64 .
+	cd host && GOOS=linux   GOARCH=arm64 CGO_ENABLED=0 go build $(LDFLAGS) -o ../dist/tailscale-browser-ext-linux-arm64 .
 	cd host && GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build $(LDFLAGS) -o ../dist/tailscale-browser-ext-windows-amd64.exe .
 
 # macOS only: universal .pkg installer (requires lipo, pkgbuild)

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The same UI renders in either surface.
 ## Install
 
 1. Get the extension from the [Chrome Web Store](https://chromewebstore.google.com/detail/tailchrome/bhfeceecialgilpedkoflminjgcjljll) (also installs in Brave, Edge, Vivaldi, Opera, and — on macOS — Arc) or [Firefox Add-ons](https://addons.mozilla.org/en-US/firefox/addon/tailchrome/)
-2. Install the native helper from the [latest release](https://github.com/dantraynor/tailchrome/releases/latest) — **`tailchrome-helper-macos.pkg`** on macOS, **`tailchrome-helper-windows-x64.msi`** on Windows, or the **`.deb`/`.rpm`** package on Linux. Raw binaries remain available for advanced/manual installs.
+2. Install the native helper from the [latest release](https://github.com/dantraynor/tailchrome/releases/latest) — **`tailchrome-helper-macos.pkg`** on macOS, **`tailchrome-helper-windows-x64.msi`** on Windows, or the **`.deb`/`.rpm`** package on Linux amd64. Linux ARM64 and per-user repair flows use the release's checksum-verifying **`tailchrome-install.sh`**.
 3. Log in to your Tailscale account
 
 ## Development

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -42,12 +42,14 @@ pnpm zip:firefox         # firefox.zip + firefox-sources.zip
 pnpm lint:firefox        # AMO-style validation
 pnpm review:firefox      # Full Firefox validation pipeline
 pnpm test                # All tests
+pnpm test:installer      # Verified installer shell tests
 pnpm typecheck           # TypeScript validation
 pnpm e2e:chrome          # Puppeteer smoke suite (Chrome)
 pnpm e2e:firefox         # Puppeteer smoke suite (Firefox)
 pnpm e2e:full            # Full Puppeteer suite, both browsers
 make host                # Native host for current platform
 make host-all            # All platform binaries
+make host-linux-arm64    # Linux ARM64 raw helper
 make dev                 # Chrome watch mode (WXT)
 ```
 

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -2,9 +2,9 @@
 
 > Access your Tailscale network directly from your browser. No system VPN required.
 
-**Version:** 0.1.12 (native host) | Manifest V3
+**Version:** 0.1.13 (native host) | Manifest V3
 **Browsers:** Chrome, Firefox
-**Platforms:** macOS (amd64, arm64), Linux (amd64), Windows (amd64)
+**Platforms:** macOS (amd64, arm64), Linux (amd64, arm64 raw helper), Windows (amd64)
 **License:** MIT
 **Website:** [tesseras.org/tailchrome](https://tesseras.org/)
 **Chrome Web Store:** [Chrome Web Store](https://chromewebstore.google.com/detail/tailchrome/bhfeceecialgilpedkoflminjgcjljll)
@@ -345,7 +345,7 @@ Defined in `packages/shared/src/constants.ts`:
 | `RECONNECT_MAX_MS`      | `30000`                             | Reconnection backoff ceiling                              |
 | `ADMIN_URL`             | `https://login.tailscale.com/admin` | Tailscale admin console                                   |
 | `DEFAULT_CONTROL_URL`   | `https://controlplane.tailscale.com` | Default coordination server                              |
-| `EXPECTED_HOST_VERSION` | `0.1.12`                            | Expected native host version (major.minor match required) |
+| `EXPECTED_HOST_VERSION` | `0.1.13`                            | Expected native host version (major.minor match required) |
 
 
 ---
@@ -590,9 +590,9 @@ The installer packages are the primary path:
 
 - **macOS:** `tailchrome-helper-macos.pkg` installs a universal binary and runs `tailscale-browser-ext -install-now` for the logged-in user during package postinstall. `Tailchrome Helper.app` remains in `/Applications` as a repair/re-run fallback.
 - **Windows:** `tailchrome-helper-windows-x64.msi` installs a staged helper under `%LOCALAPPDATA%\Tailscale\BrowserExt\installer\` and runs it with `-install-now`, which writes HKCU native messaging registrations.
-- **Linux:** `.deb` and `.rpm` packages install `/usr/lib/tailchrome/tailscale-browser-ext` plus system-wide manifests for Chrome, Chromium, Edge, and Firefox. The raw binary fallback remains available for per-user registration in additional Chromium-family browsers.
+- **Linux:** amd64 `.deb` and `.rpm` packages install `/usr/lib/tailchrome/tailscale-browser-ext` plus system-wide manifests for Chrome, Chromium, Edge, and Firefox. The version-pinned `tailchrome-install.sh` fallback verifies and installs the matching amd64 or ARM64 raw helper for per-user registration.
 
-The raw native host binary remains available for advanced/manual installs. When run interactively in a terminal, or non-interactively via **`tailscale-browser-ext -install-now`**, it:
+The raw native host binary remains available for advanced/manual installs. Download and verify `tailchrome-install.sh` from the matching tagged release instead of piping a mutable network response to a shell. The script verifies the selected raw helper before invoking **`tailscale-browser-ext -install-now`**, which:
 
 - Detects installed browsers and writes per-browser manifests for the whole Chromium family (Chrome stable/beta/canary/dev, Chromium, Brave, Edge, Vivaldi, Opera, Arc on macOS) plus Firefox
 - Copies itself to `~/.local/share/tailscale/browser-ext/` (Linux), `~/Library/Application Support/Tailscale/BrowserExt/` (macOS), or `%LOCALAPPDATA%\Tailscale\BrowserExt\` (Windows)
@@ -748,11 +748,13 @@ tailchrome/
 | `pnpm review:firefox`             | Full Firefox review gate (build + lint + zip + publish validation) |
 | `pnpm typecheck`                  | Run TypeScript type checking                                       |
 | `pnpm test`                       | Run all tests (vitest)                                             |
+| `pnpm test:installer`             | Run the verified installer shell test suite                        |
 | `pnpm validate:ids`               | Validate extension ID consistency                                  |
 | `pnpm validate:release-tag <tag>` | Validate release tag format                                        |
 | `make host`                       | Build native host for current platform                             |
 | `make host-all`                   | Build host binaries for all platforms                              |
 | `make host-linux-amd64`           | Build the Linux package input                                      |
+| `make host-linux-arm64`           | Build the Linux ARM64 raw helper                                   |
 | `make dev`                        | Chrome watch mode via WXT                                          |
 | `make all`                        | Build extension + host                                             |
 | `make clean`                      | Clean all build outputs                                            |
@@ -794,7 +796,7 @@ The workflow runs extension unit/type/ID checks, a real Chrome smoke suite, a Ch
 
 - **host-build** (Linux): dependency download, `go vet`, `go test`, and a native host build
 - **host-windows-tests**: Windows-specific Go compile/tests
-- **package-linux**: Linux amd64 host build plus `.deb` and `.rpm` generation with pinned nFPM
+- **package-linux**: Linux amd64/ARM64 raw-host validation plus amd64 `.deb` and `.rpm` generation with pinned nFPM
 
 ### Release (`release.yml`) -- Runs on `v`* Tags or Manual Dispatch
 
@@ -806,9 +808,9 @@ The release workflow:
 4. **Verifies Firefox source ZIP**: extracts sources, rebuilds from scratch, `diff -qr` against original to ensure reproducibility
 5. Signs/notarizes macOS binaries
 6. Builds Linux `.deb`/`.rpm` packages with nFPM and the Windows `.msi` with WiX
-7. Generates `SHA256SUMS.txt` for the main release assets
-8. Creates build-provenance attestations for collected release artifacts, then creates/updates the GitHub Release
-9. Builds, signs, and notarizes the macOS `.pkg` in a follow-up job and uploads it to the release with its own `.sha256` checksum
+7. Collects every final asset, including `tailchrome-install.sh`, the Linux ARM64 helper, and the notarized macOS package
+8. Generates and verifies one canonical `SHA256SUMS.txt` for that final asset set
+9. Creates build-provenance attestations, then creates or updates the GitHub Release
 
 ### Publish (`publish.yml`) -- Manual Dispatch Only
 

--- a/docs/FEATURE_PARITY.md
+++ b/docs/FEATURE_PARITY.md
@@ -2,7 +2,7 @@
 
 > Comparison of the Tailchrome browser extension against the native Tailscale desktop/mobile clients (macOS, Windows, Linux, iOS, Android).
 
-Last updated: 2026-07-20
+Last updated: 2026-08-09
 
 ---
 
@@ -156,7 +156,7 @@ Last updated: 2026-07-20
 | Keyboard navigation    | Yes           | Yes        | Arrow keys in peer list                                                                                                                            |
 | Search                 | Yes           | Yes        | Peer search in popup                                                                                                                               |
 | Auto-update            | Yes           | Partial    | Extension auto-updates via Chrome Web Store; native host updates use the platform helper installer when the extension shows "needs-update" |
-| Cross-platform         | Yes           | Yes        | Extension: Chrome + Firefox. Host: macOS (amd64/arm64), Linux (amd64), Windows (amd64)                                                             |
+| Cross-platform         | Yes           | Yes        | Extension: Chrome + Firefox. Host: macOS (amd64/arm64), Linux raw helper (amd64/arm64), Linux packages (amd64/x86_64), and Windows (amd64)          |
 
 
 ---

--- a/docs/SOURCE_CODE_REVIEW.md
+++ b/docs/SOURCE_CODE_REVIEW.md
@@ -4,6 +4,9 @@ This repository ships the Firefox source ZIP so AMO reviewers can rebuild the ex
 
 ## Reviewer Bootstrap
 
+Use Node.js 22. The root `package.json` pins the pnpm version used for the
+release build, and the source archive includes every referenced pnpm patch.
+
 1. Extract `firefox-sources.zip`.
 2. Run `corepack enable`.
 3. Run `pnpm install --frozen-lockfile`.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint:firefox": "pnpm --filter @tailchrome/extension lint:firefox",
     "review:firefox": "pnpm lint:firefox && pnpm zip:firefox && pnpm validate:firefox-publish",
     "test": "pnpm -r test",
+    "test:installer": "bash ./scripts/install.test.sh",
     "typecheck": "pnpm -r typecheck",
     "e2e": "node ./scripts/e2e/run.mjs",
     "e2e:chrome": "node ./scripts/e2e/run.mjs --browser=chrome",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailchrome/extension",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/extension/wxt.config.ts
+++ b/packages/extension/wxt.config.ts
@@ -77,6 +77,7 @@ export default defineConfig({
       "tsconfig.base.json",
       "docs/SOURCE_CODE_REVIEW.md",
       "config/extension-ids.json",
+      "patches/**",
       "packages/extension/**",
       "packages/shared/**",
     ],

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailchrome/shared",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": true,
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -27,7 +27,7 @@ export const DEFAULT_LOGIN_ORIGINS: readonly string[] = [
 ];
 /** Tailchrome project on GitHub (footer, diagnostics toast). */
 export const TAILCHROME_PROJECT_URL = "https://github.com/dantraynor/tailchrome";
-export const EXPECTED_HOST_VERSION = "0.1.12";
+export const EXPECTED_HOST_VERSION = "0.1.13";
 
 /**
  * Returns true when the given prefs.controlURL points at a custom coordination

--- a/packages/shared/src/popup/views/install-helpers.test.ts
+++ b/packages/shared/src/popup/views/install-helpers.test.ts
@@ -2,6 +2,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   buildDownloadURL,
+  buildRunCommand,
+  detectArch,
   installerDownloads,
   renderInstallFlow,
   requestNativeHostRetries,
@@ -19,13 +21,48 @@ vi.mock("../utils", () => ({
   showToast: vi.fn(),
 }));
 
+function platformInfo(arch: string): chrome.runtime.PlatformInfo {
+  return {
+    arch: arch as chrome.runtime.PlatformInfo["arch"],
+    os: "linux",
+  };
+}
+
+function mockPlatformArch(arch: string): void {
+  chrome.runtime.getPlatformInfo = vi
+    .fn()
+    .mockResolvedValue(platformInfo(arch)) as typeof chrome.runtime.getPlatformInfo;
+}
+
+function mockCallbackPlatformArch(arch: string): void {
+  chrome.runtime.getPlatformInfo = vi.fn(
+    (callback: (info: chrome.runtime.PlatformInfo) => void) => {
+      callback(platformInfo(arch));
+    },
+  ) as unknown as typeof chrome.runtime.getPlatformInfo;
+}
+
+function setNavigatorIdentity(platform: string, userAgent: string): void {
+  Object.defineProperty(navigator, "platform", {
+    configurable: true,
+    value: platform,
+  });
+  Object.defineProperty(navigator, "userAgent", {
+    configurable: true,
+    value: userAgent,
+  });
+}
+
+const REDUCED_CHROMIUM_UA =
+  "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/123.0.0.0 Safari/537.36";
+
 describe("installerDownloads", () => {
   it("returns the macOS package asset", () => {
     expect(installerDownloads("macos")).toEqual([
       {
         filename: "tailchrome-helper-macos.pkg",
         label: "Download macOS installer (.pkg)",
-        url: "https://github.com/dantraynor/tailchrome/releases/latest/download/tailchrome-helper-macos.pkg",
+        url: "https://github.com/dantraynor/tailchrome/releases/download/v0.1.13/tailchrome-helper-macos.pkg",
       },
     ]);
   });
@@ -35,43 +72,181 @@ describe("installerDownloads", () => {
       {
         filename: "tailchrome-helper-windows-x64.msi",
         label: "Download Windows installer (.msi)",
-        url: "https://github.com/dantraynor/tailchrome/releases/latest/download/tailchrome-helper-windows-x64.msi",
+        url: "https://github.com/dantraynor/tailchrome/releases/download/v0.1.13/tailchrome-helper-windows-x64.msi",
       },
     ]);
   });
 
   it("returns both Linux package assets", () => {
-    expect(installerDownloads("linux")).toEqual([
+    expect(installerDownloads("linux", "amd64")).toEqual([
       {
         filename: "tailchrome-helper-linux-amd64.deb",
         label: "Download .deb (Debian/Ubuntu)",
-        url: "https://github.com/dantraynor/tailchrome/releases/latest/download/tailchrome-helper-linux-amd64.deb",
+        url: "https://github.com/dantraynor/tailchrome/releases/download/v0.1.13/tailchrome-helper-linux-amd64.deb",
       },
       {
         filename: "tailchrome-helper-linux-x86_64.rpm",
         label: "Download .rpm (Fedora/RHEL)",
-        url: "https://github.com/dantraynor/tailchrome/releases/latest/download/tailchrome-helper-linux-x86_64.rpm",
+        url: "https://github.com/dantraynor/tailchrome/releases/download/v0.1.13/tailchrome-helper-linux-x86_64.rpm",
       },
     ]);
+  });
+
+  it("routes Linux ARM64 through the version-pinned verified installer", () => {
+    expect(installerDownloads("linux", "arm64")).toEqual([
+      {
+        filename: "tailchrome-install.sh",
+        label: "Download verified Linux ARM64 installer",
+        url: "https://github.com/dantraynor/tailchrome/releases/download/v0.1.13/tailchrome-install.sh",
+      },
+    ]);
+    expect(buildDownloadURL("linux", "arm64")).toBe(
+      "https://github.com/dantraynor/tailchrome/releases/download/v0.1.13/tailchrome-install.sh",
+    );
+    expect(buildRunCommand("linux", "arm64")).toBe(
+      'bash ~/Downloads/tailchrome-install.sh --version "v0.1.13"',
+    );
   });
 
   it("falls back to the release page for unknown platforms", () => {
     expect(installerDownloads("unknown")).toEqual([
       {
         filename: null,
-        label: "Open latest release",
-        url: "https://github.com/dantraynor/tailchrome/releases/latest",
+        label: "Open companion release",
+        url: "https://github.com/dantraynor/tailchrome/releases/tag/v0.1.13",
       },
     ]);
   });
 
+  it.each(["macos", "linux", "windows"] as const)(
+    "does not guess an installer for unsupported %s architectures",
+    (platform) => {
+      expect(installerDownloads(platform, "unknown")).toEqual([
+        {
+          filename: null,
+          label: "Open companion release",
+          url: "https://github.com/dantraynor/tailchrome/releases/tag/v0.1.13",
+        },
+      ]);
+      expect(buildDownloadURL(platform, "unknown")).toBe(
+        "https://github.com/dantraynor/tailchrome/releases/tag/v0.1.13",
+      );
+      expect(buildRunCommand(platform, "unknown")).toBeNull();
+    },
+  );
+
   it("keeps raw binary downloads available as a fallback", () => {
     expect(buildDownloadURL("windows")).toBe(
-      "https://github.com/dantraynor/tailchrome/releases/latest/download/tailscale-browser-ext-windows-amd64.exe",
+      "https://github.com/dantraynor/tailchrome/releases/download/v0.1.13/tailscale-browser-ext-windows-amd64.exe",
     );
     expect(buildDownloadURL("linux")).toBe(
-      "https://github.com/dantraynor/tailchrome/releases/latest/download/tailscale-browser-ext-linux-amd64",
+      "https://github.com/dantraynor/tailchrome/releases/download/v0.1.13/tailscale-browser-ext-linux-amd64",
     );
+  });
+});
+
+describe("detectArch", () => {
+  beforeEach(() => {
+    setNavigatorIdentity("Linux x86_64", REDUCED_CHROMIUM_UA);
+    (
+      chrome.runtime as unknown as {
+        lastError: chrome.runtime.LastError | null;
+      }
+    ).lastError = null;
+  });
+
+  it.each([
+    ["arm", "unknown"],
+    ["arm64", "arm64"],
+    ["aarch64", "arm64"],
+    ["x86-64", "amd64"],
+    ["x86-32", "unknown"],
+    ["mips", "unknown"],
+  ] as const)(
+    "maps Promise-based runtime architecture %s to %s",
+    async (runtimeArch, expected) => {
+      mockPlatformArch(runtimeArch);
+
+      await expect(detectArch()).resolves.toBe(expected);
+      expect(chrome.runtime.getPlatformInfo).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.each(["arm64", "aarch64"] as const)(
+    "reads callback-only runtime architecture %s under reduced x86 metadata",
+    async (runtimeArch) => {
+      mockCallbackPlatformArch(runtimeArch);
+
+      await expect(detectArch()).resolves.toBe("arm64");
+      expect(chrome.runtime.getPlatformInfo).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("does not treat callback-only 32-bit ARM as ARM64", async () => {
+    mockCallbackPlatformArch("arm");
+
+    await expect(detectArch()).resolves.toBe("unknown");
+  });
+
+  it("settles once if an implementation invokes the callback and returns a Promise", async () => {
+    chrome.runtime.getPlatformInfo = vi.fn(
+      (callback: (info: chrome.runtime.PlatformInfo) => void) => {
+        callback(platformInfo("arm64"));
+        return Promise.resolve(platformInfo("x86-64"));
+      },
+    ) as unknown as typeof chrome.runtime.getPlatformInfo;
+
+    await expect(detectArch()).resolves.toBe("arm64");
+  });
+
+  it("falls back when a callback reports runtime.lastError", async () => {
+    const runtimeMock = chrome.runtime as unknown as {
+      lastError: chrome.runtime.LastError | null;
+    };
+    chrome.runtime.getPlatformInfo = vi.fn(
+      (callback: (info: chrome.runtime.PlatformInfo) => void) => {
+        runtimeMock.lastError = { message: "platform lookup failed" };
+        callback(platformInfo("arm64"));
+        runtimeMock.lastError = null;
+      },
+    ) as unknown as typeof chrome.runtime.getPlatformInfo;
+
+    await expect(detectArch()).resolves.toBe("amd64");
+  });
+
+  it("falls back to navigator architecture when the runtime lookup fails", async () => {
+    chrome.runtime.getPlatformInfo = vi
+      .fn()
+      .mockRejectedValue(
+        new Error("platform lookup failed"),
+      ) as typeof chrome.runtime.getPlatformInfo;
+    setNavigatorIdentity("Linux aarch64", REDUCED_CHROMIUM_UA);
+
+    await expect(detectArch()).resolves.toBe("arm64");
+  });
+
+  it("defaults to amd64 when a failed lookup leaves only reduced x86 values", async () => {
+    chrome.runtime.getPlatformInfo = vi
+      .fn()
+      .mockRejectedValue(
+        new Error("platform lookup failed"),
+      ) as typeof chrome.runtime.getPlatformInfo;
+
+    await expect(detectArch()).resolves.toBe("amd64");
+  });
+
+  it("does not guess when failed lookup metadata is unsupported", async () => {
+    chrome.runtime.getPlatformInfo = vi
+      .fn()
+      .mockRejectedValue(
+        new Error("platform lookup failed"),
+      ) as typeof chrome.runtime.getPlatformInfo;
+    setNavigatorIdentity(
+      "Linux i686",
+      "Mozilla/5.0 (X11; Linux i686) Gecko/20100101 Firefox/152.0",
+    );
+
+    await expect(detectArch()).resolves.toBe("unknown");
   });
 });
 
@@ -92,6 +267,8 @@ describe("renderInstallFlow", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.mocked(detectPlatform).mockReturnValue("windows");
+    setNavigatorIdentity("Linux x86_64", REDUCED_CHROMIUM_UA);
+    mockPlatformArch("x86-64");
     vi.mocked(sendMessage).mockClear();
     chrome.tabs.create = vi.fn().mockResolvedValue(undefined) as unknown as typeof chrome.tabs.create;
     document.body.textContent = "";
@@ -103,11 +280,11 @@ describe("renderInstallFlow", () => {
 
   it.each(["install", "update"] as const)(
     "requests native-host retries from the %s view installer button",
-    (mode) => {
+    async (mode) => {
       const root = document.createElement("div");
       document.body.appendChild(root);
 
-      renderInstallFlow(root, { mode, hostVersion: "0.1.0" });
+      await renderInstallFlow(root, { mode, hostVersion: "0.1.0" });
 
       root.querySelector<HTMLAnchorElement>(".install-pkg-cta a")?.click();
 
@@ -115,45 +292,114 @@ describe("renderInstallFlow", () => {
       // opening the download tab closes the popup surface right after.
       expect(sendMessage).toHaveBeenCalledWith({ type: "retry-native-host" });
       expect(chrome.tabs.create).toHaveBeenCalledWith({
-        url: "https://github.com/dantraynor/tailchrome/releases/latest/download/tailchrome-helper-windows-x64.msi",
+        url: "https://github.com/dantraynor/tailchrome/releases/download/v0.1.13/tailchrome-helper-windows-x64.msi",
       });
     },
   );
 
-  it("renders both Linux package links with install commands", () => {
+  it("renders both Linux package links with install commands", async () => {
     vi.mocked(detectPlatform).mockReturnValue("linux");
     const root = document.createElement("div");
     document.body.appendChild(root);
 
-    renderInstallFlow(root, { mode: "install", hostVersion: "0.1.0" });
+    await renderInstallFlow(root, { mode: "install", hostVersion: "0.1.0" });
 
     const links = [...root.querySelectorAll<HTMLAnchorElement>(".install-pkg-cta a")];
     expect(links.map((link) => link.href)).toEqual([
-      "https://github.com/dantraynor/tailchrome/releases/latest/download/tailchrome-helper-linux-amd64.deb",
-      "https://github.com/dantraynor/tailchrome/releases/latest/download/tailchrome-helper-linux-x86_64.rpm",
+      "https://github.com/dantraynor/tailchrome/releases/download/v0.1.13/tailchrome-helper-linux-amd64.deb",
+      "https://github.com/dantraynor/tailchrome/releases/download/v0.1.13/tailchrome-helper-linux-x86_64.rpm",
     ]);
     expect(root.textContent).toContain("sudo apt install");
     expect(root.textContent).toContain("sudo dnf install");
   });
 
-  it("links to the releases page on unknown platforms", () => {
+  it("renders the pinned Linux ARM64 installer instead of an unchecked binary", async () => {
+    vi.mocked(detectPlatform).mockReturnValue("linux");
+    mockPlatformArch("aarch64");
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+
+    await renderInstallFlow(root, {
+      mode: "install",
+      hostVersion: "0.1.0",
+    });
+
+    const links = [
+      ...root.querySelectorAll<HTMLAnchorElement>(".install-pkg-cta a"),
+    ];
+    expect(links.map((link) => link.href)).toEqual([
+      "https://github.com/dantraynor/tailchrome/releases/download/v0.1.13/tailchrome-install.sh",
+    ]);
+    expect(root.textContent).toContain(
+      'bash ~/Downloads/tailchrome-install.sh --version "v0.1.13"',
+    );
+    expect(root.textContent).toContain("verifies its SHA-256 checksum");
+    expect(root.textContent).toContain(
+      "test \"$(wc -l < tailchrome-install.sh.sha256)\" -eq 1",
+    );
+    expect(root.textContent).toContain("sha256sum --check");
+    expect(root.textContent).toContain("gh attestation verify");
+    expect(root.textContent).toContain("--hostname github.com");
+    expect(root.textContent).toContain(
+      "less ~/Downloads/tailchrome-install.sh",
+    );
+    expect(
+      root.querySelector<HTMLAnchorElement>(
+        'a[href="https://github.com/dantraynor/tailchrome/releases/download/v0.1.13/SHA256SUMS.txt"]',
+      ),
+    ).not.toBeNull();
+    expect(root.textContent).not.toContain(
+      "tailscale-browser-ext-linux-arm64",
+    );
+    expect(root.textContent).not.toContain("chmod +x");
+    expect(root.querySelector(".install-advanced-toggle")).toBeNull();
+
+    links[0]?.click();
+    expect(sendMessage).toHaveBeenCalledWith({ type: "retry-native-host" });
+    expect(chrome.tabs.create).toHaveBeenCalledWith({
+      url: "https://github.com/dantraynor/tailchrome/releases/download/v0.1.13/tailchrome-install.sh",
+    });
+  });
+
+  it("links to the releases page on unknown platforms", async () => {
     vi.mocked(detectPlatform).mockReturnValue("unknown");
     const root = document.createElement("div");
     document.body.appendChild(root);
 
-    renderInstallFlow(root, { mode: "install", hostVersion: "0.1.0" });
+    await renderInstallFlow(root, { mode: "install", hostVersion: "0.1.0" });
 
     const links = [...root.querySelectorAll<HTMLAnchorElement>(".install-pkg-cta a")];
     expect(links.map((link) => link.href)).toEqual([
-      "https://github.com/dantraynor/tailchrome/releases/latest",
+      "https://github.com/dantraynor/tailchrome/releases/tag/v0.1.13",
     ]);
   });
 
-  it("reveals the raw binary fallback and requests retries from its download link", () => {
+  it("does not offer x64 Linux commands for unsupported runtime architectures", async () => {
+    vi.mocked(detectPlatform).mockReturnValue("linux");
+    mockPlatformArch("arm");
     const root = document.createElement("div");
     document.body.appendChild(root);
 
-    renderInstallFlow(root, { mode: "install", hostVersion: "0.1.0" });
+    await renderInstallFlow(root, { mode: "install", hostVersion: "0.1.0" });
+
+    const links = [
+      ...root.querySelectorAll<HTMLAnchorElement>(".install-pkg-cta a"),
+    ];
+    expect(links.map((link) => link.href)).toEqual([
+      "https://github.com/dantraynor/tailchrome/releases/tag/v0.1.13",
+    ]);
+    expect(root.textContent).toContain("No compatible installer was selected");
+    expect(root.textContent).toContain("does not guess an installer");
+    expect(root.textContent).not.toContain("sudo apt install");
+    expect(root.textContent).not.toContain("tailchrome-install.sh");
+    expect(root.querySelector(".install-advanced-toggle")).toBeNull();
+  });
+
+  it("reveals the raw binary fallback and requests retries from its download link", async () => {
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+
+    await renderInstallFlow(root, { mode: "install", hostVersion: "0.1.0" });
 
     const toggle = root.querySelector<HTMLButtonElement>(".install-advanced-toggle")!;
     const section = root.querySelector<HTMLElement>(".install-advanced-section")!;
@@ -166,7 +412,29 @@ describe("renderInstallFlow", () => {
     section.querySelector<HTMLAnchorElement>("a")!.click();
     expect(sendMessage).toHaveBeenCalledWith({ type: "retry-native-host" });
     expect(chrome.tabs.create).toHaveBeenCalledWith({
-      url: "https://github.com/dantraynor/tailchrome/releases/latest/download/tailscale-browser-ext-windows-amd64.exe",
+      url: "https://github.com/dantraynor/tailchrome/releases/download/v0.1.13/tailscale-browser-ext-windows-amd64.exe",
     });
+  });
+
+  it("does not overwrite a newer view after a delayed platform lookup", async () => {
+    let resolvePlatformInfo!: (info: chrome.runtime.PlatformInfo) => void;
+    chrome.runtime.getPlatformInfo = vi.fn(
+      () =>
+        new Promise<chrome.runtime.PlatformInfo>((resolve) => {
+          resolvePlatformInfo = resolve;
+        }),
+    ) as typeof chrome.runtime.getPlatformInfo;
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+
+    const render = renderInstallFlow(root, {
+      mode: "install",
+      hostVersion: "0.1.0",
+    });
+    root.textContent = "A newer view";
+    resolvePlatformInfo(platformInfo("x86-64"));
+    await render;
+
+    expect(root.textContent).toBe("A newer view");
   });
 });

--- a/packages/shared/src/popup/views/install-helpers.ts
+++ b/packages/shared/src/popup/views/install-helpers.ts
@@ -5,6 +5,7 @@ import { renderUiSurfaceFooter } from "../components/ui-surface-row";
 import { sendMessage } from "../popup";
 
 export type Platform = "macos" | "linux" | "windows" | "unknown";
+export type Architecture = "arm64" | "amd64" | "unknown";
 
 export interface InstallerDownload {
   filename: string | null;
@@ -12,19 +13,42 @@ export interface InstallerDownload {
   url: string;
 }
 
-const RELEASE_BASE =
-  "https://github.com/dantraynor/tailchrome/releases/latest/download";
-const RELEASE_PAGE = "https://github.com/dantraynor/tailchrome/releases/latest";
+const RELEASES_BASE = "https://github.com/dantraynor/tailchrome/releases";
+const PINNED_RELEASE_TAG = `v${EXPECTED_HOST_VERSION.replace(/^v/, "")}`;
+const PINNED_RELEASE_BASE = `${RELEASES_BASE}/download/${PINNED_RELEASE_TAG}`;
+const PINNED_RELEASE_PAGE = `${RELEASES_BASE}/tag/${PINNED_RELEASE_TAG}`;
+const PINNED_INSTALL_SCRIPT_URL = `${PINNED_RELEASE_BASE}/tailchrome-install.sh`;
+const PINNED_CHECKSUMS_URL = `${PINNED_RELEASE_BASE}/SHA256SUMS.txt`;
+const VERIFIED_INSTALL_COMMAND =
+  `bash ~/Downloads/tailchrome-install.sh --version "${PINNED_RELEASE_TAG}"`;
+const VERIFY_INSTALL_SCRIPT_COMMAND =
+  "cd ~/Downloads && grep -E '^[0-9a-f]{64}  tailchrome-install\\.sh$' SHA256SUMS.txt > tailchrome-install.sh.sha256 && test \"$(wc -l < tailchrome-install.sh.sha256)\" -eq 1 && sha256sum --check tailchrome-install.sh.sha256";
 
 function releaseAssetURL(filename: string): string {
-  return `${RELEASE_BASE}/${filename}`;
+  return `${PINNED_RELEASE_BASE}/${filename}`;
+}
+
+function companionReleaseDownload(): InstallerDownload {
+  return {
+    filename: null,
+    label: "Open companion release",
+    url: PINNED_RELEASE_PAGE,
+  };
 }
 
 /**
- * Returns package-first installer downloads for the detected platform.
+ * Returns package-first installer downloads for the detected platform and
+ * architecture. Linux ARM64 uses the checksum-verifying release installer
+ * because the OS packages are x64-only.
  */
-export function installerDownloads(platform: Platform): InstallerDownload[] {
+export function installerDownloads(
+  platform: Platform,
+  arch: Architecture = "amd64",
+): InstallerDownload[] {
   if (platform === "macos") {
+    if (arch === "unknown") {
+      return [companionReleaseDownload()];
+    }
     const filename = "tailchrome-helper-macos.pkg";
     return [
       {
@@ -35,6 +59,9 @@ export function installerDownloads(platform: Platform): InstallerDownload[] {
     ];
   }
   if (platform === "windows") {
+    if (arch === "unknown") {
+      return [companionReleaseDownload()];
+    }
     const filename = "tailchrome-helper-windows-x64.msi";
     return [
       {
@@ -45,6 +72,18 @@ export function installerDownloads(platform: Platform): InstallerDownload[] {
     ];
   }
   if (platform === "linux") {
+    if (arch === "arm64") {
+      return [
+        {
+          filename: "tailchrome-install.sh",
+          label: "Download verified Linux ARM64 installer",
+          url: PINNED_INSTALL_SCRIPT_URL,
+        },
+      ];
+    }
+    if (arch === "unknown") {
+      return [companionReleaseDownload()];
+    }
     const deb = "tailchrome-helper-linux-amd64.deb";
     const rpm = "tailchrome-helper-linux-x86_64.rpm";
     return [
@@ -60,27 +99,23 @@ export function installerDownloads(platform: Platform): InstallerDownload[] {
       },
     ];
   }
-  return [
-    {
-      filename: null,
-      label: "Open latest release",
-      url: RELEASE_PAGE,
-    },
-  ];
+  return [companionReleaseDownload()];
 }
 
 /**
  * Returns the filename of the raw native host binary for advanced fallback use.
  */
-export function binaryFilename(platform: Platform): string | null {
-  if (platform === "windows") {
+export function binaryFilename(
+  platform: Platform,
+  arch: Architecture = "amd64",
+): string | null {
+  if (platform === "windows" && arch !== "unknown") {
     return "tailscale-browser-ext-windows-amd64.exe";
   }
   if (platform === "linux") {
-    return "tailscale-browser-ext-linux-amd64";
+    return arch === "amd64" ? "tailscale-browser-ext-linux-amd64" : null;
   }
-  if (platform === "macos") {
-    const arch = detectArch();
+  if (platform === "macos" && arch !== "unknown") {
     return `tailscale-browser-ext-darwin-${arch}`;
   }
   return null;
@@ -89,20 +124,34 @@ export function binaryFilename(platform: Platform): string | null {
 /**
  * Returns the download URL for the raw native host binary.
  */
-export function buildDownloadURL(platform: Platform): string {
-  const filename = binaryFilename(platform);
+export function buildDownloadURL(
+  platform: Platform,
+  arch: Architecture = "amd64",
+): string {
+  if (platform === "linux" && arch === "arm64") {
+    return PINNED_INSTALL_SCRIPT_URL;
+  }
+  const filename = binaryFilename(platform, arch);
   if (filename) {
     return releaseAssetURL(filename);
   }
-  return RELEASE_PAGE;
+  return PINNED_RELEASE_PAGE;
 }
 
 /**
- * Returns the command to run after downloading the raw binary fallback.
- * The binary auto-installs with the hardcoded extension IDs.
+ * Returns the command to run after downloading the fallback. Linux ARM64 uses
+ * the version-pinned verified installer instead of an unchecked raw binary.
+ * Other raw binaries auto-install with the hardcoded extension IDs.
  */
-export function buildRunCommand(platform: Platform): string | null {
-  const filename = binaryFilename(platform);
+export function buildRunCommand(
+  platform: Platform,
+  arch: Architecture = "amd64",
+): string | null {
+  if (platform === "linux" && arch === "arm64") {
+    return VERIFIED_INSTALL_COMMAND;
+  }
+
+  const filename = binaryFilename(platform, arch);
   if (!filename) {
     return null;
   }
@@ -141,11 +190,22 @@ function platformLabel(platform: Platform): string {
 /**
  * Renders the shared install/update flow with platform-adaptive stepper UI.
  */
-export function renderInstallFlow(
+export async function renderInstallFlow(
   root: HTMLElement,
   opts: { mode: "install" | "update"; hostVersion?: string | null },
-): void {
-  root.textContent = "";
+): Promise<void> {
+  // Keep a marker in the root while the asynchronous platform lookup runs. If
+  // another view renders first, it removes the marker and this render stops
+  // rather than overwriting newer state.
+  const renderMarker = document.createComment("loading install flow");
+  root.replaceChildren(renderMarker);
+
+  const platform = detectPlatform();
+  const arch = await detectArch();
+  if (renderMarker.parentNode !== root) {
+    return;
+  }
+
   const view = document.createElement("div");
   view.className = "view";
 
@@ -182,19 +242,22 @@ export function renderInstallFlow(
     content.appendChild(versionInfo);
   }
 
-  const platform = detectPlatform();
-  const downloads = installerDownloads(platform);
+  const downloads = installerDownloads(platform, arch);
   const filename = downloads[0]?.filename ?? null;
-  const runCmd = buildRunCommand(platform);
+  const unsupported = platform === "unknown" || arch === "unknown";
+  const usesVerifiedLinuxInstaller = platform === "linux" && arch === "arm64";
+  const runCmd = buildRunCommand(platform, arch);
 
   const steps = document.createElement("div");
   steps.className = "install-steps";
 
   const step1 = createStep("1");
   step1.label.textContent =
-    platform === "unknown"
-      ? "Download the helper app"
-      : "Download the helper installer";
+    usesVerifiedLinuxInstaller
+      ? "Download the verified installer"
+      : unsupported
+        ? "Open release information"
+        : "Download the helper installer";
 
   const cta = document.createElement("div");
   cta.className = "install-pkg-cta";
@@ -207,9 +270,11 @@ export function renderInstallFlow(
 
   const step2 = createStep("2");
   step2.label.textContent =
-    platform === "unknown" ? "Open the downloaded file" : "Run the installer";
+    unsupported ? "Review supported releases" : "Run the installer";
   step2.content.appendChild(step2.label);
-  step2.content.appendChild(createInstallInstructions(platform, filename, opts.mode));
+  step2.content.appendChild(
+    createInstallInstructions(platform, arch, filename, opts.mode),
+  );
   steps.appendChild(step2.root);
 
   const step3 = createStep("3");
@@ -217,20 +282,22 @@ export function renderInstallFlow(
   const doneBody = document.createElement("div");
   doneBody.className = "install-step-body";
   doneBody.textContent =
-    "Leave this popup open or reopen it after setup. Tailchrome will connect automatically.";
+    unsupported
+      ? "Return after installing a supported helper build. Tailchrome will connect automatically."
+      : "Leave this popup open or reopen it after setup. Tailchrome will connect automatically.";
   step3.content.appendChild(step3.label);
   step3.content.appendChild(doneBody);
   steps.appendChild(step3.root);
 
   content.appendChild(steps);
 
-  if (runCmd) {
-    content.appendChild(createRawBinaryFallback(platform, runCmd));
+  if (runCmd && !usesVerifiedLinuxInstaller) {
+    content.appendChild(createRawBinaryFallback(platform, arch, runCmd));
   }
 
   view.appendChild(content);
   renderUiSurfaceFooter(view);
-  root.appendChild(view);
+  root.replaceChildren(view);
 }
 
 function createDownloadButton(download: InstallerDownload): HTMLElement {
@@ -255,6 +322,7 @@ function createDownloadButton(download: InstallerDownload): HTMLElement {
 
 function createInstallInstructions(
   platform: Platform,
+  arch: Architecture,
   filename: string | null,
   mode: "install" | "update",
 ): HTMLElement {
@@ -263,7 +331,10 @@ function createInstallInstructions(
   const body = document.createElement("div");
   body.className = "install-step-body";
 
-  if (platform === "macos") {
+  if (platform === "unknown" || arch === "unknown") {
+    body.textContent =
+      "No compatible installer was selected. Review the companion release for supported operating systems and architectures.";
+  } else if (platform === "macos") {
     body.textContent =
       "Open the downloaded package and complete the installer. Setup runs automatically when the package finishes.";
   } else if (platform === "windows") {
@@ -274,6 +345,9 @@ function createInstallInstructions(
     body.appendChild(
       document.createTextNode(" in your Downloads folder and double-click it."),
     );
+  } else if (platform === "linux" && arch === "arm64") {
+    body.textContent =
+      "Run the version-pinned installer. It downloads the Linux ARM64 helper, verifies its SHA-256 checksum, and registers Tailchrome with your browsers:";
   } else if (platform === "linux") {
     body.textContent =
       "Install the package with your system installer, or use one of these commands:";
@@ -283,19 +357,27 @@ function createInstallInstructions(
 
   wrapper.appendChild(body);
 
-  if (platform === "linux") {
+  if (platform === "linux" && arch === "arm64") {
+    appendVerifiedLinuxInstallerInstructions(wrapper);
+  } else if (platform === "linux" && arch === "amd64") {
     wrapper.appendChild(createCodeBlock("sudo apt install ~/Downloads/tailchrome-helper-linux-amd64.deb"));
     wrapper.appendChild(createCodeBlock("sudo dnf install ~/Downloads/tailchrome-helper-linux-x86_64.rpm"));
   }
 
   const hint = document.createElement("div");
   hint.className = "install-step-hint";
-  if (platform === "macos") {
+  if (platform === "unknown" || arch === "unknown") {
+    hint.textContent =
+      "Tailchrome does not guess an installer when runtime architecture information is unsupported.";
+  } else if (platform === "macos") {
     hint.textContent =
       "If setup needs repair later, open Tailchrome Helper from Applications.";
   } else if (platform === "windows" && mode === "update") {
     hint.textContent =
       'If it still says "Update Available" after setup, fully quit your browser and reopen it.';
+  } else if (platform === "linux" && arch === "arm64") {
+    hint.textContent =
+      "Setup stops without installing anything if the published checksum does not match.";
   } else if (platform === "linux") {
     hint.textContent =
       "The package registers system-wide browser manifests for Chrome, Chromium, Edge, and Firefox.";
@@ -308,7 +390,43 @@ function createInstallInstructions(
   return wrapper;
 }
 
-function createRawBinaryFallback(platform: Platform, runCmd: string): HTMLElement {
+function appendVerifiedLinuxInstallerInstructions(
+  container: HTMLElement,
+): void {
+  const checksum = document.createElement("a");
+  checksum.className = "btn btn-secondary btn-link";
+  checksum.href = PINNED_CHECKSUMS_URL;
+  checksum.target = "_blank";
+  checksum.rel = "noopener";
+  checksum.textContent = "Download release checksums";
+  checksum.addEventListener("click", (e) => {
+    e.preventDefault();
+    chrome.tabs.create({ url: checksum.href });
+  });
+  container.appendChild(checksum);
+  container.appendChild(createCodeBlock(VERIFY_INSTALL_SCRIPT_COMMAND));
+
+  const provenance = document.createElement("p");
+  provenance.className = "install-step-hint";
+  provenance.textContent =
+    "If GitHub CLI is installed, verify provenance too. Inspect the script before running it.";
+  container.appendChild(provenance);
+  container.appendChild(
+    createCodeBlock(
+      "gh attestation verify ~/Downloads/tailchrome-install.sh --hostname github.com --repo dantraynor/tailchrome",
+    ),
+  );
+  container.appendChild(
+    createCodeBlock("less ~/Downloads/tailchrome-install.sh"),
+  );
+  container.appendChild(createCodeBlock(VERIFIED_INSTALL_COMMAND));
+}
+
+function createRawBinaryFallback(
+  platform: Platform,
+  arch: Architecture,
+  runCmd: string,
+): HTMLElement {
   const container = document.createElement("div");
 
   const advancedToggle = document.createElement("button");
@@ -320,7 +438,7 @@ function createRawBinaryFallback(platform: Platform, runCmd: string): HTMLElemen
 
   const download = document.createElement("a");
   download.className = "btn btn-secondary btn-link";
-  download.href = buildDownloadURL(platform);
+  download.href = buildDownloadURL(platform, arch);
   download.target = "_blank";
   download.rel = "noopener";
   download.textContent = "Download raw helper binary";
@@ -400,20 +518,104 @@ function createCodeBlock(command: string): HTMLElement {
 }
 
 /**
- * Detects CPU architecture: arm64 vs amd64.
- * Checks userAgentData (Chromium) and falls back to the UA string (Firefox).
- * Firefox doesn't support userAgentData and reports ARM Macs as Intel in the
- * UA string, so we also check the platform string.
+ * Detects CPU architecture through the extension runtime API. Reduced browser
+ * user-agent values do not reliably expose architecture, so navigator and
+ * WebGL checks are only used if the runtime API is unavailable.
  */
-function detectArch(): "arm64" | "amd64" {
-  const uaData = (navigator as unknown as { userAgentData?: { architecture?: string } }).userAgentData;
-  if (uaData?.architecture === "arm") {
-    return "arm64";
+export async function detectArch(): Promise<Architecture> {
+  try {
+    const info = await getPlatformInfo();
+    return normalizeArchitecture(info?.arch);
+  } catch {
+    // Fall through when the API is unavailable or the platform lookup fails.
   }
 
-  const platform = navigator.platform?.toLowerCase() ?? "";
-  if (platform.includes("aarch64") || platform.includes("arm")) {
+  return detectArchFallback();
+}
+
+function normalizeArchitecture(value: unknown): Architecture {
+  const arch = String(value ?? "").toLowerCase();
+  if (arch === "arm64" || arch === "aarch64") {
     return "arm64";
+  }
+  if (arch === "x86-64" || arch === "x86_64" || arch === "amd64") {
+    return "amd64";
+  }
+  return "unknown";
+}
+
+/**
+ * Supports both Firefox's callback-style chrome compatibility API and
+ * Chromium's Promise-returning API. Some implementations expose both, so only
+ * the first result is allowed to settle the lookup.
+ */
+function getPlatformInfo(): Promise<chrome.runtime.PlatformInfo> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+
+    const resolveOnce = (info: chrome.runtime.PlatformInfo): void => {
+      if (settled) return;
+      settled = true;
+      resolve(info);
+    };
+    const rejectOnce = (error: unknown): void => {
+      if (settled) return;
+      settled = true;
+      reject(error);
+    };
+
+    try {
+      const getPlatformInfoCompat = chrome.runtime
+        .getPlatformInfo as unknown as (
+        callback: (info: chrome.runtime.PlatformInfo) => void,
+      ) => void | Promise<chrome.runtime.PlatformInfo>;
+      const result = getPlatformInfoCompat.call(chrome.runtime, (info) => {
+        // lastError is only valid while an extension API callback is running.
+        const lastError = chrome.runtime.lastError;
+        if (lastError) {
+          rejectOnce(new Error(lastError.message ?? "Platform lookup failed"));
+          return;
+        }
+        resolveOnce(info);
+      });
+
+      if (result && typeof result.then === "function") {
+        result.then(resolveOnce, rejectOnce);
+      }
+    } catch (error) {
+      rejectOnce(error);
+    }
+  });
+}
+
+function detectArchFallback(): Architecture {
+  const userAgentData = (
+    navigator as unknown as { userAgentData?: { architecture?: string } }
+  ).userAgentData;
+  const highEntropyArchitecture = normalizeArchitecture(
+    userAgentData?.architecture,
+  );
+  if (highEntropyArchitecture !== "unknown") {
+    return highEntropyArchitecture;
+  }
+
+  const platformAndUA =
+    `${navigator.platform ?? ""} ${navigator.userAgent ?? ""}`.toLowerCase();
+  if (
+    platformAndUA.includes("aarch64") ||
+    platformAndUA.includes("arm64") ||
+    platformAndUA.includes("armv8")
+  ) {
+    return "arm64";
+  }
+  if (
+    platformAndUA.includes("x86_64") ||
+    platformAndUA.includes("x86-64") ||
+    platformAndUA.includes("amd64") ||
+    platformAndUA.includes("win64") ||
+    platformAndUA.includes("x64")
+  ) {
+    return "amd64";
   }
 
   try {
@@ -432,5 +634,5 @@ function detectArch(): "arm64" | "amd64" {
     // Canvas may be unavailable in test or restricted extension contexts.
   }
 
-  return "amd64";
+  return "unknown";
 }

--- a/packaging/linux/README.md
+++ b/packaging/linux/README.md
@@ -12,7 +12,12 @@ The packages install the helper binary at `/usr/lib/tailchrome/tailscale-browser
 - Edge: `/etc/opt/edge/native-messaging-hosts/`
 - Firefox: `/usr/lib/mozilla/native-messaging-hosts/` (the .rpm additionally installs to `/usr/lib64/mozilla/native-messaging-hosts/`, where Fedora/RHEL Firefox builds look)
 
-For additional Chromium-family browsers that do not support these system manifest locations, use the raw helper binary fallback from the release page. The raw binary runs `-install-now` for the current user and writes per-user manifests.
+For Linux ARM64, or for additional Chromium-family browsers that do not use
+these system manifest locations, use `tailchrome-install.sh` from the matching
+tagged release. The version-pinned script selects the amd64 or ARM64 raw helper,
+verifies its release checksum, runs `-install-now`, and confirms the per-user
+installation was created. Verify the installer itself against the same release's
+`SHA256SUMS.txt` before running it; do not pipe a mutable download into a shell.
 
 ## Build
 

--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -23,7 +23,7 @@ dotnet tool install --global wix --version 6.0.2
 Then build from the repository root:
 
 ```powershell
-.\packaging\windows\build-msi.ps1 -Version v0.1.12
+.\packaging\windows\build-msi.ps1 -Version v0.1.13
 ```
 
 The release workflow may sign the MSI when Windows signing secrets are configured. Unsigned local builds still work for manual testing.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# Install or remove Tailchrome's per-user native-messaging helper on macOS and
+# Linux. System packages remain the preferred installation method where they
+# are available.
+set -euo pipefail
+
+usage() {
+  printf 'Usage: %s --version vX.Y.Z [--uninstall]\n' "${0##*/}" >&2
+}
+
+die() {
+  printf '%s: %s\n' "${0##*/}" "$1" >&2
+  exit 1
+}
+
+version=""
+uninstall=false
+
+while (($# > 0)); do
+  case "$1" in
+    --version)
+      (($# >= 2)) || {
+        usage
+        die "--version requires a value"
+      }
+      version="$2"
+      shift 2
+      ;;
+    --uninstall)
+      uninstall=true
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+if [[ ! "$version" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+  usage
+  die "--version must be an explicit release tag such as v1.2.3"
+fi
+
+system_name="$(uname -s)"
+case "$system_name" in
+  Darwin) platform="darwin" ;;
+  Linux) platform="linux" ;;
+  *) die "unsupported operating system: $system_name" ;;
+esac
+
+machine_name="$(uname -m)"
+case "$machine_name" in
+  x86_64 | amd64) architecture="amd64" ;;
+  arm64 | aarch64) architecture="arm64" ;;
+  *) die "unsupported architecture: $machine_name" ;;
+esac
+
+if [[ "$uninstall" == false ]]; then
+  command -v curl >/dev/null 2>&1 || die "curl is required"
+  if command -v sha256sum >/dev/null 2>&1; then
+    checksum_tool="sha256sum"
+  elif command -v shasum >/dev/null 2>&1; then
+    checksum_tool="shasum"
+  else
+    die "sha256sum or shasum is required"
+  fi
+fi
+
+asset="tailscale-browser-ext-$platform-$architecture"
+release_base_url="https://github.com/dantraynor/tailchrome/releases/download/$version"
+user_home="${HOME:-}"
+[[ -n "$user_home" ]] || die "HOME is not set"
+
+case "$platform" in
+  linux)
+    installed_path="$user_home/.local/share/tailscale/browser-ext/tailscale-browser-ext"
+    ;;
+  darwin)
+    installed_path="$user_home/Library/Application Support/Tailscale/BrowserExt/tailscale-browser-ext"
+    ;;
+esac
+
+if [[ "$uninstall" == true ]]; then
+  [[ -x "$installed_path" ]] ||
+    die "installed helper not found at $installed_path"
+  if ! "$installed_path" -uninstall; then
+    die "uninstall failed"
+  fi
+  printf 'Uninstalled helper from: %s\n' "$installed_path"
+  exit 0
+fi
+
+if [[ "$uninstall" == false ]]; then
+  umask 077
+  temp_dir="$(mktemp -d "${TMPDIR:-/tmp}/tailchrome-install.XXXXXX")" ||
+    die "could not create a temporary directory"
+
+  # ShellCheck cannot see the indirect invocations through these traps.
+  # shellcheck disable=SC2317,SC2329
+  cleanup() {
+    local cleanup_status=$?
+    trap - EXIT HUP INT TERM
+    if [[ -n "${temp_dir:-}" ]]; then
+      rm -rf -- "$temp_dir" || :
+    fi
+    exit "$cleanup_status"
+  }
+  trap cleanup EXIT
+  trap 'exit 129' HUP
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
+
+  artifact_path="$temp_dir/$asset"
+  checksum_path="$temp_dir/SHA256SUMS.txt"
+  if ! curl --disable --fail --silent --show-error --location \
+    --proto '=https' --proto-redir '=https' --tlsv1.2 \
+    --output "$checksum_path" \
+    "$release_base_url/SHA256SUMS.txt"; then
+    die "checksum download failed"
+  fi
+
+  matching_checksum=""
+  checksum_matches=0
+  checksum_line_pattern='^([0-9a-f]{64})[[:space:]]+[*]?([A-Za-z0-9][A-Za-z0-9._-]*)$'
+  while IFS= read -r checksum_line || [[ -n "$checksum_line" ]]; do
+    [[ -n "$checksum_line" ]] || continue
+    if [[ ! "$checksum_line" =~ $checksum_line_pattern ]]; then
+      die "unsafe or malformed checksum entry"
+    fi
+    if [[ "${BASH_REMATCH[2]}" == "$asset" ]]; then
+      matching_checksum="${BASH_REMATCH[1]}"
+      checksum_matches=$((checksum_matches + 1))
+    fi
+  done <"$checksum_path"
+
+  if ((checksum_matches != 1)); then
+    die "expected exactly one checksum entry for $asset"
+  fi
+
+  if ! curl --disable --fail --silent --show-error --location \
+    --proto '=https' --proto-redir '=https' --tlsv1.2 \
+    --output "$artifact_path" \
+    "$release_base_url/$asset"; then
+    die "artifact download failed for $platform/$architecture"
+  fi
+
+  if [[ "$checksum_tool" == "sha256sum" ]]; then
+    checksum_output="$(sha256sum "$artifact_path")" ||
+      die "checksum verification failed"
+  else
+    checksum_output="$(shasum -a 256 "$artifact_path")" ||
+      die "checksum verification failed"
+  fi
+  actual_checksum="${checksum_output%% *}"
+  if [[ "$actual_checksum" != "$matching_checksum" ]]; then
+    die "checksum verification failed"
+  fi
+
+  if command -v gh >/dev/null 2>&1 &&
+    gh attestation verify --help >/dev/null 2>&1 &&
+    gh auth status --hostname github.com >/dev/null 2>&1; then
+    if ! gh attestation verify "$artifact_path" \
+      --hostname github.com \
+      --repo dantraynor/tailchrome >/dev/null; then
+      die "attestation verification failed"
+    fi
+  else
+    printf '%s\n' \
+      "Warning: GitHub CLI attestation verification is unavailable; the checksum and artifact share the GitHub Release trust boundary." >&2
+  fi
+
+  chmod 755 "$artifact_path" || die "could not make the verified artifact executable"
+  if ! "$artifact_path" -install-now; then
+    die "-install-now failed"
+  fi
+  [[ -x "$installed_path" ]] ||
+    die "installed helper was not created at $installed_path"
+
+  printf 'Installed helper: %s\n' "$installed_path"
+  printf 'Uninstall with:\n  "%s" -uninstall\n' "$installed_path"
+  exit 0
+fi
+
+die "unreachable installer state"

--- a/scripts/install.test.sh
+++ b/scripts/install.test.sh
@@ -1,0 +1,857 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+INSTALLER="$ROOT/scripts/install.sh"
+
+tests_run=0
+tests_failed=0
+
+make_platform_bin() {
+  local bin_dir="$1"
+  local system_name="$2"
+  local machine_name="$3"
+  local bash_path
+
+  bash_path="$(command -v bash)"
+  mkdir -p "$bin_dir"
+  ln -s "$bash_path" "$bin_dir/bash"
+  {
+    printf '%s\n' '#!/bin/sh'
+    printf '%s\n' "case \"\$1\" in"
+    printf '  -s) printf '"'"'%%s\\n'"'"' %q ;;\n' "$system_name"
+    printf '  -m) printf '"'"'%%s\\n'"'"' %q ;;\n' "$machine_name"
+    printf '%s\n' '  *) exit 2 ;;'
+    printf '%s\n' 'esac'
+  } >"$bin_dir/uname"
+  chmod 755 "$bin_dir/uname"
+}
+
+write_stub() {
+  local path="$1"
+
+  {
+    printf '%s\n' '#!/bin/sh'
+    command cat
+  } >"$path"
+  chmod 755 "$path"
+}
+
+link_command() {
+  local bin_dir="$1"
+  local command_name="$2"
+  local command_path
+
+  command_path="$(command -v "$command_name")"
+  ln -s "$command_path" "$bin_dir/$command_name"
+}
+
+link_checksum_command() {
+  local bin_dir="$1"
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    link_command "$bin_dir" sha256sum
+  else
+    link_command "$bin_dir" shasum
+  fi
+}
+
+write_fixture_curl_stub() {
+  local bin_dir="$1"
+
+  link_command "$bin_dir" cp
+  write_stub "$bin_dir/curl" <<'STUB'
+set -eu
+output=""
+url=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output) output="$2"; shift 2 ;;
+    http*) url="$1"; shift ;;
+    *) shift ;;
+  esac
+done
+if [ -n "${TEST_CURL_LOG:-}" ]; then
+  printf "%s\n" "$url" >>"$TEST_CURL_LOG"
+fi
+case "$url" in
+  */SHA256SUMS.txt)
+    [ "${TEST_CHECKSUM_DOWNLOAD_FAIL:-0}" = 0 ] || exit 22
+    cp "$TEST_CHECKSUM_FIXTURE" "$output"
+    ;;
+  *)
+    [ "${TEST_ARTIFACT_DOWNLOAD_FAIL:-0}" = 0 ] || exit 22
+    cp "$TEST_ARTIFACT_FIXTURE" "$output"
+    ;;
+esac
+STUB
+}
+
+sha256_of() {
+  local file="$1"
+  local output
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    output="$(sha256sum "$file")"
+  else
+    output="$(shasum -a 256 "$file")"
+  fi
+  printf '%s\n' "${output%% *}"
+}
+
+pass_test() {
+  tests_run=$((tests_run + 1))
+  printf 'ok %d - %s\n' "$tests_run" "$1"
+}
+
+fail_test() {
+  tests_run=$((tests_run + 1))
+  tests_failed=$((tests_failed + 1))
+  printf 'not ok %d - %s\n' "$tests_run" "$1"
+  printf '  %s\n' "$2"
+}
+
+test_requires_explicit_version() {
+  local output
+
+  if output="$("$INSTALLER" 2>&1)"; then
+    fail_test "requires an explicit release version" "installer unexpectedly succeeded"
+  elif [[ "$output" != *"Usage:"* ]]; then
+    fail_test "requires an explicit release version" "missing usage guidance: $output"
+  else
+    pass_test "requires an explicit release version"
+  fi
+}
+
+test_rejects_non_release_version() {
+  local output
+
+  if output="$("$INSTALLER" --version latest 2>&1)"; then
+    fail_test "rejects a non-release version" "installer unexpectedly succeeded"
+  elif [[ "$output" != *"--version must be an explicit release tag"* ]]; then
+    fail_test "rejects a non-release version" "unexpected error: $output"
+  else
+    pass_test "rejects a non-release version"
+  fi
+}
+
+test_rejects_unsupported_os() {
+  local case_dir output
+  case_dir="$(mktemp -d "${TMPDIR:-/tmp}/tailchrome-install-test.XXXXXX")"
+  make_platform_bin "$case_dir/bin" "Windows_NT" "x86_64"
+
+  if output="$(PATH="$case_dir/bin" "$INSTALLER" --version v1.2.3 2>&1)"; then
+    fail_test "rejects an unsupported operating system" "installer unexpectedly succeeded"
+  elif [[ "$output" != *"unsupported operating system: Windows_NT"* ]]; then
+    fail_test "rejects an unsupported operating system" "unexpected error: $output"
+  else
+    pass_test "rejects an unsupported operating system"
+  fi
+
+  rm -rf "$case_dir"
+}
+
+test_rejects_unsupported_architecture() {
+  local case_dir output
+  case_dir="$(mktemp -d "${TMPDIR:-/tmp}/tailchrome-install-test.XXXXXX")"
+  make_platform_bin "$case_dir/bin" "Linux" "riscv64"
+
+  if output="$(PATH="$case_dir/bin" "$INSTALLER" --version v1.2.3 2>&1)"; then
+    fail_test "rejects an unsupported architecture" "installer unexpectedly succeeded"
+  elif [[ "$output" != *"unsupported architecture: riscv64"* ]]; then
+    fail_test "rejects an unsupported architecture" "unexpected error: $output"
+  else
+    pass_test "rejects an unsupported architecture"
+  fi
+
+  rm -rf "$case_dir"
+}
+
+test_requires_curl() {
+  local case_dir output
+  case_dir="$(mktemp -d "${TMPDIR:-/tmp}/tailchrome-install-test.XXXXXX")"
+  make_platform_bin "$case_dir/bin" "Linux" "x86_64"
+
+  if output="$(PATH="$case_dir/bin" "$INSTALLER" --version v1.2.3 2>&1)"; then
+    fail_test "requires curl for installation" "installer unexpectedly succeeded"
+  elif [[ "$output" != *"curl is required"* ]]; then
+    fail_test "requires curl for installation" "unexpected error: $output"
+  else
+    pass_test "requires curl for installation"
+  fi
+
+  rm -rf "$case_dir"
+}
+
+test_requires_checksum_tool() {
+  local case_dir output
+  case_dir="$(mktemp -d "${TMPDIR:-/tmp}/tailchrome-install-test.XXXXXX")"
+  make_platform_bin "$case_dir/bin" "Linux" "x86_64"
+  write_stub "$case_dir/bin/curl" <<'STUB'
+exit 0
+STUB
+
+  if output="$(PATH="$case_dir/bin" "$INSTALLER" --version v1.2.3 2>&1)"; then
+    fail_test "requires a SHA-256 checksum tool" "installer unexpectedly succeeded"
+  elif [[ "$output" != *"sha256sum or shasum is required"* ]]; then
+    fail_test "requires a SHA-256 checksum tool" "unexpected error: $output"
+  else
+    pass_test "requires a SHA-256 checksum tool"
+  fi
+
+  rm -rf "$case_dir"
+}
+
+test_uses_tag_pinned_url() {
+  local system_name="$1"
+  local machine_name="$2"
+  local expected_asset="$3"
+  local label="$4"
+  local case_dir output expected_log release_url
+  case_dir="$(mktemp -d "${TMPDIR:-/tmp}/tailchrome-install-test.XXXXXX")"
+  make_platform_bin "$case_dir/bin" "$system_name" "$machine_name"
+  link_command "$case_dir/bin" mktemp
+  link_command "$case_dir/bin" rm
+  link_checksum_command "$case_dir/bin"
+  write_fixture_curl_stub "$case_dir/bin"
+  printf '%064d  %s\n' 0 "$expected_asset" >"$case_dir/SHA256SUMS.txt"
+  release_url="https://github.com/dantraynor/tailchrome/releases/download/v1.2.3"
+  expected_log="${release_url}/SHA256SUMS.txt
+${release_url}/${expected_asset}"
+
+  if output="$(
+    TEST_ARTIFACT_DOWNLOAD_FAIL=1 \
+      TEST_ARTIFACT_FIXTURE="$case_dir/unused-artifact" \
+      TEST_CHECKSUM_FIXTURE="$case_dir/SHA256SUMS.txt" \
+      TEST_CURL_LOG="$case_dir/curl.log" \
+      TMPDIR="$case_dir" \
+      PATH="$case_dir/bin" \
+      "$INSTALLER" --version v1.2.3 2>&1
+  )"; then
+    fail_test "$label" "installer unexpectedly succeeded"
+  elif [[ "$output" != *"artifact download failed"* ]]; then
+    fail_test "$label" "unexpected error: $output"
+  elif [[ ! -f "$case_dir/curl.log" ]] ||
+    [[ "$(command cat "$case_dir/curl.log")" != "$expected_log" ]]; then
+    fail_test "$label" "unexpected request order: $(command cat "$case_dir/curl.log" 2>/dev/null)"
+  else
+    pass_test "$label"
+  fi
+
+  rm -rf "$case_dir"
+}
+
+test_reports_checksum_download_failure() {
+  local case_dir output
+  case_dir="$(mktemp -d "${TMPDIR:-/tmp}/tailchrome-install-test.XXXXXX")"
+  make_platform_bin "$case_dir/bin" "Darwin" "arm64"
+  link_command "$case_dir/bin" mktemp
+  link_command "$case_dir/bin" rm
+  link_checksum_command "$case_dir/bin"
+  write_stub "$case_dir/bin/curl" <<'STUB'
+output=""
+url=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output) output="$2"; shift 2 ;;
+    http*) url="$1"; shift ;;
+    *) shift ;;
+  esac
+done
+case "$url" in
+  */SHA256SUMS.txt) exit 22 ;;
+  *) printf "%s\n" "#!/bin/sh" "exit 0" >"$output" ;;
+esac
+STUB
+
+  if output="$(
+    TMPDIR="$case_dir" \
+      PATH="$case_dir/bin" \
+      "$INSTALLER" --version v1.2.3 2>&1
+  )"; then
+    fail_test "reports a checksum download failure" "installer unexpectedly succeeded"
+  elif [[ "$output" != *"checksum download failed"* ]]; then
+    fail_test "reports a checksum download failure" "unexpected error: $output"
+  else
+    pass_test "reports a checksum download failure"
+  fi
+
+  rm -rf "$case_dir"
+}
+
+test_rejects_missing_checksum_entry() {
+  local case_dir output expected_url
+  case_dir="$(mktemp -d "${TMPDIR:-/tmp}/tailchrome-install-test.XXXXXX")"
+  make_platform_bin "$case_dir/bin" "Linux" "aarch64"
+  link_command "$case_dir/bin" mktemp
+  link_command "$case_dir/bin" rm
+  link_checksum_command "$case_dir/bin"
+  write_fixture_curl_stub "$case_dir/bin"
+  write_stub "$case_dir/artifact" <<'STUB'
+exit 0
+STUB
+  printf '%064d  unrelated-file\n' 0 >"$case_dir/SHA256SUMS.txt"
+  expected_url="https://github.com/dantraynor/tailchrome/releases/download/v1.2.3/SHA256SUMS.txt"
+
+  if output="$(
+    TEST_ARTIFACT_FIXTURE="$case_dir/artifact" \
+      TEST_CHECKSUM_FIXTURE="$case_dir/SHA256SUMS.txt" \
+      TEST_CURL_LOG="$case_dir/curl.log" \
+      TMPDIR="$case_dir" \
+      PATH="$case_dir/bin" \
+      "$INSTALLER" --version v1.2.3 2>&1
+  )"; then
+    fail_test "rejects a missing checksum entry" "installer unexpectedly succeeded"
+  elif [[ "$output" != *"exactly one checksum entry"* ]]; then
+    fail_test "rejects a missing checksum entry" "unexpected error: $output"
+  elif [[ "$(command cat "$case_dir/curl.log")" != "$expected_url" ]]; then
+    fail_test "rejects a missing checksum entry" "artifact was requested before the manifest was validated"
+  else
+    pass_test "rejects a missing checksum entry"
+  fi
+
+  rm -rf "$case_dir"
+}
+
+test_rejects_duplicate_checksum_entry() {
+  local case_dir output asset
+  case_dir="$(mktemp -d "${TMPDIR:-/tmp}/tailchrome-install-test.XXXXXX")"
+  asset="tailscale-browser-ext-linux-arm64"
+  make_platform_bin "$case_dir/bin" "Linux" "arm64"
+  link_command "$case_dir/bin" mktemp
+  link_command "$case_dir/bin" rm
+  link_checksum_command "$case_dir/bin"
+  write_fixture_curl_stub "$case_dir/bin"
+  write_stub "$case_dir/artifact" <<'STUB'
+exit 0
+STUB
+  {
+    printf '%064d  %s\n' 0 "$asset"
+    printf '%064d  %s\n' 1 "$asset"
+  } >"$case_dir/SHA256SUMS.txt"
+
+  if output="$(
+    TEST_ARTIFACT_FIXTURE="$case_dir/artifact" \
+      TEST_CHECKSUM_FIXTURE="$case_dir/SHA256SUMS.txt" \
+      TMPDIR="$case_dir" \
+      PATH="$case_dir/bin" \
+      "$INSTALLER" --version v1.2.3 2>&1
+  )"; then
+    fail_test "rejects a duplicate checksum entry" "installer unexpectedly succeeded"
+  elif [[ "$output" != *"exactly one checksum entry"* ]]; then
+    fail_test "rejects a duplicate checksum entry" "unexpected error: $output"
+  else
+    pass_test "rejects a duplicate checksum entry"
+  fi
+
+  rm -rf "$case_dir"
+}
+
+test_rejects_unsafe_checksum_entry() {
+  local case_dir output
+  case_dir="$(mktemp -d "${TMPDIR:-/tmp}/tailchrome-install-test.XXXXXX")"
+  make_platform_bin "$case_dir/bin" "Darwin" "x86_64"
+  link_command "$case_dir/bin" mktemp
+  link_command "$case_dir/bin" rm
+  link_checksum_command "$case_dir/bin"
+  write_fixture_curl_stub "$case_dir/bin"
+  write_stub "$case_dir/artifact" <<'STUB'
+exit 0
+STUB
+  printf '%064d  ../tailscale-browser-ext-darwin-amd64\n' 0 \
+    >"$case_dir/SHA256SUMS.txt"
+
+  if output="$(
+    TEST_ARTIFACT_FIXTURE="$case_dir/artifact" \
+      TEST_CHECKSUM_FIXTURE="$case_dir/SHA256SUMS.txt" \
+      TMPDIR="$case_dir" \
+      PATH="$case_dir/bin" \
+      "$INSTALLER" --version v1.2.3 2>&1
+  )"; then
+    fail_test "rejects an unsafe checksum entry" "installer unexpectedly succeeded"
+  elif [[ "$output" != *"unsafe or malformed checksum entry"* ]]; then
+    fail_test "rejects an unsafe checksum entry" "unexpected error: $output"
+  else
+    pass_test "rejects an unsafe checksum entry"
+  fi
+
+  rm -rf "$case_dir"
+}
+
+test_rejects_checksum_mismatch() {
+  local case_dir output asset
+  case_dir="$(mktemp -d "${TMPDIR:-/tmp}/tailchrome-install-test.XXXXXX")"
+  asset="tailscale-browser-ext-darwin-arm64"
+  make_platform_bin "$case_dir/bin" "Darwin" "arm64"
+  link_command "$case_dir/bin" mktemp
+  link_command "$case_dir/bin" rm
+  link_checksum_command "$case_dir/bin"
+  write_fixture_curl_stub "$case_dir/bin"
+  write_stub "$case_dir/artifact" <<'STUB'
+exit 0
+STUB
+  printf '%064d  %s\n' 0 "$asset" >"$case_dir/SHA256SUMS.txt"
+
+  if output="$(
+    TEST_ARTIFACT_FIXTURE="$case_dir/artifact" \
+      TEST_CHECKSUM_FIXTURE="$case_dir/SHA256SUMS.txt" \
+      TMPDIR="$case_dir" \
+      PATH="$case_dir/bin" \
+      "$INSTALLER" --version v1.2.3 2>&1
+  )"; then
+    fail_test "rejects a checksum mismatch" "installer unexpectedly succeeded"
+  elif [[ "$output" != *"checksum verification failed"* ]]; then
+    fail_test "rejects a checksum mismatch" "unexpected error: $output"
+  else
+    pass_test "rejects a checksum mismatch"
+  fi
+
+  rm -rf "$case_dir"
+}
+
+test_stops_when_attestation_verification_fails() {
+  local case_dir output asset digest
+  case_dir="$(mktemp -d "${TMPDIR:-/tmp}/tailchrome-install-test.XXXXXX")"
+  asset="tailscale-browser-ext-linux-amd64"
+  make_platform_bin "$case_dir/bin" "Linux" "amd64"
+  link_command "$case_dir/bin" mktemp
+  link_command "$case_dir/bin" rm
+  link_checksum_command "$case_dir/bin"
+  write_fixture_curl_stub "$case_dir/bin"
+  write_stub "$case_dir/bin/gh" <<'STUB'
+case "$*" in
+  "attestation verify --help" | "auth status --hostname github.com") exit 0 ;;
+  attestation\ verify\ *)
+    printf "%s\n" "$@" >"$TEST_GH_LOG"
+    exit 1
+    ;;
+  *) exit 2 ;;
+esac
+STUB
+  write_stub "$case_dir/artifact" <<'STUB'
+exit 0
+STUB
+  digest="$(sha256_of "$case_dir/artifact")"
+  printf '%s  %s\n' "$digest" "$asset" >"$case_dir/SHA256SUMS.txt"
+
+  if output="$(
+    TEST_ARTIFACT_FIXTURE="$case_dir/artifact" \
+      TEST_CHECKSUM_FIXTURE="$case_dir/SHA256SUMS.txt" \
+      TEST_GH_LOG="$case_dir/gh.log" \
+      TMPDIR="$case_dir" \
+      PATH="$case_dir/bin" \
+      "$INSTALLER" --version v1.2.3 2>&1
+  )"; then
+    fail_test "stops when attestation verification fails" "installer unexpectedly succeeded"
+  elif [[ "$output" != *"attestation verification failed"* ]]; then
+    fail_test "stops when attestation verification fails" "unexpected error: $output"
+  elif [[ "$(command cat "$case_dir/gh.log")" != *"dantraynor/tailchrome"* ]]; then
+    fail_test "stops when attestation verification fails" "repository was not pinned"
+  elif [[ "$(command cat "$case_dir/gh.log")" != *"github.com"* ]]; then
+    fail_test "stops when attestation verification fails" "GitHub host was not pinned"
+  else
+    pass_test "stops when attestation verification fails"
+  fi
+
+  rm -rf "$case_dir"
+}
+
+test_installs_after_attestation_verification() {
+  local case_dir output asset digest installed_path leftovers
+  case_dir="$(mktemp -d "${TMPDIR:-/tmp}/tailchrome-install-test.XXXXXX")"
+  asset="tailscale-browser-ext-linux-amd64"
+  installed_path="$case_dir/home/.local/share/tailscale/browser-ext/tailscale-browser-ext"
+  make_platform_bin "$case_dir/bin" "Linux" "x86_64"
+  link_command "$case_dir/bin" chmod
+  link_command "$case_dir/bin" mktemp
+  link_command "$case_dir/bin" mkdir
+  link_command "$case_dir/bin" rm
+  link_checksum_command "$case_dir/bin"
+  write_fixture_curl_stub "$case_dir/bin"
+  write_stub "$case_dir/bin/gh" <<'STUB'
+printf "%s\n" "$@" >"$TEST_GH_LOG"
+exit 0
+STUB
+  write_stub "$case_dir/artifact" <<'STUB'
+mkdir -p "${TEST_INSTALLED_PATH%/*}"
+cp "$0" "$TEST_INSTALLED_PATH"
+chmod 755 "$TEST_INSTALLED_PATH"
+printf "%s\n" "$@" >"$TEST_EXEC_LOG"
+STUB
+  digest="$(sha256_of "$case_dir/artifact")"
+  printf '%s  %s\n' "$digest" "$asset" >"$case_dir/SHA256SUMS.txt"
+
+  if ! output="$(
+    HOME="$case_dir/home" \
+      TEST_ARTIFACT_FIXTURE="$case_dir/artifact" \
+      TEST_CHECKSUM_FIXTURE="$case_dir/SHA256SUMS.txt" \
+      TEST_EXEC_LOG="$case_dir/exec.log" \
+      TEST_GH_LOG="$case_dir/gh.log" \
+      TEST_INSTALLED_PATH="$installed_path" \
+      TMPDIR="$case_dir" \
+      PATH="$case_dir/bin" \
+      "$INSTALLER" --version v1.2.3 2>&1
+  )"; then
+    fail_test "installs after attestation verification" "unexpected error: $output"
+  elif leftovers="$(
+    find "$case_dir" -maxdepth 1 -type d -name 'tailchrome-install.*' -print
+  )" && [[ -n "$leftovers" ]]; then
+    fail_test "installs after attestation verification" "temporary directory remains: $leftovers"
+  elif [[ "$(command cat "$case_dir/exec.log")" != "-install-now" ]]; then
+    fail_test "installs after attestation verification" "helper did not receive -install-now"
+  elif [[ "$output" != *"Installed helper: $installed_path"* ]] ||
+    [[ "$output" != *"\"$installed_path\" -uninstall"* ]]; then
+    fail_test "installs after attestation verification" "installed path or uninstall command was incorrect: $output"
+  else
+    pass_test "installs after attestation verification"
+  fi
+
+  rm -rf "$case_dir"
+}
+
+test_warns_and_installs_without_gh() {
+  local case_dir output asset digest installed_path
+  case_dir="$(mktemp -d "${TMPDIR:-/tmp}/tailchrome-install-test.XXXXXX")"
+  asset="tailscale-browser-ext-darwin-arm64"
+  installed_path="$case_dir/home/Library/Application Support/Tailscale/BrowserExt/tailscale-browser-ext"
+  make_platform_bin "$case_dir/bin" "Darwin" "aarch64"
+  link_command "$case_dir/bin" chmod
+  link_command "$case_dir/bin" mktemp
+  link_command "$case_dir/bin" mkdir
+  link_command "$case_dir/bin" rm
+  link_checksum_command "$case_dir/bin"
+  write_fixture_curl_stub "$case_dir/bin"
+  write_stub "$case_dir/artifact" <<'STUB'
+mkdir -p "${TEST_INSTALLED_PATH%/*}"
+cp "$0" "$TEST_INSTALLED_PATH"
+chmod 755 "$TEST_INSTALLED_PATH"
+printf "%s\n" "$@" >"$TEST_EXEC_LOG"
+STUB
+  digest="$(sha256_of "$case_dir/artifact")"
+  printf '%s  %s\n' "$digest" "$asset" >"$case_dir/SHA256SUMS.txt"
+
+  if ! output="$(
+    HOME="$case_dir/home" \
+      TEST_ARTIFACT_FIXTURE="$case_dir/artifact" \
+      TEST_CHECKSUM_FIXTURE="$case_dir/SHA256SUMS.txt" \
+      TEST_EXEC_LOG="$case_dir/exec.log" \
+      TEST_INSTALLED_PATH="$installed_path" \
+      TMPDIR="$case_dir" \
+      PATH="$case_dir/bin" \
+      "$INSTALLER" --version v1.2.3 2>&1
+  )"; then
+    fail_test "warns and installs when gh is unavailable" "unexpected error: $output"
+  elif [[ "$output" != *"checksum and artifact share the GitHub Release trust boundary"* ]]; then
+    fail_test "warns and installs when gh is unavailable" "missing trust-boundary warning: $output"
+  elif [[ "$(command cat "$case_dir/exec.log")" != "-install-now" ]]; then
+    fail_test "warns and installs when gh is unavailable" "helper did not receive -install-now"
+  else
+    pass_test "warns and installs when gh is unavailable"
+  fi
+
+  rm -rf "$case_dir"
+}
+
+test_warns_and_installs_with_unusable_gh() {
+  local gh_mode="$1"
+  local label="$2"
+  local case_dir output asset digest installed_path expected_gh_log
+  case_dir="$(mktemp -d "${TMPDIR:-/tmp}/tailchrome-install-test.XXXXXX")"
+  asset="tailscale-browser-ext-linux-amd64"
+  installed_path="$case_dir/home/.local/share/tailscale/browser-ext/tailscale-browser-ext"
+  make_platform_bin "$case_dir/bin" "Linux" "x86_64"
+  link_command "$case_dir/bin" chmod
+  link_command "$case_dir/bin" mktemp
+  link_command "$case_dir/bin" mkdir
+  link_command "$case_dir/bin" rm
+  link_checksum_command "$case_dir/bin"
+  write_fixture_curl_stub "$case_dir/bin"
+  write_stub "$case_dir/bin/gh" <<'STUB'
+printf '%s\n' "$*" >>"$TEST_GH_LOG"
+case "${TEST_GH_MODE:?}" in
+  old) exit 1 ;;
+  unauthenticated)
+    case "$*" in
+      "attestation verify --help") exit 0 ;;
+      "auth status --hostname github.com") exit 4 ;;
+      *) exit 2 ;;
+    esac
+    ;;
+  *) exit 2 ;;
+esac
+STUB
+  write_stub "$case_dir/artifact" <<'STUB'
+mkdir -p "${TEST_INSTALLED_PATH%/*}"
+cp "$0" "$TEST_INSTALLED_PATH"
+chmod 755 "$TEST_INSTALLED_PATH"
+printf "%s\n" "$@" >"$TEST_EXEC_LOG"
+STUB
+  digest="$(sha256_of "$case_dir/artifact")"
+  printf '%s  %s\n' "$digest" "$asset" >"$case_dir/SHA256SUMS.txt"
+
+  if ! output="$(
+    HOME="$case_dir/home" \
+      TEST_ARTIFACT_FIXTURE="$case_dir/artifact" \
+      TEST_CHECKSUM_FIXTURE="$case_dir/SHA256SUMS.txt" \
+      TEST_EXEC_LOG="$case_dir/exec.log" \
+      TEST_GH_LOG="$case_dir/gh.log" \
+      TEST_GH_MODE="$gh_mode" \
+      TEST_INSTALLED_PATH="$installed_path" \
+      TMPDIR="$case_dir" \
+      PATH="$case_dir/bin" \
+      "$INSTALLER" --version v1.2.3 2>&1
+  )"; then
+    fail_test "$label" "unexpected error: $output"
+  elif [[ "$output" != *"checksum and artifact share the GitHub Release trust boundary"* ]]; then
+    fail_test "$label" "missing trust-boundary warning: $output"
+  elif [[ "$(command cat "$case_dir/exec.log")" != "-install-now" ]]; then
+    fail_test "$label" "helper did not receive -install-now"
+  else
+    case "$gh_mode" in
+      old) expected_gh_log="attestation verify --help" ;;
+      unauthenticated)
+        expected_gh_log="attestation verify --help
+auth status --hostname github.com"
+        ;;
+    esac
+    if [[ "$(command cat "$case_dir/gh.log")" != "$expected_gh_log" ]]; then
+      fail_test "$label" "unexpected GitHub CLI calls: $(command cat "$case_dir/gh.log")"
+    else
+      pass_test "$label"
+    fi
+  fi
+
+  rm -rf "$case_dir"
+}
+
+test_reports_install_now_failure() {
+  local case_dir output asset digest
+  case_dir="$(mktemp -d "${TMPDIR:-/tmp}/tailchrome-install-test.XXXXXX")"
+  asset="tailscale-browser-ext-linux-arm64"
+  make_platform_bin "$case_dir/bin" "Linux" "arm64"
+  link_command "$case_dir/bin" chmod
+  link_command "$case_dir/bin" mktemp
+  link_command "$case_dir/bin" rm
+  link_checksum_command "$case_dir/bin"
+  write_fixture_curl_stub "$case_dir/bin"
+  write_stub "$case_dir/artifact" <<'STUB'
+exit 9
+STUB
+  digest="$(sha256_of "$case_dir/artifact")"
+  printf '%s  %s\n' "$digest" "$asset" >"$case_dir/SHA256SUMS.txt"
+
+  if output="$(
+    HOME="$case_dir/home" \
+      TEST_ARTIFACT_FIXTURE="$case_dir/artifact" \
+      TEST_CHECKSUM_FIXTURE="$case_dir/SHA256SUMS.txt" \
+      TMPDIR="$case_dir" \
+      PATH="$case_dir/bin" \
+      "$INSTALLER" --version v1.2.3 2>&1
+  )"; then
+    fail_test "reports -install-now failure" "installer unexpectedly succeeded"
+  elif [[ "$output" != *"-install-now failed"* ]]; then
+    fail_test "reports -install-now failure" "unexpected error: $output"
+  else
+    pass_test "reports -install-now failure"
+  fi
+
+  rm -rf "$case_dir"
+}
+
+test_rejects_success_without_installed_helper() {
+  local case_dir output asset digest
+  case_dir="$(mktemp -d "${TMPDIR:-/tmp}/tailchrome-install-test.XXXXXX")"
+  asset="tailscale-browser-ext-linux-amd64"
+  make_platform_bin "$case_dir/bin" "Linux" "amd64"
+  link_command "$case_dir/bin" chmod
+  link_command "$case_dir/bin" mktemp
+  link_command "$case_dir/bin" rm
+  link_checksum_command "$case_dir/bin"
+  write_fixture_curl_stub "$case_dir/bin"
+  write_stub "$case_dir/artifact" <<'STUB'
+exit 0
+STUB
+  digest="$(sha256_of "$case_dir/artifact")"
+  printf '%s  %s\n' "$digest" "$asset" >"$case_dir/SHA256SUMS.txt"
+
+  if output="$(
+    HOME="$case_dir/home" \
+      TEST_ARTIFACT_FIXTURE="$case_dir/artifact" \
+      TEST_CHECKSUM_FIXTURE="$case_dir/SHA256SUMS.txt" \
+      TMPDIR="$case_dir" \
+      PATH="$case_dir/bin" \
+      "$INSTALLER" --version v1.2.3 2>&1
+  )"; then
+    fail_test "requires the installed helper after -install-now" "installer unexpectedly succeeded"
+  elif [[ "$output" != *"installed helper was not created at"* ]]; then
+    fail_test "requires the installed helper after -install-now" "unexpected error: $output"
+  else
+    pass_test "requires the installed helper after -install-now"
+  fi
+
+  rm -rf "$case_dir"
+}
+
+test_cleans_temporary_files_after_failure() {
+  local case_dir output leftovers
+  case_dir="$(mktemp -d "${TMPDIR:-/tmp}/tailchrome-install-test.XXXXXX")"
+  make_platform_bin "$case_dir/bin" "Linux" "x86_64"
+  link_command "$case_dir/bin" mktemp
+  link_command "$case_dir/bin" rm
+  link_checksum_command "$case_dir/bin"
+  write_stub "$case_dir/bin/curl" <<'STUB'
+exit 22
+STUB
+
+  output="$(
+    TMPDIR="$case_dir" \
+      PATH="$case_dir/bin" \
+      "$INSTALLER" --version v1.2.3 2>&1
+  )" || true
+  leftovers="$(find "$case_dir" -maxdepth 1 -type d -name 'tailchrome-install.*' -print)"
+  if [[ -n "$leftovers" ]]; then
+    fail_test "cleans temporary files after failure" "temporary directory remains: $leftovers"
+  else
+    pass_test "cleans temporary files after failure"
+  fi
+
+  rm -rf "$case_dir"
+}
+
+test_signal_cleans_temporary_files() {
+  local signal_name="$1"
+  local expected_status="$2"
+  local label="$3"
+  local case_dir output status leftovers
+  case_dir="$(mktemp -d "${TMPDIR:-/tmp}/tailchrome-install-test.XXXXXX")"
+  make_platform_bin "$case_dir/bin" "Linux" "x86_64"
+  link_command "$case_dir/bin" mktemp
+  link_command "$case_dir/bin" rm
+  link_checksum_command "$case_dir/bin"
+  write_stub "$case_dir/bin/curl" <<'STUB'
+kill "-$TEST_SIGNAL" "$PPID"
+exit 22
+STUB
+
+  if output="$(
+    TEST_SIGNAL="$signal_name" \
+      TMPDIR="$case_dir" \
+      PATH="$case_dir/bin" \
+      "$INSTALLER" --version v1.2.3 2>&1
+  )"; then
+    status=0
+  else
+    status=$?
+  fi
+  leftovers="$(find "$case_dir" -maxdepth 1 -type d -name 'tailchrome-install.*' -print)"
+
+  if ((status != expected_status)); then
+    fail_test "$label" "expected status $expected_status, got $status: $output"
+  elif [[ -n "$leftovers" ]]; then
+    fail_test "$label" "temporary directory remains: $leftovers"
+  else
+    pass_test "$label"
+  fi
+
+  rm -rf "$case_dir"
+}
+
+test_uninstalls_from_linux_installed_path() {
+  local case_dir output installed_path
+  case_dir="$(mktemp -d "${TMPDIR:-/tmp}/tailchrome-install-test.XXXXXX")"
+  installed_path="$case_dir/home/.local/share/tailscale/browser-ext/tailscale-browser-ext"
+  make_platform_bin "$case_dir/bin" "Linux" "x86_64"
+  mkdir -p "${installed_path%/*}"
+  write_stub "$installed_path" <<'STUB'
+printf "%s\n" "$@" >"$TEST_EXEC_LOG"
+exit 0
+STUB
+
+  if ! output="$(
+    HOME="$case_dir/home" \
+      TEST_EXEC_LOG="$case_dir/exec.log" \
+      PATH="$case_dir/bin" \
+      "$INSTALLER" --version v1.2.3 --uninstall 2>&1
+  )"; then
+    fail_test "uninstalls from the Linux installed path" "unexpected error: $output"
+  elif [[ "$(command cat "$case_dir/exec.log")" != "-uninstall" ]]; then
+    fail_test "uninstalls from the Linux installed path" "installed helper did not receive -uninstall"
+  else
+    pass_test "uninstalls from the Linux installed path"
+  fi
+
+  rm -rf "$case_dir"
+}
+
+test_uninstalls_from_macos_installed_path() {
+  local case_dir output installed_path
+  case_dir="$(mktemp -d "${TMPDIR:-/tmp}/tailchrome-install-test.XXXXXX")"
+  installed_path="$case_dir/home/Library/Application Support/Tailscale/BrowserExt/tailscale-browser-ext"
+  make_platform_bin "$case_dir/bin" "Darwin" "arm64"
+  mkdir -p "${installed_path%/*}"
+  write_stub "$installed_path" <<'STUB'
+printf "%s\n" "$@" >"$TEST_EXEC_LOG"
+exit 0
+STUB
+
+  if ! output="$(
+    HOME="$case_dir/home" \
+      TEST_EXEC_LOG="$case_dir/exec.log" \
+      PATH="$case_dir/bin" \
+      "$INSTALLER" --version v1.2.3 --uninstall 2>&1
+  )"; then
+    fail_test "uninstalls from the macOS installed path" "unexpected error: $output"
+  elif [[ "$(command cat "$case_dir/exec.log")" != "-uninstall" ]]; then
+    fail_test "uninstalls from the macOS installed path" "installed helper did not receive -uninstall"
+  else
+    pass_test "uninstalls from the macOS installed path"
+  fi
+
+  rm -rf "$case_dir"
+}
+
+test_requires_explicit_version
+test_rejects_non_release_version
+test_rejects_unsupported_os
+test_rejects_unsupported_architecture
+test_requires_curl
+test_requires_checksum_tool
+test_uses_tag_pinned_url \
+  "Linux" "x86_64" "tailscale-browser-ext-linux-amd64" \
+  "maps Linux x86_64 to the tag-pinned amd64 asset"
+test_uses_tag_pinned_url \
+  "Linux" "aarch64" "tailscale-browser-ext-linux-arm64" \
+  "maps Linux aarch64 to the tag-pinned arm64 asset"
+test_uses_tag_pinned_url \
+  "Darwin" "x86_64" "tailscale-browser-ext-darwin-amd64" \
+  "maps macOS x86_64 to the tag-pinned amd64 asset"
+test_uses_tag_pinned_url \
+  "Darwin" "arm64" "tailscale-browser-ext-darwin-arm64" \
+  "maps macOS arm64 to the tag-pinned arm64 asset"
+test_reports_checksum_download_failure
+test_rejects_missing_checksum_entry
+test_rejects_duplicate_checksum_entry
+test_rejects_unsafe_checksum_entry
+test_rejects_checksum_mismatch
+test_stops_when_attestation_verification_fails
+test_installs_after_attestation_verification
+test_warns_and_installs_without_gh
+test_warns_and_installs_with_unusable_gh \
+  old "warns and installs when gh lacks attestation support"
+test_warns_and_installs_with_unusable_gh \
+  unauthenticated "warns and installs when gh is unauthenticated"
+test_reports_install_now_failure
+test_rejects_success_without_installed_helper
+test_cleans_temporary_files_after_failure
+test_signal_cleans_temporary_files HUP 129 "cleans temporary files after HUP"
+test_signal_cleans_temporary_files INT 130 "cleans temporary files after INT"
+test_signal_cleans_temporary_files TERM 143 "cleans temporary files after TERM"
+test_uninstalls_from_linux_installed_path
+test_uninstalls_from_macos_installed_path
+
+if ((tests_failed > 0)); then
+  printf '%d of %d tests failed\n' "$tests_failed" "$tests_run" >&2
+  exit 1
+fi
+
+printf '%d tests passed\n' "$tests_run"


### PR DESCRIPTION
## What

Adds Linux ARM64 host builds, a version-pinned checksum and provenance-aware per-user installer, architecture-aware v0.1.13 install guidance, and corresponding documentation. Hardens CI and release workflows with pinned actions, final-asset checksums and attestations, coordinated notarized macOS packaging, and a reproducible Firefox source archive.

## Why

Provides a safe Linux ARM64 installation path while making companion releases complete, consistent, and independently verifiable; no linked issue.

## How to Test

- [x] Run `pnpm typecheck` and `pnpm test`
- [x] Run `pnpm test:installer`
- [x] Run `pnpm e2e:chrome` and `pnpm e2e:firefox`
- [x] Run Go vet/race tests and `make host-all`
- [x] Run the Firefox review and clean source-rebuild gates

## Checklist

- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Updated README if needed
