### PR TITLE
Fix version gate rejecting newer helper builds

### DIFF
--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -345,7 +345,7 @@ Defined in `packages/shared/src/constants.ts`:
 | `RECONNECT_MAX_MS`      | `30000`                             | Reconnection backoff ceiling                              |
 | `ADMIN_URL`             | `https://login.tailscale.com/admin` | Tailscale admin console                                   |
 | `DEFAULT_CONTROL_URL`   | `https://controlplane.tailscale.com` | Default coordination server                              |
-| `EXPECTED_HOST_VERSION` | `0.1.12`                            | Expected native host version (major.minor match required) |
+| `EXPECTED_HOST_VERSION` | `0.1.12`                            | Minimum native host version (major.minor, newer accepted) |
 
 
 ---
@@ -964,7 +964,7 @@ For a configured custom coordination server, delegated login URLs may use anothe
 
 ### Host Version Checking
 
-The extension enforces major.minor version matching between the expected version (`EXPECTED_HOST_VERSION`) and the host's reported version. Patch version differences are tolerated. A mismatch shows the "needs-update" view.
+The extension treats `EXPECTED_HOST_VERSION` as a minimum at major.minor granularity: a host reporting an older major.minor shows the "needs-update" view, while patch differences and hosts newer than expected are accepted (the helper never self-updates, so a rebuilt helper must stay usable).
 
 ### Proxy Scope
 

--- a/packages/shared/src/background/background.test.ts
+++ b/packages/shared/src/background/background.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { ProxyManager, TailscaleState, NativeReply } from "../types";
-import { initBackground, isValidLoginURL } from "./background";
+import { initBackground, isValidLoginURL, isVersionMismatch } from "./background";
 
 type MessageListener = (msg: unknown) => void;
 type DisconnectListener = (port: unknown) => void;
@@ -101,6 +101,38 @@ describe("isValidLoginURL", () => {
         "https://headscale.example.com",
       ),
     ).toBe(false);
+  });
+});
+
+describe("isVersionMismatch", () => {
+  // EXPECTED_HOST_VERSION is "0.1.12" — the gate is a minimum, not an exact match.
+  it("accepts the expected version and tolerates patch differences", () => {
+    expect(isVersionMismatch("0.1.12")).toBe(false);
+    expect(isVersionMismatch("0.1.0")).toBe(false);
+    expect(isVersionMismatch("0.1.99")).toBe(false);
+    expect(isVersionMismatch("v0.1.12")).toBe(false);
+  });
+
+  it("accepts hosts newer than expected", () => {
+    expect(isVersionMismatch("0.2.0")).toBe(false);
+    expect(isVersionMismatch("1.0.0")).toBe(false);
+    expect(isVersionMismatch("1.0.0-rc1")).toBe(false);
+  });
+
+  it("compares fields numerically, not lexically", () => {
+    expect(isVersionMismatch("0.10.0")).toBe(false);
+  });
+
+  it("rejects hosts older than expected", () => {
+    expect(isVersionMismatch("0.0.1")).toBe(true);
+    expect(isVersionMismatch("0.0.99")).toBe(true);
+  });
+
+  it("rejects missing or unparseable versions", () => {
+    expect(isVersionMismatch(null)).toBe(true);
+    expect(isVersionMismatch("")).toBe(true);
+    expect(isVersionMismatch("1")).toBe(true);
+    expect(isVersionMismatch("abc.def")).toBe(true);
   });
 });
 

--- a/packages/shared/src/background/background.ts
+++ b/packages/shared/src/background/background.ts
@@ -147,18 +147,39 @@ function controlServerChanged(
 }
 
 /**
- * Returns true if the host version's major.minor doesn't match the expected version.
- * Patch differences are tolerated. Missing or unparseable versions are treated as a mismatch.
+ * Returns true if the host version's major.minor is older than the expected
+ * version's. Patch differences are tolerated, and a host newer than expected
+ * is accepted: the helper never self-updates, so rebuilding it against newer
+ * sources is the only way to move it forward and must not lock out the UI
+ * (#109). Missing or unparseable versions are treated as a mismatch.
  */
-function isVersionMismatch(hostVersion: string | null): boolean {
+export function isVersionMismatch(hostVersion: string | null): boolean {
   if (!hostVersion) return true;
   // Strip leading "v" if present
   const host = hostVersion.replace(/^v/, "");
   const expected = EXPECTED_HOST_VERSION.replace(/^v/, "");
+  // Leading digits only, so pre-release suffixes ("2-beta1") still parse.
+  const field = (part: string | undefined): number | null => {
+    const digits = part?.match(/^\d+/)?.[0];
+    return digits === undefined ? null : Number(digits);
+  };
   const hostParts = host.split(".");
   const expectedParts = expected.split(".");
   if (hostParts.length < 2 || expectedParts.length < 2) return true;
-  return hostParts[0] !== expectedParts[0] || hostParts[1] !== expectedParts[1];
+  const hostMajor = field(hostParts[0]);
+  const hostMinor = field(hostParts[1]);
+  const expectedMajor = field(expectedParts[0]);
+  const expectedMinor = field(expectedParts[1]);
+  if (
+    hostMajor === null ||
+    hostMinor === null ||
+    expectedMajor === null ||
+    expectedMinor === null
+  ) {
+    return true;
+  }
+  if (hostMajor !== expectedMajor) return hostMajor < expectedMajor;
+  return hostMinor < expectedMinor;
 }
 
 const NATIVE_HOST_UNREACHABLE =


### PR DESCRIPTION
## Summary

The host version check treated `EXPECTED_HOST_VERSION` as an exact major.minor match, so a helper rebuilt against newer sources (the only way to move the embedded Tailscale forward — the helper never self-updates) was locked out of the UI exactly like an outdated one, with only a downgrade installer offered.

This treats the expected version as a minimum instead, per option (1) in the issue:

- Hosts at or above the expected major.minor pass; the needs-update view still appears for genuinely older helpers.
- Patch differences stay tolerated in both directions, as before.
- Version fields are compared numerically, so `0.10` sorts after `0.9` (the old string compare would have rejected it).
- The field parser takes leading digits, so a pre-release suffix like `1.0.0-rc1` still parses.
- Missing or unparseable versions still count as a mismatch.

Also syncs the two spots in `docs/DOCUMENTATION.md` that described the gate as an exact match.

## Testing

- New `isVersionMismatch` unit tests: expected/patch/newer/lexical/older/unparseable cases.
- Full suite green: 423 shared + 59 extension tests, typecheck clean in both packages.

Fixes #109