### PR TITLE
Add Homebrew tap and source formula for macOS and Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,12 +181,11 @@ jobs:
           tap="$(brew --repository)/Library/Taps/dantraynor/homebrew-tailchrome"
           mkdir -p "$(dirname "$tap")"
           ln -s "$GITHUB_WORKSPACE" "$tap"
-      - name: Test Linux helper registration and removal
-        if: runner.os == 'Linux'
+      - name: Build the formula from source and test registration and removal
         run: |
           set -euo pipefail
           brew style --formula dantraynor/tailchrome/tailchrome
-          brew install --formula dantraynor/tailchrome/tailchrome
+          brew install --build-from-source --formula dantraynor/tailchrome/tailchrome
           brew test dantraynor/tailchrome/tailchrome
           brew uninstall --formula dantraynor/tailchrome/tailchrome
       - name: Validate and fetch the signed macOS installer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
     outputs:
       host: ${{ steps.filter.outputs.host }}
       packaging: ${{ steps.filter.outputs.packaging }}
+      homebrew: ${{ steps.filter.outputs.homebrew }}
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
@@ -43,6 +44,12 @@ jobs:
               - 'scripts/verify-windows-signatures.test.ps1'
               - 'Makefile'
               - '.github/workflows/*.yml'
+            homebrew:
+              - 'Casks/**'
+              - 'Formula/**'
+              - 'scripts/update-homebrew*.mjs'
+              - '.github/workflows/ci.yml'
+              - '.github/workflows/update-homebrew.yml'
 
   extension-tests:
     runs-on: ubuntu-latest
@@ -60,6 +67,7 @@ jobs:
       - run: pnpm typecheck
       - run: pnpm test
       - run: pnpm test:installer
+      - run: pnpm test:homebrew
       - name: Lint installer shell script
         run: shellcheck scripts/install.sh scripts/install.test.sh
 
@@ -149,6 +157,48 @@ jobs:
           cache-dependency-path: host/go.sum
       - run: go test ./...
         working-directory: host
+
+  homebrew:
+    needs: changes
+    if: needs.changes.outputs.homebrew == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    env:
+      HOMEBREW_NO_AUTO_UPDATE: "1"
+      HOMEBREW_NO_ANALYTICS: "1"
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - name: Add Linux Homebrew to PATH
+        if: runner.os == 'Linux'
+        run: echo /home/linuxbrew/.linuxbrew/bin >> "$GITHUB_PATH"
+      - name: Tap the checkout under test
+        run: |
+          set -euo pipefail
+          tap="$(brew --repository)/Library/Taps/dantraynor/homebrew-tailchrome"
+          mkdir -p "$(dirname "$tap")"
+          ln -s "$GITHUB_WORKSPACE" "$tap"
+      - name: Test Linux helper registration and removal
+        if: runner.os == 'Linux'
+        run: |
+          set -euo pipefail
+          brew style --formula dantraynor/tailchrome/tailchrome
+          brew install --formula dantraynor/tailchrome/tailchrome
+          brew test dantraynor/tailchrome/tailchrome
+          brew uninstall --formula dantraynor/tailchrome/tailchrome
+      - name: Validate and fetch the signed macOS installer
+        if: runner.os == 'macOS'
+        run: |
+          set -euo pipefail
+          brew style --cask dantraynor/tailchrome/tailchrome
+          brew info --cask --json=v2 dantraynor/tailchrome/tailchrome
+          brew fetch --cask dantraynor/tailchrome/tailchrome
+          pkg="$(brew --cache --cask dantraynor/tailchrome/tailchrome)"
+          pkgutil --check-signature "$pkg"
+          xcrun stapler validate "$pkg"
 
   package-linux:
     needs: changes

--- a/.github/workflows/publish-helper-release.yml
+++ b/.github/workflows/publish-helper-release.yml
@@ -592,3 +592,14 @@ jobs:
             echo "- Candidate run ID: \`$CANDIDATE_RUN_ID\`"
             echo "- SHA256SUMS.txt digest: \`$EXPECTED_MANIFEST_DIGEST\`"
           } >> "$GITHUB_STEP_SUMMARY"
+
+  update-homebrew:
+    needs: publish
+    if: ${{ !cancelled() && needs.publish.result == 'success' }}
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: ./.github/workflows/update-homebrew.yml
+    with:
+      release_tag: ${{ inputs.release_tag }}
+      sha256sums_digest: ${{ inputs.sha256sums_digest }}

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -1,0 +1,117 @@
+name: Update Homebrew
+
+on:
+  workflow_call:
+    inputs:
+      release_tag:
+        required: true
+        type: string
+      sha256sums_digest:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Published stable release tag, for example v0.1.13
+        required: true
+        type: string
+      sha256sums_digest:
+        description: SHA-256 of the published SHA256SUMS.txt
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: update-homebrew
+  cancel-in-progress: false
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+      RELEASE_TAG: ${{ inputs.release_tag }}
+      EXPECTED_MANIFEST_DIGEST: ${{ inputs.sha256sums_digest }}
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          ref: main
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: 22
+          package-manager-cache: false
+      - name: Verify the published release manifest
+        run: |
+          set -euo pipefail
+          [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          [[ "$EXPECTED_MANIFEST_DIGEST" =~ ^[0-9a-f]{64}$ ]]
+          gh release view "$RELEASE_TAG" --json tagName,isDraft,isPrerelease > "$RUNNER_TEMP/homebrew-release.json"
+          jq -e --arg tag "$RELEASE_TAG" \
+            '.tagName == $tag and .isDraft == false and .isPrerelease == false' \
+            "$RUNNER_TEMP/homebrew-release.json"
+          gh release download "$RELEASE_TAG" --pattern SHA256SUMS.txt --dir "$RUNNER_TEMP/homebrew-release"
+          manifest="$RUNNER_TEMP/homebrew-release/SHA256SUMS.txt"
+          test "$(sha256sum "$manifest" | cut -d' ' -f1)" = "$EXPECTED_MANIFEST_DIGEST"
+          node scripts/update-homebrew.mjs "$RELEASE_TAG" "$manifest"
+          node --test scripts/update-homebrew.test.mjs
+          ruby -c Casks/tailchrome.rb
+          ruby -c Formula/tailchrome.rb
+          git diff --check
+      - name: Save the update for manual application
+        run: git diff -- Casks/tailchrome.rb Formula/tailchrome.rb > homebrew-update.patch
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: homebrew-update-${{ inputs.release_tag }}
+          path: homebrew-update.patch
+      - name: Open an update pull request
+        id: pull-request
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- Casks/tailchrome.rb Formula/tailchrome.rb; then
+            echo "Homebrew already points to $RELEASE_TAG." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          branch="automation/homebrew-$RELEASE_TAG"
+          existing_pr="$(gh pr list --base main --head "$branch" --state open --json url --jq '.[0].url // empty')"
+          if [ -n "$existing_pr" ]; then
+            echo "Homebrew update already awaiting review: $existing_pr" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          git switch -c "$branch"
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add Casks/tailchrome.rb Formula/tailchrome.rb
+          git commit -m "chore(homebrew): update to $RELEASE_TAG"
+          # Retry safely if a previous run pushed the branch but could not open a PR.
+          if git ls-remote --exit-code --heads origin "$branch" >/dev/null; then
+            git fetch origin "$branch"
+            git diff --exit-code FETCH_HEAD -- Casks/tailchrome.rb Formula/tailchrome.rb
+          else
+            git push origin "HEAD:refs/heads/$branch"
+          fi
+          body="$RUNNER_TEMP/homebrew-pr.md"
+          {
+            printf 'Update the macOS cask and Linux formula to the published %s helper release.\n\n' "$RELEASE_TAG"
+            printf "The package hashes come from the final SHA256SUMS.txt, verified against \`%s\`.\n\n" "$EXPECTED_MANIFEST_DIGEST"
+            printf 'Validation: Homebrew updater tests, Ruby syntax checks, and git diff --check.\n\n'
+            printf 'Approve any pending CI workflow runs on this automated PR before merging. If your GitHub deployment does not create runs for GITHUB_TOKEN PRs, close and reopen the PR as a maintainer to trigger CI.\n'
+          } > "$body"
+          gh pr create --base main --head "$branch" \
+            --title "chore(homebrew): update to $RELEASE_TAG" --body-file "$body" \
+            >> "$GITHUB_STEP_SUMMARY"
+      - name: Report the manual fallback
+        if: steps.pull-request.outcome == 'failure'
+        run: |
+          echo "::warning::Could not open the Homebrew update PR. Apply the saved patch artifact or enable Actions PR creation and rerun Update Homebrew."
+          {
+            echo "Homebrew update PR creation failed; the helper release remains published."
+            echo "Download the homebrew-update-$RELEASE_TAG patch artifact and apply it in a normal pull request, or enable Actions PR creation and rerun this workflow."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           node-version: 22
           package-manager-cache: false
-      - name: Verify the published release manifest
+      - name: Verify the published release manifest and fetch its source
         run: |
           set -euo pipefail
           [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
@@ -59,7 +59,17 @@ jobs:
           gh release download "$RELEASE_TAG" --pattern SHA256SUMS.txt --dir "$RUNNER_TEMP/homebrew-release"
           manifest="$RUNNER_TEMP/homebrew-release/SHA256SUMS.txt"
           test "$(sha256sum "$manifest" | cut -d' ' -f1)" = "$EXPECTED_MANIFEST_DIGEST"
-          node scripts/update-homebrew.mjs "$RELEASE_TAG" "$manifest"
+          source_archive="$RUNNER_TEMP/homebrew-release/$RELEASE_TAG.tar.gz"
+          curl --fail --location --proto '=https' --tlsv1.2 \
+            "https://github.com/dantraynor/tailchrome/archive/refs/tags/$RELEASE_TAG.tar.gz" \
+            --output "$source_archive"
+          # Check the archive's declared version before proposing its checksum.
+          source_version="${RELEASE_TAG#v}"
+          tar -xzOf "$source_archive" "tailchrome-$source_version/packages/extension/package.json" | \
+            jq -e --arg version "$source_version" '.version == $version'
+          node scripts/update-homebrew.mjs "$RELEASE_TAG" "$manifest" "$source_archive"
+          source_sha256="$(sha256sum "$source_archive" | cut -d' ' -f1)"
+          echo "SOURCE_ARCHIVE_SHA256=$source_sha256" >> "$GITHUB_ENV"
           node --test scripts/update-homebrew.test.mjs
           ruby -c Casks/tailchrome.rb
           ruby -c Formula/tailchrome.rb
@@ -99,8 +109,9 @@ jobs:
           fi
           body="$RUNNER_TEMP/homebrew-pr.md"
           {
-            printf 'Update the macOS cask and Linux formula to the published %s helper release.\n\n' "$RELEASE_TAG"
-            printf "The package hashes come from the final SHA256SUMS.txt, verified against \`%s\`.\n\n" "$EXPECTED_MANIFEST_DIGEST"
+            printf 'Update the macOS cask and source formula to the published %s helper release.\n\n' "$RELEASE_TAG"
+            printf "The cask checksum comes from the final SHA256SUMS.txt, verified against \`%s\`.\n\n" "$EXPECTED_MANIFEST_DIGEST"
+            printf "The source archive for the release tag has SHA-256 \`%s\`.\n\n" "$SOURCE_ARCHIVE_SHA256"
             printf 'Validation: Homebrew updater tests, Ruby syntax checks, and git diff --check.\n\n'
             printf 'Approve any pending CI workflow runs on this automated PR before merging. If your GitHub deployment does not create runs for GITHUB_TOKEN PRs, close and reopen the PR as a maintainer to trigger CI.\n'
           } > "$body"

--- a/Casks/tailchrome.rb
+++ b/Casks/tailchrome.rb
@@ -1,0 +1,35 @@
+cask "tailchrome" do
+  version "0.1.13"
+  sha256 "46719646d0c144d1ed3ea95fcbfca4ccd81296781519832d56ed26e810b6e045"
+
+  url "https://github.com/dantraynor/tailchrome/releases/download/v#{version}/tailchrome-helper-macos.pkg"
+  name "Tailchrome Helper"
+  desc "Native helper for accessing a Tailscale network from your browser"
+  homepage "https://github.com/dantraynor/tailchrome"
+
+  depends_on :macos
+
+  pkg "tailchrome-helper-macos.pkg"
+
+  uninstall script:  {
+              executable:   "/Library/Application Support/Tailscale/BrowserExt/tailscale-browser-ext",
+              args:         ["-uninstall"],
+              sudo:         false,
+              must_succeed: false,
+            },
+            pkgutil: "org.tesseras.tailchrome.helper"
+
+  caveats <<~EOS
+    Install the Tailchrome browser extension from the Chrome Web Store or Firefox Add-ons.
+    Restart your browser after installing or upgrading the helper.
+
+    To register another macOS user or repair browser discovery, open:
+      /Applications/Tailchrome Helper.app
+
+    Before uninstalling, disconnect Tailchrome and close your browsers.
+    Uninstall removes registrations for the current user. Other users should run
+    the following command in their account before the package is removed:
+      "/Library/Application Support/Tailscale/BrowserExt/tailscale-browser-ext" -uninstall
+    Tailscale identities and profile data are preserved.
+  EOS
+end

--- a/Formula/tailchrome.rb
+++ b/Formula/tailchrome.rb
@@ -1,0 +1,61 @@
+class Tailchrome < Formula
+  desc "Native helper for accessing a Tailscale network from your browser"
+  homepage "https://github.com/dantraynor/tailchrome"
+  version "0.1.13"
+  license "MIT"
+
+  depends_on :linux
+
+  if on_arch_conditional(arm: true, intel: false)
+    url "https://github.com/dantraynor/tailchrome/releases/download/v#{version}/tailscale-browser-ext-linux-arm64",
+        using: :nounzip
+    sha256 "4f54db1343a4de8d659907bab62abdb2a53d78d437a53db12803d7cd26c1a9af"
+  else
+    url "https://github.com/dantraynor/tailchrome/releases/download/v#{version}/tailscale-browser-ext-linux-amd64",
+        using: :nounzip
+    sha256 "2cd1e869d80a9c27f49e7d6959883b586e84d25859541693b7e33b467bb66213"
+  end
+
+  def install
+    arch = Hardware::CPU.arm? ? "arm64" : "amd64"
+    bin.install "tailscale-browser-ext-linux-#{arch}" => "tailscale-browser-ext"
+  end
+
+  def caveats
+    <<~EOS
+      Install the Tailchrome browser extension from the Chrome Web Store or Firefox Add-ons.
+
+      After installing AND after each brew upgrade, disconnect Tailchrome, close
+      your browsers, and register the helper for your user (without sudo):
+        #{opt_bin}/tailscale-browser-ext -install-now
+      This refreshes a separate runtime copy in ~/.local/share/tailscale/browser-ext.
+      Reopen your browser when registration finishes.
+
+      Before brew uninstall, remove that runtime copy and your browser registrations:
+        #{opt_bin}/tailscale-browser-ext -uninstall
+      Run this in each account that registered the helper.
+      Tailscale identities and profile data are preserved.
+    EOS
+  end
+
+  test do
+    assert_equal "v#{version}", shell_output("#{bin}/tailscale-browser-ext -version").strip
+    system bin/"tailscale-browser-ext", "-install-now"
+
+    runtime = testpath/".local/share/tailscale/browser-ext/tailscale-browser-ext"
+    chrome = testpath/".config/google-chrome/NativeMessagingHosts/com.tailscale.browserext.chrome.json"
+    firefox = testpath/".mozilla/native-messaging-hosts/com.tailscale.browserext.firefox.json"
+    assert_path_exists runtime
+    assert_equal runtime.to_s, JSON.parse(chrome.read).fetch("path")
+    assert_equal ["chrome-extension://bhfeceecialgilpedkoflminjgcjljll/"],
+                 JSON.parse(chrome.read).fetch("allowed_origins")
+    assert_equal runtime.to_s, JSON.parse(firefox.read).fetch("path")
+    assert_equal ["tailchrome@tesseras.org"], JSON.parse(firefox.read).fetch("allowed_extensions")
+
+    system bin/"tailscale-browser-ext", "-uninstall"
+    refute_path_exists runtime
+    refute_path_exists chrome
+    refute_path_exists firefox
+    assert_path_exists bin/"tailscale-browser-ext"
+  end
+end

--- a/Formula/tailchrome.rb
+++ b/Formula/tailchrome.rb
@@ -1,24 +1,24 @@
 class Tailchrome < Formula
-  desc "Native helper for accessing a Tailscale network from your browser"
+  desc "Browser native messaging host for Tailscale networks"
   homepage "https://github.com/dantraynor/tailchrome"
-  version "0.1.13"
+  url "https://github.com/dantraynor/tailchrome/archive/refs/tags/v0.1.13.tar.gz"
+  sha256 "6f8da65c49a6f1a94c91dda5bf781db83ba4b9aaee7299cccd4aca0899750e57"
   license "MIT"
 
-  depends_on :linux
-
-  if on_arch_conditional(arm: true, intel: false)
-    url "https://github.com/dantraynor/tailchrome/releases/download/v#{version}/tailscale-browser-ext-linux-arm64",
-        using: :nounzip
-    sha256 "4f54db1343a4de8d659907bab62abdb2a53d78d437a53db12803d7cd26c1a9af"
-  else
-    url "https://github.com/dantraynor/tailchrome/releases/download/v#{version}/tailscale-browser-ext-linux-amd64",
-        using: :nounzip
-    sha256 "2cd1e869d80a9c27f49e7d6959883b586e84d25859541693b7e33b467bb66213"
-  end
+  depends_on "go" => :build
 
   def install
-    arch = Hardware::CPU.arm? ? "arm64" : "amd64"
-    bin.install "tailscale-browser-ext-linux-#{arch}" => "tailscale-browser-ext"
+    ENV["CGO_ENABLED"] = "0"
+    cd "host" do
+      ts_version = Utils.safe_popen_read("go", "list", "-m", "-f", "{{.Version}}", "tailscale.com")
+      ts_version = ts_version.strip.delete_prefix("v")
+      ldflags = %W[
+        -X main.version=v#{version}
+        -X tailscale.com/version.shortStamp=#{ts_version}
+        -X tailscale.com/version.longStamp=#{ts_version}
+      ]
+      system "go", "build", *std_go_args(ldflags:, output: bin/"tailscale-browser-ext")
+    end
   end
 
   def caveats
@@ -28,7 +28,7 @@ class Tailchrome < Formula
       After installing AND after each brew upgrade, disconnect Tailchrome, close
       your browsers, and register the helper for your user (without sudo):
         #{opt_bin}/tailscale-browser-ext -install-now
-      This refreshes a separate runtime copy in ~/.local/share/tailscale/browser-ext.
+      This refreshes a separate runtime copy in your user account.
       Reopen your browser when registration finishes.
 
       Before brew uninstall, remove that runtime copy and your browser registrations:
@@ -42,9 +42,16 @@ class Tailchrome < Formula
     assert_equal "v#{version}", shell_output("#{bin}/tailscale-browser-ext -version").strip
     system bin/"tailscale-browser-ext", "-install-now"
 
-    runtime = testpath/".local/share/tailscale/browser-ext/tailscale-browser-ext"
-    chrome = testpath/".config/google-chrome/NativeMessagingHosts/com.tailscale.browserext.chrome.json"
-    firefox = testpath/".mozilla/native-messaging-hosts/com.tailscale.browserext.firefox.json"
+    if OS.mac?
+      support = testpath/"Library/Application Support"
+      runtime = support/"Tailscale/BrowserExt/tailscale-browser-ext"
+      chrome = support/"Google/Chrome/NativeMessagingHosts/com.tailscale.browserext.chrome.json"
+      firefox = support/"Mozilla/NativeMessagingHosts/com.tailscale.browserext.firefox.json"
+    else
+      runtime = testpath/".local/share/tailscale/browser-ext/tailscale-browser-ext"
+      chrome = testpath/".config/google-chrome/NativeMessagingHosts/com.tailscale.browserext.chrome.json"
+      firefox = testpath/".mozilla/native-messaging-hosts/com.tailscale.browserext.firefox.json"
+    end
     assert_path_exists runtime
     assert_equal runtime.to_s, JSON.parse(chrome.read).fetch("path")
     assert_equal ["chrome-extension://bhfeceecialgilpedkoflminjgcjljll/"],

--- a/README.md
+++ b/README.md
@@ -46,8 +46,33 @@ The same UI renders in either surface.
 ## Install
 
 1. Get the extension from the [Chrome Web Store](https://chromewebstore.google.com/detail/tailchrome/bhfeceecialgilpedkoflminjgcjljll) (also installs in Brave, Edge, Vivaldi, Opera, and — on macOS — Arc) or [Firefox Add-ons](https://addons.mozilla.org/en-US/firefox/addon/tailchrome/)
-2. Install the native helper from the [latest release](https://github.com/dantraynor/tailchrome/releases/latest) — **`tailchrome-helper-macos.pkg`** on macOS, **`tailchrome-helper-windows-x64.msi`** on Windows, or the **`.deb`/`.rpm`** package on Linux amd64. Linux ARM64 and per-user repair flows use the release's checksum-verifying **`tailchrome-install.sh`**.
+2. Install the native helper with [Homebrew](#homebrew-macos-and-linux) on macOS/Linux, or from the [latest release](https://github.com/dantraynor/tailchrome/releases/latest) — **`tailchrome-helper-macos.pkg`** on macOS, **`tailchrome-helper-windows-x64.msi`** on Windows, or the **`.deb`/`.rpm`** package on Linux amd64. Linux ARM64 and per-user repair flows can also use the release's checksum-verifying **`tailchrome-install.sh`**.
 3. Log in to your Tailscale account
+
+### Homebrew (macOS and Linux)
+
+Add this repository as a tap once:
+
+```bash
+brew tap dantraynor/tailchrome https://github.com/dantraynor/tailchrome
+```
+
+On macOS, install the signed helper package with
+`brew install --cask dantraynor/tailchrome/tailchrome`.
+
+On Linux (x86_64 or ARM64), run:
+
+```bash
+brew install --formula dantraynor/tailchrome/tailchrome
+tailscale-browser-ext -install-now
+```
+
+Linux users must close their browsers and repeat `tailscale-browser-ext -install-now`
+after each `brew upgrade` to refresh the per-user runtime copy. See the
+[Homebrew instructions](packaging/homebrew/README.md) for upgrades, repair,
+and removal. The browser extension is installed separately.
+
+### Platform installers
 
 The platform release package is the primary installation path. The macOS
 installer is platform-signed. A Windows installer is release-quality only when

--- a/README.md
+++ b/README.md
@@ -60,15 +60,16 @@ brew tap dantraynor/tailchrome https://github.com/dantraynor/tailchrome
 On macOS, install the signed helper package with
 `brew install --cask dantraynor/tailchrome/tailchrome`.
 
-On Linux (x86_64 or ARM64), run:
+To build the helper from source on Linux or macOS, run:
 
 ```bash
 brew install --formula dantraynor/tailchrome/tailchrome
 tailscale-browser-ext -install-now
 ```
 
-Linux users must close their browsers and repeat `tailscale-browser-ext -install-now`
-after each `brew upgrade` to refresh the per-user runtime copy. See the
+The formula installs Go as a build dependency. Formula users must close their
+browsers and repeat `tailscale-browser-ext -install-now` after each `brew upgrade`
+to refresh the per-user runtime copy. See the
 [Homebrew instructions](packaging/homebrew/README.md) for upgrades, repair,
 and removal. The browser extension is installed separately.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -43,6 +43,7 @@ pnpm lint:firefox        # AMO-style validation
 pnpm review:firefox      # Full Firefox validation pipeline
 pnpm test                # All tests
 pnpm test:installer      # Verified installer shell tests
+pnpm test:homebrew       # Homebrew release updater tests
 pnpm typecheck           # TypeScript validation
 pnpm e2e:chrome          # Puppeteer smoke suite (Chrome)
 pnpm e2e:firefox         # Puppeteer smoke suite (Firefox)
@@ -64,6 +65,7 @@ seam you touched, then finish with:
 pnpm typecheck
 pnpm test
 pnpm test:installer
+pnpm test:homebrew
 (cd host && go test -race ./... && go vet ./...)
 git diff --check
 ```
@@ -97,3 +99,7 @@ Include your browser, OS, extension version, and steps to reproduce.
   accepted provider and exact signer subject. Signing cannot silently skip or
   switch publisher identities.
 - Store publication uses GitHub Actions with manual environment approvals for Chrome Web Store and Firefox AMO submission
+- Successful helper publication calls the Homebrew update workflow, which
+  proposes the published version and final package checksums in a pull request.
+  See [Homebrew maintenance](../packaging/homebrew/README.md#maintaining-the-tap)
+  for setup, retries, and manual updates.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -100,6 +100,8 @@ Include your browser, OS, extension version, and steps to reproduce.
   switch publisher identities.
 - Store publication uses GitHub Actions with manual environment approvals for Chrome Web Store and Firefox AMO submission
 - Successful helper publication calls the Homebrew update workflow, which
-  proposes the published version and final package checksums in a pull request.
+  proposes the published version, final macOS package checksum, and release
+  source archive checksum in a pull request. CI builds the formula from source
+  and tests registration and removal on macOS and Linux.
   See [Homebrew maintenance](../packaging/homebrew/README.md#maintaining-the-tap)
   for setup, retries, and manual updates.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -114,3 +114,15 @@ If either scanner reports malware, PUA, or suspicious behavior, stop. Record the
 - [ ] The draft was made public only by the final publication step.
 
 If the candidate artifact expires, or any file or digest differs, create a new candidate and repeat this checklist. Never rebuild, resign, repackage, regenerate checksums, or replace assets after clearance.
+
+## After publication: Homebrew
+
+- [ ] Inspect the `Update Homebrew` follow-up for the published release tag and the same approved `SHA256SUMS.txt` digest.
+- [ ] Review the automated Homebrew update PR. If no PR was created, apply the `homebrew-update-vX.Y.Z` patch artifact in a normal PR, or use the documented manual update.
+- [ ] Confirm `Casks/tailchrome.rb` and `Formula/tailchrome.rb` use the published version and that the macOS package and both Linux helper hashes match the approved release manifest.
+- [ ] Approve any pending CI workflow runs on the update PR and wait for the updater tests and Homebrew checks to pass.
+- [ ] Merge the update PR into `main` and verify that `brew update` makes the published version available in the tap.
+
+See [Homebrew maintenance](../packaging/homebrew/README.md#maintaining-the-tap)
+for workflow retries and manual updates. The helper release remains published
+while this follow-up is completed.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -119,7 +119,8 @@ If the candidate artifact expires, or any file or digest differs, create a new c
 
 - [ ] Inspect the `Update Homebrew` follow-up for the published release tag and the same approved `SHA256SUMS.txt` digest.
 - [ ] Review the automated Homebrew update PR. If no PR was created, apply the `homebrew-update-vX.Y.Z` patch artifact in a normal PR, or use the documented manual update.
-- [ ] Confirm `Casks/tailchrome.rb` and `Formula/tailchrome.rb` use the published version and that the macOS package and both Linux helper hashes match the approved release manifest.
+- [ ] Confirm both definitions use the published version and that the cask's macOS package hash matches the approved release manifest.
+- [ ] Verify the formula's source archive URL points to the reviewed release tag and independently check its SHA-256 against the downloaded archive; GitHub's tag archive is separate from the signed package manifest.
 - [ ] Approve any pending CI workflow runs on the update PR and wait for the updater tests and Homebrew checks to pass.
 - [ ] Merge the update PR into `main` and verify that `brew update` makes the published version available in the tap.
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "pnpm -r test && pnpm test:e2e-utils",
     "test:e2e-utils": "node --test scripts/e2e/*.test.mjs",
     "test:installer": "bash ./scripts/install.test.sh",
+    "test:homebrew": "node --test scripts/update-homebrew.test.mjs",
     "typecheck": "pnpm -r typecheck",
     "e2e": "node ./scripts/e2e/run.mjs",
     "e2e:chrome": "node ./scripts/e2e/run.mjs --browser=chrome",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
       "postcss": "^8.5.23",
       "ws": "^8.20.1",
       "tmp": "^0.2.6",
-      "fast-uri": "^3.1.5",
+      "fast-uri": "^3.1.6",
       "defu": "^6.1.5",
       "brace-expansion@1": "^1.1.18",
       "brace-expansion@5": "^5.0.9",

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -1,0 +1,163 @@
+# Homebrew installation
+
+This repository is also a Homebrew tap. The macOS cask uses the signed,
+notarized universal `.pkg`; the Linux formula uses the published x86_64 or
+ARM64 helper. Both pin a release version and SHA-256 checksums.
+
+Install [Homebrew](https://brew.sh/) and add the tap:
+
+```bash
+brew tap dantraynor/tailchrome https://github.com/dantraynor/tailchrome
+```
+
+The explicit URL is required because this repository is named `tailchrome`,
+rather than `homebrew-tailchrome`. This is a project tap, not an entry in
+Homebrew's core or cask repositories. Install the browser extension separately
+from the [Chrome Web Store](https://chromewebstore.google.com/detail/tailchrome/bhfeceecialgilpedkoflminjgcjljll)
+or [Firefox Add-ons](https://addons.mozilla.org/en-US/firefox/addon/tailchrome/).
+
+## macOS
+
+```bash
+brew install --cask dantraynor/tailchrome/tailchrome
+```
+
+The package requires an administrator password and supports both Apple Silicon
+and Intel Macs. It installs `/Applications/Tailchrome Helper.app` and the helper
+at `/Library/Application Support/Tailscale/BrowserExt/tailscale-browser-ext`.
+The package registers a per-user runtime copy for the logged-in console user.
+Restart your browser after installation.
+
+To repair discovery or register another macOS user, open **Tailchrome Helper**
+in that account, or run:
+
+```bash
+"/Library/Application Support/Tailscale/BrowserExt/tailscale-browser-ext" -install-now
+```
+
+Before upgrading, disconnect Tailchrome and close your browsers:
+
+```bash
+brew update
+brew upgrade --cask dantraynor/tailchrome/tailchrome
+```
+
+Reopen your browsers when the upgrade finishes. Other macOS accounts that use
+Tailchrome should run the repair command above to refresh their runtime copy.
+
+To uninstall, disconnect Tailchrome and close your browsers, then run:
+
+```bash
+brew uninstall --cask dantraynor/tailchrome/tailchrome
+```
+
+The cask invokes the helper's `-uninstall` command as the current user before
+removing the package payload and receipt (`org.tesseras.tailchrome.helper`).
+If other accounts used Tailchrome, run the following once in each account
+**before** uninstalling the cask:
+
+```bash
+"/Library/Application Support/Tailscale/BrowserExt/tailscale-browser-ext" -uninstall
+```
+
+## Linux
+
+```bash
+brew install --formula dantraynor/tailchrome/tailchrome
+tailscale-browser-ext -install-now
+```
+
+Run registration without `sudo`. The helper registers Chrome, Firefox, and
+the other supported Chromium-family browsers for your current user. It copies
+the executable to `~/.local/share/tailscale/browser-ext/tailscale-browser-ext`.
+Homebrew owns the downloaded helper in its prefix; the registration command
+owns this separate runtime copy and your native-messaging manifests.
+
+After **every** upgrade, disconnect Tailchrome and close your browsers before
+refreshing that runtime copy:
+
+```bash
+brew update
+brew upgrade --formula dantraynor/tailchrome/tailchrome
+tailscale-browser-ext -install-now
+```
+
+Reopen your browser after registration finishes. The same registration command
+repairs discovery. Run it in each account that uses Tailchrome. If the executable
+is not on `PATH`, use `"$(brew --prefix tailchrome)/bin/tailscale-browser-ext"`.
+
+Before removing the formula, disconnect Tailchrome and close your browsers,
+then run:
+
+```bash
+tailscale-browser-ext -uninstall
+brew uninstall --formula dantraynor/tailchrome/tailchrome
+```
+
+Run `-uninstall` in each registered user account before removing the formula.
+If you already removed it, the runtime copy can still clean itself up:
+
+```bash
+"$HOME/.local/share/tailscale/browser-ext/tailscale-browser-ext" -uninstall
+```
+
+Neither platform's uninstall deletes Tailscale identities or profile data.
+Use one helper installation method at a time; per-user registrations can take
+precedence over package registrations. When switching from another installer,
+disconnect Tailchrome, close browsers, follow that installer's uninstall steps,
+then install and register with Homebrew.
+
+Homebrew does not install a native Windows helper. Use the
+[Windows MSI](../windows/README.md) for browsers running on Windows, including
+when Homebrew is available inside WSL.
+
+## Maintaining the tap
+
+`Casks/tailchrome.rb` and `Formula/tailchrome.rb` track the latest **published**
+stable helper release. Do not bump them with `scripts/bump-version.sh`: the
+final checksums are available only after signing, notarization, and packaging.
+
+After protected helper publication succeeds, `Publish Helper Release` calls
+`Update Homebrew`. That workflow verifies the public release and the approved
+`SHA256SUMS.txt` digest, updates both definitions, tests the updater, and opens a
+pull request against `main`. It uses this repository's `GITHUB_TOKEN`; no separate
+tap repository or PAT is needed. Merge the update PR to make the new version
+available through `brew update`.
+
+For automatic PR creation, enable **Settings → Actions → General → Workflow
+permissions → Allow GitHub Actions to create and approve pull requests**. This
+workflow only creates PRs; it does not approve or merge them. Approve any pending
+CI workflow runs on the automated PR before merging; see GitHub's
+[GITHUB_TOKEN workflow rules](https://docs.github.com/en/actions/concepts/security/github_token).
+If your GitHub deployment does not create runs for these PRs, close and reopen
+the PR as a maintainer to trigger CI. The workflow also saves a
+`homebrew-update-vX.Y.Z` patch artifact so updates remain available when PR
+creation is disabled or branch protection prevents the push. A PR creation
+failure produces a warning with this fallback and does not fail the helper
+publication job.
+
+If an update fails, the helper release stays published. Re-run `Update Homebrew`
+from `main` with the same `release_tag` and `sha256sums_digest`. The workflow
+rejects drafts and prereleases; the updater rejects malformed/missing/duplicate
+checksums and version downgrades. Existing update PRs are left for review.
+
+For a manual update, replace `vX.Y.Z` with the published release tag:
+
+```bash
+mkdir -p .context/homebrew-update
+gh release download vX.Y.Z --repo dantraynor/tailchrome \
+  --pattern SHA256SUMS.txt --dir .context/homebrew-update
+# Compare this digest with the approved publication summary before continuing.
+shasum -a 256 .context/homebrew-update/SHA256SUMS.txt
+node scripts/update-homebrew.mjs vX.Y.Z .context/homebrew-update/SHA256SUMS.txt
+pnpm test:homebrew
+git diff --check
+git diff -- Casks/tailchrome.rb Formula/tailchrome.rb
+```
+
+Commit the reviewed definition updates through a pull request. CI tests Linux
+installation, registration, and removal in Homebrew's temporary test home. On
+macOS it checks cask syntax/style and fetches the package to verify its checksum,
+signature, and stapled notarization ticket. Full macOS install/upgrade/uninstall
+still needs a Mac with a logged-in user; follow the commands above and check
+browser discovery after each step.

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -1,8 +1,9 @@
 # Homebrew installation
 
 This repository is also a Homebrew tap. The macOS cask uses the signed,
-notarized universal `.pkg`; the Linux formula uses the published x86_64 or
-ARM64 helper. Both pin a release version and SHA-256 checksums.
+notarized universal `.pkg`. The formula builds the helper from a checksummed
+release source archive on macOS and Linux, with Go as a build dependency.
+Both pin a release version and SHA-256 checksum.
 
 Install [Homebrew](https://brew.sh/) and add the tap:
 
@@ -60,7 +61,11 @@ If other accounts used Tailchrome, run the following once in each account
 "/Library/Application Support/Tailscale/BrowserExt/tailscale-browser-ext" -uninstall
 ```
 
-## Linux
+## Source formula (macOS and Linux)
+
+The formula builds the native helper locally for your architecture. It does
+not install the macOS package or **Tailchrome Helper.app**; register the helper
+with the command below. Go is needed only to build the helper.
 
 ```bash
 brew install --formula dantraynor/tailchrome/tailchrome
@@ -68,10 +73,12 @@ tailscale-browser-ext -install-now
 ```
 
 Run registration without `sudo`. The helper registers Chrome, Firefox, and
-the other supported Chromium-family browsers for your current user. It copies
-the executable to `~/.local/share/tailscale/browser-ext/tailscale-browser-ext`.
-Homebrew owns the downloaded helper in its prefix; the registration command
-owns this separate runtime copy and your native-messaging manifests.
+the other supported Chromium-family browsers for your current user. Homebrew
+owns the built helper in its prefix; the registration command owns a separate
+runtime copy and your native-messaging manifests. The runtime copy lives at:
+
+- macOS: `~/Library/Application Support/Tailscale/BrowserExt/tailscale-browser-ext`
+- Linux: `~/.local/share/tailscale/browser-ext/tailscale-browser-ext`
 
 After **every** upgrade, disconnect Tailchrome and close your browsers before
 refreshing that runtime copy:
@@ -95,9 +102,13 @@ brew uninstall --formula dantraynor/tailchrome/tailchrome
 ```
 
 Run `-uninstall` in each registered user account before removing the formula.
-If you already removed it, the runtime copy can still clean itself up:
+If you already removed it, run the runtime copy's `-uninstall` command using
+the path for your platform:
 
 ```bash
+# macOS
+"$HOME/Library/Application Support/Tailscale/BrowserExt/tailscale-browser-ext" -uninstall
+# Linux
 "$HOME/.local/share/tailscale/browser-ext/tailscale-browser-ext" -uninstall
 ```
 
@@ -115,13 +126,17 @@ when Homebrew is available inside WSL.
 
 `Casks/tailchrome.rb` and `Formula/tailchrome.rb` track the latest **published**
 stable helper release. Do not bump them with `scripts/bump-version.sh`: the
-final checksums are available only after signing, notarization, and packaging.
+cask's final checksum is available only after signing, notarization, and packaging.
 
 After protected helper publication succeeds, `Publish Helper Release` calls
 `Update Homebrew`. That workflow verifies the public release and the approved
-`SHA256SUMS.txt` digest, updates both definitions, tests the updater, and opens a
-pull request against `main`. It uses this repository's `GITHUB_TOKEN`; no separate
-tap repository or PAT is needed. Merge the update PR to make the new version
+`SHA256SUMS.txt` digest for the cask. It also downloads the release tag's source
+archive, checks its declared version, and computes the formula's SHA-256.
+GitHub's source archive is separate from the signed package manifest; review
+its tag and checksum independently. The workflow updates both definitions,
+tests the updater, and opens a pull request against `main`. It uses this
+repository's `GITHUB_TOKEN`; no separate tap repository or PAT is needed.
+Merge the update PR to make the new version
 available through `brew update`.
 
 For automatic PR creation, enable **Settings → Actions → General → Workflow
@@ -149,15 +164,42 @@ gh release download vX.Y.Z --repo dantraynor/tailchrome \
   --pattern SHA256SUMS.txt --dir .context/homebrew-update
 # Compare this digest with the approved publication summary before continuing.
 shasum -a 256 .context/homebrew-update/SHA256SUMS.txt
-node scripts/update-homebrew.mjs vX.Y.Z .context/homebrew-update/SHA256SUMS.txt
+curl --fail --location --proto '=https' --tlsv1.2 \
+  https://github.com/dantraynor/tailchrome/archive/refs/tags/vX.Y.Z.tar.gz \
+  --output .context/homebrew-update/vX.Y.Z.tar.gz
+shasum -a 256 .context/homebrew-update/vX.Y.Z.tar.gz
+node scripts/update-homebrew.mjs vX.Y.Z .context/homebrew-update/SHA256SUMS.txt \
+  .context/homebrew-update/vX.Y.Z.tar.gz
 pnpm test:homebrew
 git diff --check
 git diff -- Casks/tailchrome.rb Formula/tailchrome.rb
 ```
 
-Commit the reviewed definition updates through a pull request. CI tests Linux
-installation, registration, and removal in Homebrew's temporary test home. On
-macOS it checks cask syntax/style and fetches the package to verify its checksum,
-signature, and stapled notarization ticket. Full macOS install/upgrade/uninstall
-still needs a Mac with a logged-in user; follow the commands above and check
-browser discovery after each step.
+Commit the reviewed definition updates through a pull request. CI builds the
+formula from source on macOS and Linux and tests registration and removal in
+Homebrew's temporary test home. It also checks cask syntax/style on macOS and
+fetches the package to verify its checksum, signature, and stapled notarization
+ticket. Full macOS cask install/upgrade/uninstall still needs a Mac with a
+logged-in user; follow the commands above and check browser discovery after
+each step.
+
+## Preparing a Homebrew core submission
+
+`Formula/tailchrome.rb` builds from source on both supported platforms and can
+be proposed to [Homebrew/homebrew-core](https://github.com/Homebrew/homebrew-core)
+as `Formula/t/tailchrome.rb`. Follow Homebrew's
+[new formula checklist](https://docs.brew.sh/Adding-Software-to-Homebrew) and
+[acceptance requirements](https://docs.brew.sh/Acceptable-Formulae). In a local
+checkout of that tap, validate the formula before opening the upstream PR:
+
+```bash
+brew style --formula homebrew/core/tailchrome
+brew audit --new --strict --online --formula homebrew/core/tailchrome
+HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source --formula homebrew/core/tailchrome
+brew test homebrew/core/tailchrome
+```
+
+Homebrew reviews eligibility and generates bottles through its own CI. Core
+acceptance is separate from this project's tap; the release workflow above
+updates only this repository. Once accepted, submit later core updates through
+Homebrew's contribution process as well.

--- a/packaging/linux/README.md
+++ b/packaging/linux/README.md
@@ -1,5 +1,10 @@
 # Linux helper installation
 
+Homebrew users on x86_64 or ARM64 can use the
+[Tailchrome formula](../homebrew/README.md#linux). It installs a checksummed
+release helper; browser registration is a separate per-user command that
+must also be run after upgrades.
+
 `build-packages.sh` produces:
 
 - `dist/tailchrome-helper-linux-amd64.deb`
@@ -19,9 +24,9 @@ Package ownership stops at those system files. The packages have no
 post-install registration script and write nothing below a user's home
 directory, so removing the package removes everything it owns.
 
-ARM64 `.deb` and `.rpm` packages are not published. Linux ARM64 users use the
-verified `tailscale-browser-ext-linux-arm64` raw helper through the repair
-script described below.
+ARM64 `.deb` and `.rpm` packages are not published. Linux ARM64 users can use
+Homebrew or the verified `tailscale-browser-ext-linux-arm64` raw helper through
+the repair script described below.
 
 ## Per-user registration repair
 

--- a/packaging/linux/README.md
+++ b/packaging/linux/README.md
@@ -1,8 +1,9 @@
 # Linux helper installation
 
 Homebrew users on x86_64 or ARM64 can use the
-[Tailchrome formula](../homebrew/README.md#linux). It installs a checksummed
-release helper; browser registration is a separate per-user command that
+[Tailchrome formula](../homebrew/README.md#source-formula-macos-and-linux). It builds
+the helper from a checksummed release source archive using Homebrew's Go;
+browser registration is a separate per-user command that
 must also be run after upgrades.
 
 `build-packages.sh` produces:

--- a/packaging/macos/README.md
+++ b/packaging/macos/README.md
@@ -3,6 +3,9 @@
 Homebrew users can install the same signed release package with the
 [Tailchrome cask](../homebrew/README.md#macos). It supports Apple Silicon and
 Intel Macs and uses the package's existing registration and repair flow.
+The [source formula](../homebrew/README.md#source-formula-macos-and-linux) is also
+available for users who prefer to build the helper locally and register it
+without administrator privileges.
 
 The script `build-pkg.sh` produces `dist/tailchrome-helper-macos.pkg`, which installs:
 

--- a/packaging/macos/README.md
+++ b/packaging/macos/README.md
@@ -1,5 +1,9 @@
 # macOS Helper installer (.pkg)
 
+Homebrew users can install the same signed release package with the
+[Tailchrome cask](../homebrew/README.md#macos). It supports Apple Silicon and
+Intel Macs and uses the package's existing registration and repair flow.
+
 The script `build-pkg.sh` produces `dist/tailchrome-helper-macos.pkg`, which installs:
 
 1. **Universal** `tailscale-browser-ext` at  

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
   postcss: ^8.5.23
   ws: ^8.20.1
   tmp: ^0.2.6
-  fast-uri: ^3.1.5
+  fast-uri: ^3.1.6
   defu: ^6.1.5
   brace-expansion@1: ^1.1.18
   brace-expansion@5: ^5.0.9
@@ -1172,8 +1172,8 @@ packages:
     resolution: {integrity: sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==}
     engines: {node: '>=6'}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.7:
+    resolution: {integrity: sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -2931,7 +2931,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.7
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -3435,7 +3435,7 @@ snapshots:
 
   fast-redact@3.5.0: {}
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.7: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:

--- a/scripts/update-homebrew.mjs
+++ b/scripts/update-homebrew.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const root = fileURLToPath(new URL("../", import.meta.url));
+const releasePattern = /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+const assets = [
+  "tailchrome-helper-macos.pkg",
+  "tailscale-browser-ext-linux-arm64",
+  "tailscale-browser-ext-linux-amd64",
+];
+
+export function parseChecksums(contents) {
+  const checksums = new Map();
+  for (const line of contents.trimEnd().split(/\r?\n/)) {
+    const match = /^([0-9a-f]{64}) {2}([A-Za-z0-9][A-Za-z0-9._-]*)$/.exec(line);
+    if (!match) throw new Error(`Invalid SHA256SUMS.txt entry: ${line}`);
+    const [, checksum, asset] = match;
+    if (checksums.has(asset)) throw new Error(`Duplicate checksum for ${asset}`);
+    checksums.set(asset, checksum);
+  }
+  for (const asset of assets) {
+    if (!checksums.has(asset)) throw new Error(`Missing checksum for ${asset}`);
+  }
+  return checksums;
+}
+
+function replaceOnce(contents, pattern, replacement) {
+  let matches = 0;
+  const result = contents.replace(pattern, (...args) => {
+    matches += 1;
+    return replacement(...args);
+  });
+  if (matches !== 1) throw new Error(`Expected one match for ${pattern}, found ${matches}`);
+  return result;
+}
+
+function updateVersion(contents, tag) {
+  return replaceOnce(contents, /^  version "([0-9]+\.[0-9]+\.[0-9]+)"$/gm, (_, current) => {
+    const previous = current.split(".").map(BigInt);
+    const next = tag.slice(1).split(".").map(BigInt);
+    const difference = next.findIndex((part, i) => part !== previous[i]);
+    if (difference !== -1 && next[difference] < previous[difference]) {
+      throw new Error(`Refusing to downgrade Homebrew from ${current} to ${tag}`);
+    }
+    return `  version "${tag.slice(1)}"`;
+  });
+}
+
+// Read the final release manifest, never the pre-signing build outputs. Compute
+// both updates before writing either file so invalid input cannot partially bump.
+export async function updateHomebrew(tag, manifest, directory = root) {
+  if (!releasePattern.test(tag) || tag.trim() !== tag) {
+    throw new Error("Expected an explicit stable release tag such as v0.1.13");
+  }
+  const checksums = parseChecksums(manifest);
+  const caskPath = path.join(directory, "Casks/tailchrome.rb");
+  const formulaPath = path.join(directory, "Formula/tailchrome.rb");
+  const [originalCask, originalFormula] = await Promise.all([
+    readFile(caskPath, "utf8"),
+    readFile(formulaPath, "utf8"),
+  ]);
+  const cask = replaceOnce(
+    updateVersion(originalCask, tag),
+    /^  sha256 "[0-9a-f]{64}"$/gm,
+    () => `  sha256 "${checksums.get(assets[0])}"`,
+  );
+  let formula = updateVersion(originalFormula, tag);
+  for (const asset of assets.slice(1)) {
+    formula = replaceOnce(
+      formula,
+      new RegExp(`(url "[^"\\n]+/${asset}",\\n +using: :nounzip\\n +sha256 ")[0-9a-f]{64}"`, "g"),
+      (_, prefix) => `${prefix}${checksums.get(asset)}"`,
+    );
+  }
+  await writeFile(caskPath, cask);
+  await writeFile(formulaPath, formula);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  try {
+    const [tag, manifestPath, ...extra] = process.argv.slice(2);
+    if (!tag || !manifestPath || extra.length) {
+      throw new Error("Usage: node scripts/update-homebrew.mjs <vX.Y.Z> <SHA256SUMS.txt>");
+    }
+    await updateHomebrew(tag, await readFile(manifestPath, "utf8"));
+    console.log(`Updated the Homebrew cask and formula to ${tag}`);
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/update-homebrew.mjs
+++ b/scripts/update-homebrew.mjs
@@ -1,16 +1,13 @@
 #!/usr/bin/env node
 
 import { readFile, writeFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 const root = fileURLToPath(new URL("../", import.meta.url));
 const releasePattern = /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
-const assets = [
-  "tailchrome-helper-macos.pkg",
-  "tailscale-browser-ext-linux-arm64",
-  "tailscale-browser-ext-linux-amd64",
-];
+const caskAsset = "tailchrome-helper-macos.pkg";
 
 export function parseChecksums(contents) {
   const checksums = new Map();
@@ -21,9 +18,7 @@ export function parseChecksums(contents) {
     if (checksums.has(asset)) throw new Error(`Duplicate checksum for ${asset}`);
     checksums.set(asset, checksum);
   }
-  for (const asset of assets) {
-    if (!checksums.has(asset)) throw new Error(`Missing checksum for ${asset}`);
-  }
+  if (!checksums.has(caskAsset)) throw new Error(`Missing checksum for ${caskAsset}`);
   return checksums;
 }
 
@@ -37,23 +32,30 @@ function replaceOnce(contents, pattern, replacement) {
   return result;
 }
 
+function checkUpgrade(current, tag) {
+  const previous = current.split(".").map(BigInt);
+  const next = tag.slice(1).split(".").map(BigInt);
+  const difference = next.findIndex((part, i) => part !== previous[i]);
+  if (difference !== -1 && next[difference] < previous[difference]) {
+    throw new Error(`Refusing to downgrade Homebrew from ${current} to ${tag}`);
+  }
+}
+
 function updateVersion(contents, tag) {
   return replaceOnce(contents, /^  version "([0-9]+\.[0-9]+\.[0-9]+)"$/gm, (_, current) => {
-    const previous = current.split(".").map(BigInt);
-    const next = tag.slice(1).split(".").map(BigInt);
-    const difference = next.findIndex((part, i) => part !== previous[i]);
-    if (difference !== -1 && next[difference] < previous[difference]) {
-      throw new Error(`Refusing to downgrade Homebrew from ${current} to ${tag}`);
-    }
+    checkUpgrade(current, tag);
     return `  version "${tag.slice(1)}"`;
   });
 }
 
-// Read the final release manifest, never the pre-signing build outputs. Compute
-// both updates before writing either file so invalid input cannot partially bump.
-export async function updateHomebrew(tag, manifest, directory = root) {
+// The cask uses the final release manifest; the formula pins the tag's source
+// archive separately. Compute both updates before writing either definition.
+export async function updateHomebrew(tag, manifest, sourceSha256, directory = root) {
   if (!releasePattern.test(tag) || tag.trim() !== tag) {
     throw new Error("Expected an explicit stable release tag such as v0.1.13");
+  }
+  if (!/^[0-9a-f]{64}$/.test(sourceSha256) || sourceSha256.trim() !== sourceSha256) {
+    throw new Error("Expected the SHA-256 of the release source archive");
   }
   const checksums = parseChecksums(manifest);
   const caskPath = path.join(directory, "Casks/tailchrome.rb");
@@ -65,27 +67,29 @@ export async function updateHomebrew(tag, manifest, directory = root) {
   const cask = replaceOnce(
     updateVersion(originalCask, tag),
     /^  sha256 "[0-9a-f]{64}"$/gm,
-    () => `  sha256 "${checksums.get(assets[0])}"`,
+    () => `  sha256 "${checksums.get(caskAsset)}"`,
   );
-  let formula = updateVersion(originalFormula, tag);
-  for (const asset of assets.slice(1)) {
-    formula = replaceOnce(
-      formula,
-      new RegExp(`(url "[^"\\n]+/${asset}",\\n +using: :nounzip\\n +sha256 ")[0-9a-f]{64}"`, "g"),
-      (_, prefix) => `${prefix}${checksums.get(asset)}"`,
-    );
-  }
+  let formula = replaceOnce(
+    originalFormula,
+    /^  url "https:\/\/github\.com\/dantraynor\/tailchrome\/archive\/refs\/tags\/v([0-9]+\.[0-9]+\.[0-9]+)\.tar\.gz"$/gm,
+    (_, current) => {
+      checkUpgrade(current, tag);
+      return `  url "https://github.com/dantraynor/tailchrome/archive/refs/tags/${tag}.tar.gz"`;
+    },
+  );
+  formula = replaceOnce(formula, /^  sha256 "[0-9a-f]{64}"$/gm, () => `  sha256 "${sourceSha256}"`);
   await writeFile(caskPath, cask);
   await writeFile(formulaPath, formula);
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
   try {
-    const [tag, manifestPath, ...extra] = process.argv.slice(2);
-    if (!tag || !manifestPath || extra.length) {
-      throw new Error("Usage: node scripts/update-homebrew.mjs <vX.Y.Z> <SHA256SUMS.txt>");
+    const [tag, manifestPath, sourcePath, ...extra] = process.argv.slice(2);
+    if (!tag || !manifestPath || !sourcePath || extra.length) {
+      throw new Error("Usage: node scripts/update-homebrew.mjs <vX.Y.Z> <SHA256SUMS.txt> <source.tar.gz>");
     }
-    await updateHomebrew(tag, await readFile(manifestPath, "utf8"));
+    const sourceSha256 = createHash("sha256").update(await readFile(sourcePath)).digest("hex");
+    await updateHomebrew(tag, await readFile(manifestPath, "utf8"), sourceSha256);
     console.log(`Updated the Homebrew cask and formula to ${tag}`);
   } catch (error) {
     console.error(error.message);

--- a/scripts/update-homebrew.test.mjs
+++ b/scripts/update-homebrew.test.mjs
@@ -12,6 +12,7 @@ const assets = [
 ];
 const hashes = ["a".repeat(64), "b".repeat(64), "c".repeat(64)];
 const manifest = assets.map((asset, i) => `${hashes[i]}  ${asset}\n`).join("");
+const sourceHash = "d".repeat(64);
 
 async function fixture(t) {
   const directory = await mkdtemp(path.join(os.tmpdir(), "tailchrome-homebrew-"));
@@ -19,7 +20,9 @@ async function fixture(t) {
   for (const folder of ["Casks", "Formula"]) {
     await mkdir(path.join(directory, folder));
     const definition = await readFile(new URL(`../${folder}/tailchrome.rb`, import.meta.url), "utf8");
-    await writeFile(path.join(directory, folder, "tailchrome.rb"), definition.replace(/^  version ".*"$/m, '  version "0.1.13"'));
+    await writeFile(path.join(directory, folder, "tailchrome.rb"), definition
+      .replace(/^  version ".*"$/m, '  version "0.1.13"')
+      .replace(/\/tags\/v\d+\.\d+\.\d+\.tar\.gz/, "/tags/v0.1.13.tar.gz"));
   }
   return directory;
 }
@@ -28,32 +31,34 @@ async function definitions(directory) {
   return Promise.all(["Casks", "Formula"].map((folder) => readFile(path.join(directory, folder, "tailchrome.rb"), "utf8")));
 }
 
-test("updates both definitions with the correct platform hashes and is idempotent", async (t) => {
+test("pins the cask asset and source archive independently and is idempotent", async (t) => {
   const directory = await fixture(t);
-  await updateHomebrew("v0.1.14", manifest, directory);
+  await updateHomebrew("v0.1.14", manifest, sourceHash, directory);
   const updated = await definitions(directory);
-  for (const definition of updated) assert.match(definition, /version "0\.1\.14"/);
+  assert.match(updated[0], /version "0\.1\.14"/);
   assert.match(updated[0], new RegExp(`sha256 "${hashes[0]}"`));
-  for (let i = 1; i < assets.length; i++) {
-    assert.match(updated[1], new RegExp(`${assets[i]}",\\n +using: :nounzip\\n +sha256 "${hashes[i]}"`));
-  }
+  assert.match(updated[1], /archive\/refs\/tags\/v0\.1\.14\.tar\.gz/);
+  assert.match(updated[1], new RegExp(`sha256 "${sourceHash}"`));
+  assert.doesNotMatch(updated[1], /releases\/download|using: :nounzip/);
   assert.match(updated[0], /releases\/download\/v#\{version\}/);
-  await updateHomebrew("v0.1.14", manifest, directory);
+  await updateHomebrew("v0.1.14", manifest, sourceHash, directory);
   assert.deepEqual(await definitions(directory), updated);
 });
 
 test("compares version components numerically", async (t) => {
   const directory = await fixture(t);
-  await updateHomebrew("v0.2.0", manifest, directory);
-  await updateHomebrew("v0.10.0", manifest, directory);
-  for (const definition of await definitions(directory)) assert.match(definition, /version "0\.10\.0"/);
+  await updateHomebrew("v0.2.0", manifest, sourceHash, directory);
+  await updateHomebrew("v0.10.0", manifest, sourceHash, directory);
+  const updated = await definitions(directory);
+  assert.match(updated[0], /version "0\.10\.0"/);
+  assert.match(updated[1], /\/tags\/v0\.10\.0\.tar\.gz/);
 });
 
 test("rejects invalid tags and downgrades without changing either definition", async (t) => {
   const directory = await fixture(t);
   const original = await definitions(directory);
   for (const tag of ["latest", "0.1.14", "v0.1.14-beta.1", "v01.1.14", "v0.1.14\n", 'v0.1.14"', "v0.1.12", "v0.0.99"]) {
-    await assert.rejects(updateHomebrew(tag, manifest, directory));
+    await assert.rejects(updateHomebrew(tag, manifest, sourceHash, directory));
     assert.deepEqual(await definitions(directory), original);
   }
 });
@@ -67,9 +72,9 @@ test("rejects malformed, duplicate, and missing checksums before writing", async
     manifest.replace(hashes[0], "a".repeat(63)),
     manifest.replace(assets[0], `../${assets[0]}`),
     manifest + `${hashes[0]}  ${assets[0]}\n`,
-    manifest.replace(`${hashes[1]}  ${assets[1]}\n`, ""),
+    manifest.replace(`${hashes[0]}  ${assets[0]}\n`, ""),
   ]) {
-    await assert.rejects(updateHomebrew("v0.1.14", invalid, directory));
+    await assert.rejects(updateHomebrew("v0.1.14", invalid, sourceHash, directory));
     assert.deepEqual(await definitions(directory), original);
   }
 });
@@ -77,10 +82,34 @@ test("rejects malformed, duplicate, and missing checksums before writing", async
 test("refuses to partially update when a definition's expected structure changes", async (t) => {
   const directory = await fixture(t);
   const formulaPath = path.join(directory, "Formula/tailchrome.rb");
-  await writeFile(formulaPath, (await readFile(formulaPath, "utf8")).replace("linux-arm64", "linux-aarch64"));
+  await writeFile(formulaPath, (await readFile(formulaPath, "utf8")).replace("archive/refs/tags", "archive/refs/heads"));
   const original = await definitions(directory);
-  await assert.rejects(updateHomebrew("v0.1.14", manifest, directory), /Expected one match/);
+  await assert.rejects(updateHomebrew("v0.1.14", manifest, sourceHash, directory), /Expected one match/);
   assert.deepEqual(await definitions(directory), original);
+});
+
+test("refuses to downgrade a formula that is newer than the cask", async (t) => {
+  const directory = await fixture(t);
+  const formulaPath = path.join(directory, "Formula/tailchrome.rb");
+  await writeFile(formulaPath, (await readFile(formulaPath, "utf8")).replace("v0.1.13.tar.gz", "v0.2.0.tar.gz"));
+  const original = await definitions(directory);
+  await assert.rejects(updateHomebrew("v0.1.14", manifest, sourceHash, directory), /Refusing to downgrade/);
+  assert.deepEqual(await definitions(directory), original);
+});
+
+test("rejects invalid source archive checksums without writing either definition", async (t) => {
+  const directory = await fixture(t);
+  const original = await definitions(directory);
+  for (const invalid of [undefined, "", "not-a-checksum", "a".repeat(63), sourceHash + "\n"]) {
+    await assert.rejects(updateHomebrew("v0.1.14", manifest, invalid, directory), /source archive/);
+    assert.deepEqual(await definitions(directory), original);
+  }
+});
+
+test("source formula updates do not require raw binary release assets", async (t) => {
+  const directory = await fixture(t);
+  await updateHomebrew("v0.1.14", `${hashes[0]}  ${assets[0]}\n`, sourceHash, directory);
+  assert.match((await definitions(directory))[1], new RegExp(`sha256 "${sourceHash}"`));
 });
 
 test("accepts other final release assets and CRLF manifests", () => {

--- a/scripts/update-homebrew.test.mjs
+++ b/scripts/update-homebrew.test.mjs
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { parseChecksums, updateHomebrew } from "./update-homebrew.mjs";
+
+const assets = [
+  "tailchrome-helper-macos.pkg",
+  "tailscale-browser-ext-linux-arm64",
+  "tailscale-browser-ext-linux-amd64",
+];
+const hashes = ["a".repeat(64), "b".repeat(64), "c".repeat(64)];
+const manifest = assets.map((asset, i) => `${hashes[i]}  ${asset}\n`).join("");
+
+async function fixture(t) {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "tailchrome-homebrew-"));
+  t.after(() => rm(directory, { recursive: true, force: true }));
+  for (const folder of ["Casks", "Formula"]) {
+    await mkdir(path.join(directory, folder));
+    const definition = await readFile(new URL(`../${folder}/tailchrome.rb`, import.meta.url), "utf8");
+    await writeFile(path.join(directory, folder, "tailchrome.rb"), definition.replace(/^  version ".*"$/m, '  version "0.1.13"'));
+  }
+  return directory;
+}
+
+async function definitions(directory) {
+  return Promise.all(["Casks", "Formula"].map((folder) => readFile(path.join(directory, folder, "tailchrome.rb"), "utf8")));
+}
+
+test("updates both definitions with the correct platform hashes and is idempotent", async (t) => {
+  const directory = await fixture(t);
+  await updateHomebrew("v0.1.14", manifest, directory);
+  const updated = await definitions(directory);
+  for (const definition of updated) assert.match(definition, /version "0\.1\.14"/);
+  assert.match(updated[0], new RegExp(`sha256 "${hashes[0]}"`));
+  for (let i = 1; i < assets.length; i++) {
+    assert.match(updated[1], new RegExp(`${assets[i]}",\\n +using: :nounzip\\n +sha256 "${hashes[i]}"`));
+  }
+  assert.match(updated[0], /releases\/download\/v#\{version\}/);
+  await updateHomebrew("v0.1.14", manifest, directory);
+  assert.deepEqual(await definitions(directory), updated);
+});
+
+test("compares version components numerically", async (t) => {
+  const directory = await fixture(t);
+  await updateHomebrew("v0.2.0", manifest, directory);
+  await updateHomebrew("v0.10.0", manifest, directory);
+  for (const definition of await definitions(directory)) assert.match(definition, /version "0\.10\.0"/);
+});
+
+test("rejects invalid tags and downgrades without changing either definition", async (t) => {
+  const directory = await fixture(t);
+  const original = await definitions(directory);
+  for (const tag of ["latest", "0.1.14", "v0.1.14-beta.1", "v01.1.14", "v0.1.14\n", 'v0.1.14"', "v0.1.12", "v0.0.99"]) {
+    await assert.rejects(updateHomebrew(tag, manifest, directory));
+    assert.deepEqual(await definitions(directory), original);
+  }
+});
+
+test("rejects malformed, duplicate, and missing checksums before writing", async (t) => {
+  const directory = await fixture(t);
+  const original = await definitions(directory);
+  for (const invalid of [
+    "",
+    manifest.replace(hashes[0], "not-a-checksum"),
+    manifest.replace(hashes[0], "a".repeat(63)),
+    manifest.replace(assets[0], `../${assets[0]}`),
+    manifest + `${hashes[0]}  ${assets[0]}\n`,
+    manifest.replace(`${hashes[1]}  ${assets[1]}\n`, ""),
+  ]) {
+    await assert.rejects(updateHomebrew("v0.1.14", invalid, directory));
+    assert.deepEqual(await definitions(directory), original);
+  }
+});
+
+test("refuses to partially update when a definition's expected structure changes", async (t) => {
+  const directory = await fixture(t);
+  const formulaPath = path.join(directory, "Formula/tailchrome.rb");
+  await writeFile(formulaPath, (await readFile(formulaPath, "utf8")).replace("linux-arm64", "linux-aarch64"));
+  const original = await definitions(directory);
+  await assert.rejects(updateHomebrew("v0.1.14", manifest, directory), /Expected one match/);
+  assert.deepEqual(await definitions(directory), original);
+});
+
+test("accepts other final release assets and CRLF manifests", () => {
+  const checksums = parseChecksums((manifest + `${"d".repeat(64)}  chrome.zip\n`).replaceAll("\n", "\r\n"));
+  assert.equal(checksums.get(assets[1]), hashes[1]);
+  assert.equal(checksums.get("chrome.zip"), "d".repeat(64));
+});


### PR DESCRIPTION
## What

Add a Homebrew tap with a signed macOS cask and a formula that builds the pinned v0.1.13 source release on macOS and Linux using Go.
Add release-update PR automation with a patch fallback, separate package/source checksum validation, updater tests, platform CI, and installation and release-maintenance docs.
Update fast-uri to patched 3.1.7 to clear the high-severity dependency audit before publication.

## Why

Closes #115

## How to Test

- [x] `pnpm typecheck`, `pnpm test`, `pnpm test:installer`, `pnpm test:homebrew`, Go race tests and vet
- [x] Homebrew style; `brew audit --new --strict --online` in a local homebrew/core checkout; Linux source install → `brew test` → uninstall with all dependencies
- [x] actionlint v1.7.12 with ShellCheck 0.11.0 and `git diff --check`
- [x] All PR CI checks, including source formula builds, registration and removal on macOS and Linux
- [x] Automatic update PR creation enabled in repository Actions settings
- [x] `pnpm audit --audit-level high` and `pnpm review:firefox` with fast-uri 3.1.7
- [ ] macOS cask install/upgrade/uninstall and browser discovery using [the Homebrew instructions](packaging/homebrew/README.md)

## Checklist

- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [x] Updated README if needed

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/ddfe44d0-4193-44a2-8f1c-f80008742270)
