### PR TITLE
fix(host): tolerate browser-injected unusable SSLKEYLOGFILE paths

### DIFF
--- a/host/main.go
+++ b/host/main.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path/filepath"
 
 	"golang.org/x/term"
 	"tailscale.com/hostinfo"
@@ -124,18 +123,23 @@ func main() {
 }
 
 // sanitizeNativeHostEnvironment removes browser-injected environment values
-// that are unsafe for a native messaging host. Some security products set
-// SSLKEYLOGFILE to a relative virtual filename in Firefox child processes.
-// A native host has no stable or necessarily writable working directory, and
-// Tailscale's TLS dialer treats failure to open that file as fatal. Preserve an
-// absolute value so an intentionally configured TLS key log still works.
+// that are unusable by a native messaging host. Some security products set
+// SSLKEYLOGFILE to a protected virtual path in Firefox child processes, and
+// Tailscale's TLS dialer treats failure to open that file as fatal. Probe the
+// path with the same access Tailscale requires and preserve it when usable so
+// an intentionally configured TLS key log still works.
 func sanitizeNativeHostEnvironment() {
 	const sslKeyLogFile = "SSLKEYLOGFILE"
 	path := os.Getenv(sslKeyLogFile)
-	if path == "" || filepath.IsAbs(path) {
+	if path == "" {
 		return
 	}
-	_ = os.Unsetenv(sslKeyLogFile)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
+	if err != nil {
+		_ = os.Unsetenv(sslKeyLogFile)
+		return
+	}
+	_ = f.Close()
 }
 
 func errString(err error) string {

--- a/host/main.go
+++ b/host/main.go
@@ -136,6 +136,9 @@ func sanitizeNativeHostEnvironment() {
 	}
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
 	if err != nil {
+		// Stderr reaches the browser's captured helper output, so leave a
+		// trace explaining why an expected TLS key log never appears.
+		log.Printf("clearing unusable %s %q: %v", sslKeyLogFile, path, err)
 		_ = os.Unsetenv(sslKeyLogFile)
 		return
 	}

--- a/host/main.go
+++ b/host/main.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 
 	"golang.org/x/term"
 	"tailscale.com/hostinfo"
@@ -83,6 +84,7 @@ func main() {
 	}
 
 	// Default: run as native messaging host (launched by browser).
+	sanitizeNativeHostEnvironment()
 	hostinfo.SetApp("tailscale-browser-ext")
 
 	h := newHost(os.Stdin, os.Stdout)
@@ -119,6 +121,21 @@ func main() {
 
 	h.readMessages()
 	h.shutdownSession()
+}
+
+// sanitizeNativeHostEnvironment removes browser-injected environment values
+// that are unsafe for a native messaging host. Some security products set
+// SSLKEYLOGFILE to a relative virtual filename in Firefox child processes.
+// A native host has no stable or necessarily writable working directory, and
+// Tailscale's TLS dialer treats failure to open that file as fatal. Preserve an
+// absolute value so an intentionally configured TLS key log still works.
+func sanitizeNativeHostEnvironment() {
+	const sslKeyLogFile = "SSLKEYLOGFILE"
+	path := os.Getenv(sslKeyLogFile)
+	if path == "" || filepath.IsAbs(path) {
+		return
+	}
+	_ = os.Unsetenv(sslKeyLogFile)
 }
 
 func errString(err error) string {

--- a/host/main_test.go
+++ b/host/main_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSanitizeNativeHostEnvironment(t *testing.T) {
+	t.Run("clears relative SSL key log path", func(t *testing.T) {
+		t.Setenv("SSLKEYLOGFILE", "virtual_file.log")
+
+		sanitizeNativeHostEnvironment()
+
+		if value, ok := os.LookupEnv("SSLKEYLOGFILE"); ok {
+			t.Fatalf("SSLKEYLOGFILE still set to %q; want unset", value)
+		}
+	})
+
+	t.Run("preserves absolute SSL key log path", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "keys.log")
+		t.Setenv("SSLKEYLOGFILE", path)
+
+		sanitizeNativeHostEnvironment()
+
+		if got := os.Getenv("SSLKEYLOGFILE"); got != path {
+			t.Fatalf("SSLKEYLOGFILE = %q; want %q", got, path)
+		}
+	})
+}

--- a/host/main_test.go
+++ b/host/main_test.go
@@ -7,8 +7,9 @@ import (
 )
 
 func TestSanitizeNativeHostEnvironment(t *testing.T) {
-	t.Run("clears relative SSL key log path", func(t *testing.T) {
-		t.Setenv("SSLKEYLOGFILE", "virtual_file.log")
+	t.Run("clears unusable SSL key log path", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "missing", "virtual_file.log")
+		t.Setenv("SSLKEYLOGFILE", path)
 
 		sanitizeNativeHostEnvironment()
 
@@ -17,7 +18,7 @@ func TestSanitizeNativeHostEnvironment(t *testing.T) {
 		}
 	})
 
-	t.Run("preserves absolute SSL key log path", func(t *testing.T) {
+	t.Run("preserves usable SSL key log path", func(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "keys.log")
 		t.Setenv("SSLKEYLOGFILE", path)
 


### PR DESCRIPTION
## What

- Sanitize `SSLKEYLOGFILE` when the browser launches Tailchrome's native host with a path it cannot open.
- Preserve usable key-log paths so intentional TLS debugging continues to work.
- Add regression coverage for unusable and usable key-log targets.

## Why

Closes #113.

Bitdefender's encrypted web scanning injects `SSLKEYLOGFILE=\\?\Volume{...}\virtual_file.log` into Firefox child processes. The Tailchrome helper inherits the protected absolute volume path. Tailscale 1.100.0's TLS dialer treats the failed open as fatal, so the helper exits before initialization and Tailchrome repeatedly reports `native-host-stopped`.

The sanitization runs only in native-host mode. Installer, uninstaller, and version operations are unchanged.

## How to Test

- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm test` (567 tests)
- [x] `corepack pnpm test:installer` under Ubuntu 24.04 WSL
- [x] `(cd host && go test ./... && go vet ./...)` on Windows amd64
- [x] `git diff --check`
- [x] Reproduced with Firefox 154, Tailchrome 0.1.13, and Bitdefender Total Security 27.0.61.344
- [x] Built and installed the revised helper; Firefox launched it directly, it remained logged in with established connections, and a proxied route check exited in Miami, Florida
- [x] `go test -race ./...` locally (Windows host has no C compiler; Linux PR CI runs this gate)

## Checklist

- [x] Tested in Chrome (Firefox/Bitdefender-specific reproduction)
- [x] Tested in Firefox
- [x] Updated README if needed (no documentation change needed)
