### PR TITLE
docs: link Tailscale privacy policy

### DIFF
--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,6 +1,6 @@
 # Tailchrome Privacy Policy
 
-Last updated: 2026-07-26
+Last updated: 2026-09-08
 
 ## Summary
 
@@ -39,6 +39,9 @@ Tailchrome sends this data only to:
 - the local native helper on the same machine,
 - the user's tailnet and configured coordination plane (Tailscale by default), and
 - the sites or services the user chooses to access through Tailchrome.
+
+For information about how Tailscale handles data, see the
+[Tailscale Privacy Policy](https://tailscale.com/privacy-policy).
 
 ## Data Tailchrome Does Not Collect
 


### PR DESCRIPTION
## What

Adds a direct link to the Tailscale privacy policy and updates the Tailchrome policy revision date.

## Why

Makes the relevant third-party privacy information easier to find.

## How to Test

- [x ] Open `docs/privacy-policy.md` and confirm the Tailscale Privacy Policy link resolves correctly

## Checklist

- [x] Updated README if needed

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/16e91464-1b90-4045-8e97-0ba826aecbc6)
