### PR TITLE
fix(popup): report split-tunneling state on the collapsed row

### DIFF
--- a/packages/shared/src/popup/styles/components.css
+++ b/packages/shared/src/popup/styles/components.css
@@ -600,6 +600,15 @@ button.setting-row {
   color: var(--text-tertiary);
 }
 
+/* Disclosure rows expand in place, so their chevron points down when open. */
+.split-tunneling-chevron {
+  transition: transform var(--transition-fast);
+}
+
+.split-tunneling-chevron--expanded {
+  transform: rotate(90deg);
+}
+
 .quick-settings .setting-row--stacked {
   flex-direction: column;
   align-items: stretch;

--- a/packages/shared/src/popup/views/connected.test.ts
+++ b/packages/shared/src/popup/views/connected.test.ts
@@ -57,6 +57,100 @@ describe("connected view", () => {
     expect(input.value).toBe("unsaved.example.com");
   });
 
+  it("summarises saved split-tunneling rules on the collapsed row", () => {
+    const root = document.createElement("div");
+    renderConnected(
+      root,
+      baseState({
+        domainSplit: { mode: "only", domains: ["a.example.com", "b.example.com"] },
+      }),
+    );
+
+    const header = root.querySelector<HTMLButtonElement>(
+      ".split-tunneling-header",
+    )!;
+    const editor = root.querySelector<HTMLElement>(".split-tunneling-editor")!;
+
+    // Collapsed by default, but the row still reports the live rule state.
+    expect(editor.classList.contains("hidden")).toBe(true);
+    expect(header.getAttribute("aria-expanded")).toBe("false");
+    expect(
+      header.querySelector(".setting-value-split-tunneling")!.firstChild!
+        .textContent,
+    ).toBe("Only · 2 domains");
+  });
+
+  it("reports no rules as Off, but never reports empty Only mode as Off", () => {
+    const offRoot = document.createElement("div");
+    renderConnected(
+      offRoot,
+      baseState({ domainSplit: { mode: "bypass", domains: [] } }),
+    );
+    expect(
+      offRoot.querySelector(".setting-value-split-tunneling")!.firstChild!
+        .textContent,
+    ).toBe("Off");
+
+    // "only" with an empty list routes nothing through the exit node — the
+    // opposite of off — so it must not read as "Off".
+    const onlyRoot = document.createElement("div");
+    renderConnected(
+      onlyRoot,
+      baseState({ domainSplit: { mode: "only", domains: [] } }),
+    );
+    expect(
+      onlyRoot.querySelector(".setting-value-split-tunneling")!.firstChild!
+        .textContent,
+    ).toBe("Only · no domains");
+  });
+
+  it("expands the split-tunneling editor when the row is clicked", () => {
+    const root = document.createElement("div");
+    renderConnected(root, baseState({}));
+
+    const header = root.querySelector<HTMLButtonElement>(
+      ".split-tunneling-header",
+    )!;
+    const editor = root.querySelector<HTMLElement>(".split-tunneling-editor")!;
+    expect(header.getAttribute("aria-controls")).toBe(editor.id);
+
+    header.click();
+    expect(editor.classList.contains("hidden")).toBe(false);
+    expect(header.getAttribute("aria-expanded")).toBe("true");
+
+    header.click();
+    expect(editor.classList.contains("hidden")).toBe(true);
+    expect(header.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("refreshes the split-tunneling summary on save and on state updates", () => {
+    const root = document.createElement("div");
+    const state = baseState({ domainSplit: { mode: "bypass", domains: [] } });
+    renderConnected(root, state);
+
+    const summary = () =>
+      root.querySelector(".setting-value-split-tunneling")!.firstChild!
+        .textContent;
+    expect(summary()).toBe("Off");
+
+    const input = root.querySelector<HTMLTextAreaElement>(
+      ".split-tunneling-input",
+    )!;
+    input.value = "saved.example.com";
+    input.dispatchEvent(new Event("input"));
+    root.querySelector<HTMLButtonElement>(".split-tunneling-save")!.click();
+
+    // Optimistic: the summary updates without waiting for the background.
+    expect(summary()).toBe("Bypass · 1 domain");
+
+    updateConnected(root, {
+      ...state,
+      stateVersion: 1,
+      domainSplit: { mode: "only", domains: ["a.example.com", "b.example.com"] },
+    });
+    expect(summary()).toBe("Only · 2 domains");
+  });
+
   it("commits unsaved split-tunneling domains when the mode changes", () => {
     const root = document.createElement("div");
     renderConnected(

--- a/packages/shared/src/popup/views/connected.ts
+++ b/packages/shared/src/popup/views/connected.ts
@@ -28,6 +28,9 @@ let advertiseRoutesEditorOpen = false;
 /** UI-only: whether the split-tunneling editor is visible. */
 let splitTunnelingEditorOpen = false;
 
+/** Ties the Split tunneling disclosure row to the editor it expands. */
+const SPLIT_TUNNELING_EDITOR_ID = "split-tunneling-editor";
+
 /** UI-only: whether the coordination-server URL editor is visible. */
 let coordinationServerEditorOpen = false;
 
@@ -542,25 +545,81 @@ function applyConfig(
   if (warning) warning.textContent = "";
 }
 
+/**
+ * Summary text for the collapsed Split tunneling row.
+ *
+ * The row only opens and closes the editor, so it has to report the saved rule
+ * state itself — otherwise a collapsed row is indistinguishable from a disabled
+ * feature. "Only" with an empty list is deliberately not reported as "Off": in
+ * that combination the PAC catch-all sends *nothing* through the exit node.
+ */
+function splitTunnelingSummary(config: DomainSplitConfig): string {
+  const count = config.domains.length;
+  if (count === 0) {
+    return config.mode === "only" ? "Only · no domains" : "Off";
+  }
+  const modeLabel = config.mode === "only" ? "Only" : "Bypass";
+  return `${modeLabel} · ${count} ${count === 1 ? "domain" : "domains"}`;
+}
+
+/** Patches the collapsed-row summary in place, preserving the chevron span. */
+function setSplitTunnelingSummary(
+  scope: ParentNode,
+  config: DomainSplitConfig,
+): void {
+  const valueEl = scope.querySelector<HTMLElement>(
+    ".setting-value-split-tunneling",
+  );
+  const textNode = valueEl?.firstChild;
+  if (!textNode || textNode.nodeType !== Node.TEXT_NODE) return;
+  const next = splitTunnelingSummary(config);
+  if (textNode.textContent !== next) textNode.textContent = next;
+}
+
 function renderSplitTunnelingSection(
   parent: HTMLElement,
   state: TailscaleState,
 ): void {
-  const headerRow = document.createElement("div");
-  headerRow.className = "setting-row";
+  const headerRow = document.createElement("button");
+  headerRow.type = "button";
+  headerRow.className =
+    "setting-row setting-row--clickable split-tunneling-header";
+  headerRow.setAttribute("aria-expanded", String(splitTunnelingEditorOpen));
+  headerRow.setAttribute("aria-controls", SPLIT_TUNNELING_EDITOR_ID);
+
   const label = document.createElement("span");
   label.className = "setting-label";
   label.textContent = "Split tunneling";
   headerRow.appendChild(label);
 
-  const expandToggle = createToggle(splitTunnelingEditorOpen, (checked) => {
-    splitTunnelingEditorOpen = checked;
-    editorSection.classList.toggle("hidden", !checked);
-  }, "Show split tunneling settings");
-  headerRow.appendChild(expandToggle);
+  const value = document.createElement("span");
+  value.className = "setting-value setting-value-split-tunneling";
+  value.textContent = splitTunnelingSummary(state.domainSplit);
+
+  const chevron = document.createElement("span");
+  chevron.className =
+    "setting-value-chevron split-tunneling-chevron" +
+    (splitTunnelingEditorOpen ? " split-tunneling-chevron--expanded" : "");
+  const chevronIcon = document.createElement("span");
+  chevronIcon.className = "icon";
+  chevronIcon.appendChild(iconChevronRight());
+  chevron.appendChild(chevronIcon);
+  value.appendChild(chevron);
+
+  headerRow.appendChild(value);
+  headerRow.addEventListener("click", () => {
+    splitTunnelingEditorOpen = !splitTunnelingEditorOpen;
+    editorSection.classList.toggle("hidden", !splitTunnelingEditorOpen);
+    headerRow.setAttribute("aria-expanded", String(splitTunnelingEditorOpen));
+    chevron.classList.toggle(
+      "split-tunneling-chevron--expanded",
+      splitTunnelingEditorOpen,
+    );
+  });
   parent.appendChild(headerRow);
 
   const editorSection = document.createElement("div");
+  editorSection.id = SPLIT_TUNNELING_EDITOR_ID;
   editorSection.className =
     "setting-row setting-row--stacked split-tunneling-editor";
   if (!splitTunnelingEditorOpen) editorSection.classList.add("hidden");
@@ -611,7 +670,11 @@ function renderSplitTunnelingSection(
   const commit = (): void => {
     const parsed = parseDomainsInput(ta.value);
     const mode = activeModeFromSection(editorSection);
-    applyConfig(editorSection, { mode, domains: parsed.domains });
+    const config: DomainSplitConfig = { mode, domains: parsed.domains };
+    applyConfig(editorSection, config);
+    // Reflect the save immediately; the round-trip through the background
+    // arrives later and updateConnected only patches what has changed.
+    setSplitTunnelingSummary(headerRow, config);
     ta.dataset.dirty = "false";
     warning.textContent =
       parsed.invalid.length > 0
@@ -841,6 +904,7 @@ export function updateConnected(root: HTMLElement, state: TailscaleState): void 
       }
       setActiveMode(splitSection, state.domainSplit.mode);
     }
+    setSplitTunnelingSummary(quickSettings, state.domainSplit);
   }
 
   const peerContainer = view.querySelector<HTMLElement>(".peer-container");

--- a/scripts/e2e/assertions.mjs
+++ b/scripts/e2e/assertions.mjs
@@ -75,6 +75,48 @@ export async function setInputValue(page, selector, value) {
   await page.keyboard.type(value);
 }
 
+export async function expectTextIn(page, selector, expected) {
+  try {
+    await page.waitForFunction(
+      ({ selector, expected }) =>
+        (document.querySelector(selector)?.textContent ?? "").includes(expected),
+      { timeout: 5_000 },
+      { selector, expected },
+    );
+  } catch (err) {
+    const actual = await page
+      .evaluate(
+        (selector) => document.querySelector(selector)?.textContent ?? "<missing>",
+        selector,
+      )
+      .catch(() => "<unavailable>");
+    throw new Error(
+      `Expected ${selector} to contain: ${expected}\nActual: ${actual}`,
+      { cause: err },
+    );
+  }
+}
+
+/**
+ * Opens a disclosure row (a `.setting-row` button carrying aria-expanded) that
+ * expands an editor in place. No-op when the row is already open.
+ */
+export async function expandDisclosureRow(page, selector) {
+  await page.waitForSelector(selector);
+  const expanded = await page.evaluate((selector) => {
+    const row = document.querySelector(selector);
+    if (!row) return null;
+    if (row.getAttribute("aria-expanded") !== "true") row.click();
+    return row.getAttribute("aria-expanded");
+  }, selector);
+  if (expanded !== "true") {
+    const text = await visibleText(page).catch(() => "");
+    throw new Error(
+      `Could not expand disclosure row: ${selector}\nVisible text:\n${text}`,
+    );
+  }
+}
+
 export async function clickToggleForLabel(page, label) {
   const clicked = await page.evaluate((label) => {
     const rows = [...document.querySelectorAll(".setting-row, .header")];

--- a/scripts/e2e/scenarios/split-tunneling.mjs
+++ b/scripts/e2e/scenarios/split-tunneling.mjs
@@ -1,7 +1,8 @@
 import {
   clickText,
-  clickToggleForLabel,
+  expandDisclosureRow,
   expectText,
+  expectTextIn,
   setInputValue,
   waitForPopup,
 } from "../assertions.mjs";
@@ -66,8 +67,9 @@ export async function run({ openPopup }) {
   try {
     await waitForPopup(page);
     await expectText(page, "example.ts.net");
+    await expectTextIn(page, ".split-tunneling-header", "Off");
 
-    await clickToggleForLabel(page, "Split tunneling");
+    await expandDisclosureRow(page, ".split-tunneling-header");
     await setInputValue(
       page,
       ".split-tunneling-input",
@@ -84,6 +86,24 @@ export async function run({ openPopup }) {
     }
     if (!pac.includes("SOCKS5 127.0.0.1:1055")) {
       throw new Error("Proxy still expected for unlisted hosts");
+    }
+
+    await expectTextIn(page, ".split-tunneling-header", "Bypass · 2 domains");
+
+    // Regression (#116): a freshly opened popup starts with the editor
+    // collapsed, so the row itself has to report the saved rules. It used to
+    // render an off-looking switch, which read as "split tunneling disabled"
+    // while the rules were in force.
+    const reopened = await openPopup();
+    try {
+      await waitForPopup(reopened);
+      await expectTextIn(
+        reopened,
+        ".split-tunneling-header",
+        "Bypass · 2 domains",
+      );
+    } finally {
+      await reopened.close();
     }
 
     // Regression: typing new domains and clicking a mode button (without


### PR DESCRIPTION
## What

The Split tunneling row rendered a toggle switch that only opened and closed the editor, with its state in a module-level variable that resets whenever the popup document is recreated — so reopening the popup showed an off-looking switch styled exactly like the Shields Up and MagicDNS preference toggles while the saved rules were still in force. It is now a disclosure row modelled on Exit Node: a summary value (`Off`, `Bypass · 2 domains`, `Only · 1 domain`) plus a chevron that rotates when expanded, with `aria-expanded`/`aria-controls`, refreshed both optimistically on save and from state in `updateConnected`. `Only` with an empty domain list is deliberately not reported as `Off`, since that combination routes nothing through the exit node.

## Why

Closes #116

## How to Test

- [x] Connect, pick an exit node, expand Split tunneling, add a domain and hit Save rules
- [x] Close and reopen the popup — the collapsed row reports `Bypass · 1 domain` instead of an off-looking switch
- [x] Clear the domains in Bypass mode and confirm the row reads `Off`; switch to Only with an empty list and confirm it reads `Only · no domains`
- [x] Click the row to expand and collapse; the chevron rotates and the editor follows

## Checklist

- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Updated README if needed

Verification: `pnpm typecheck` clean, 571 unit tests pass (4 new in `connected.test.ts`), and the full e2e suite passes in Chrome (26 cases) and Firefox (20 cases). The `split-tunneling` e2e scenario now reopens the popup after saving to assert the row still reports the saved rules — the exact regression reported in the issue.
