### PR TITLE
Prepare SignPath application and update fast-uri

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,20 @@ and packaging. Windows publication is additionally gated by the
 [Windows code-signing policy](docs/WINDOWS_CODE_SIGNING_POLICY.md) and the
 [release security checklist](docs/RELEASE_CHECKLIST.md).
 
+## Code signing policy
+
+Tailchrome is applying to SignPath Foundation for Windows Authenticode signing.
+Until the application is accepted and the release workflow produces a verified
+test signature, Windows release notes continue to identify those artifacts as
+unsigned. The public [Windows code-signing
+policy](docs/WINDOWS_CODE_SIGNING_POLICY.md) defines who may submit and approve
+signing requests, which builds are eligible, how signatures are verified, and
+how a compromised or replaced publisher identity is handled.
+
+For releases signed through the SignPath Foundation program:
+
+> Free code signing provided by SignPath.io, certificate by SignPath Foundation
+
 ## Development
 
 ```

--- a/docs/WINDOWS_CODE_SIGNING_POLICY.md
+++ b/docs/WINDOWS_CODE_SIGNING_POLICY.md
@@ -22,12 +22,13 @@ SmartScreen unknown-publisher warning. The variable must be removed as soon as
 a signing provider and expected signer subject are recorded, at which point the
 fail-closed signed gate below is the only release path again.
 
-SignPath Foundation and Azure Artifact Signing Individual are the evaluated
-onboarding paths. SignPath is preferred if the Foundation application is
-accepted and its trusted-build flow succeeds. Otherwise, Azure may be selected
-after Individual identity validation and a successful OIDC-backed test
-signature. Exactly one integration and one expected signer subject must be
-recorded here before this change can merge.
+The project is applying to SignPath Foundation. SignPath becomes the selected
+production provider only after the Foundation accepts the application and its
+trusted-build flow produces a successful test signature. Azure Artifact Signing
+Individual remains the evaluated alternative if SignPath does not accept the
+project. Azure may be selected only after Individual identity validation and a
+successful OIDC-backed test signature. Exactly one integration and one expected
+signer subject must be recorded here before signed publication is enabled.
 
 If SignPath supplies the production signature, the project home and download
 surfaces must include this acknowledgement:
@@ -54,16 +55,20 @@ The signed Windows release consists of:
 
 ## Roles
 
-- **Maintainer:** approves policy changes, provider selection, publisher
-  migrations, and releases.
-- **Developer:** prepares reviewed source changes but cannot approve their own
-  release solely by authoring them.
-- **Signing submitter:** submits only artifacts produced by the reviewed,
-  GitHub-hosted release workflow.
-- **Signing approver:** reviews the source revision and signing request before
-  the provider releases a signature.
-- **Release reviewer:** compares Defender and Malwarebytes results with the
-  exact candidate hashes and approves the protected publication environment.
+- **Maintainer, author, committer, and reviewer:** [Daniel Traynor
+  (`dantraynor`)](https://github.com/dantraynor) approves policy changes,
+  provider selection, publisher migrations, and releases. Changes proposed by
+  other contributors require his review before merge.
+- **Developer:** a contributor may prepare source changes but cannot approve a
+  signing request solely by authoring those changes.
+- **Signing submitter and approver:** [Daniel Traynor
+  (`dantraynor`)](https://github.com/dantraynor) submits only artifacts produced
+  by the reviewed, GitHub-hosted release workflow and explicitly reviews each
+  source revision and signing request before the provider releases a signature.
+- **Release reviewer:** [Daniel Traynor
+  (`dantraynor`)](https://github.com/dantraynor) compares Defender and
+  Malwarebytes results with the exact candidate hashes and approves the
+  protected publication environment.
 
 One person may hold more than one role for a small project, but the workflow's
 provider approval and protected publication approval must remain explicit.

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
       "postcss": "^8.5.23",
       "ws": "^8.20.1",
       "tmp": "^0.2.6",
-      "fast-uri": "^3.1.5",
+      "fast-uri": "^3.1.6",
       "defu": "^6.1.5",
       "brace-expansion@1": "^1.1.18",
       "brace-expansion@5": "^5.0.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
   postcss: ^8.5.23
   ws: ^8.20.1
   tmp: ^0.2.6
-  fast-uri: ^3.1.5
+  fast-uri: ^3.1.6
   defu: ^6.1.5
   brace-expansion@1: ^1.1.18
   brace-expansion@5: ^5.0.9
@@ -1172,8 +1172,8 @@ packages:
     resolution: {integrity: sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==}
     engines: {node: '>=6'}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.7:
+    resolution: {integrity: sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -2931,7 +2931,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.7
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -3435,7 +3435,7 @@ snapshots:
 
   fast-redact@3.5.0: {}
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.7: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:


### PR DESCRIPTION
## Summary

- add the required SignPath Foundation acknowledgement to the public project page
- name the maintainer, reviewer, signing submitter, approver, and release reviewer
- record SignPath as the active application path while retaining Azure as the fallback
- keep Windows artifacts explicitly unsigned until acceptance and a verified test signature
- update the fast-uri override from 3.1.5 to a patched 3.1.7 resolution

## Validation

- pnpm audit --audit-level high
- pnpm validate:ids
- pnpm typecheck
- pnpm test
- pnpm test:installer
- git diff --check