### PR TITLE
Fix e2e Chrome launch on current CI runners

### DIFF
--- a/scripts/e2e/launch.mjs
+++ b/scripts/e2e/launch.mjs
@@ -108,6 +108,11 @@ async function launchChrome(extensionDir) {
       `--load-extension=${extensionDir}`,
       "--no-first-run",
       "--no-default-browser-check",
+      // CI runners restrict unprivileged user namespaces (AppArmor on current
+      // Ubuntu images), which crashes Chrome's sandbox at launch. The suite
+      // only visits extension pages and localhost, so dropping the sandbox
+      // there is acceptable; local runs keep it.
+      ...(process.env.CI ? ["--no-sandbox", "--disable-setuid-sandbox"] : []),
     ],
   });
 


### PR DESCRIPTION
Ubuntu runner images now restrict unprivileged user namespaces via AppArmor, so Chrome's zygote sandbox aborts at launch (`No usable sandbox!`) and every `e2e-chrome` job has failed since the rollout — including image-only changes like #108, which confirms it's the environment rather than any change under test.

Pass `--no-sandbox`/`--disable-setuid-sandbox` only when `CI` is set. The suite only loads the unpacked extension and localhost pages, so dropping the sandbox there is acceptable; local runs keep it.