### PR TITLE
Make no-admin helper installation easier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,9 +268,10 @@ jobs:
           bash -n \
             packaging/macos/TailchromeHelper.app/Contents/MacOS/tailchrome-helper \
             packaging/macos/build-pkg.sh \
+            packaging/macos/test-user-app.sh \
             packaging/macos/scripts/postinstall
           test -x packaging/macos/TailchromeHelper.app/Contents/MacOS/tailchrome-helper
-      - name: Build and inspect unsigned package
+      - name: Build and inspect unsigned installers
         run: |
           set -euo pipefail
           VERSION=0.0.0 ./packaging/macos/build-pkg.sh
@@ -280,6 +281,7 @@ jobs:
           test -f "$app/Contents/Info.plist"
           test -x "$app/Contents/MacOS/tailchrome-helper"
           test -x "$expanded/Payload/Library/Application Support/Tailscale/BrowserExt/tailscale-browser-ext"
+          ./packaging/macos/test-user-app.sh
 
   windows-signature-verifier:
     needs: changes
@@ -340,4 +342,5 @@ jobs:
             scripts/install.test.sh \
             packaging/linux/build-packages.sh \
             packaging/macos/build-pkg.sh \
+            packaging/macos/test-user-app.sh \
             packaging/macos/scripts/postinstall

--- a/.github/workflows/publish-helper-release.yml
+++ b/.github/workflows/publish-helper-release.yml
@@ -165,6 +165,7 @@ jobs:
           firefox.zip
           tailchrome-helper-linux-amd64.deb
           tailchrome-helper-linux-x86_64.rpm
+          tailchrome-helper-macos-user.zip
           tailchrome-helper-macos.pkg
           tailchrome-helper-windows-x64.msi
           tailchrome-install.sh
@@ -423,6 +424,14 @@ jobs:
           test -x "$app/Contents/MacOS/tailchrome-helper"
           codesign --verify --deep --strict --verbose=2 "$app"
           spctl --assess --type execute --verbose=2 "$app"
+          ditto -x -k candidate/release/tailchrome-helper-macos-user.zip "$RUNNER_TEMP/tailchrome-user"
+          user_app="$RUNNER_TEMP/tailchrome-user/Tailchrome Helper.app"
+          test -x "$user_app/Contents/MacOS/tailscale-browser-ext"
+          test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$user_app/Contents/Info.plist")" = \
+            org.tesseras.tailchrome.helper.user
+          codesign --verify --deep --strict --verbose=2 "$user_app"
+          xcrun stapler validate "$user_app"
+          spctl --assess --type execute --verbose=2 "$user_app"
 
   windows-release-clearance:
     needs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,13 +237,13 @@ jobs:
             -k "$keychain_password" \
             "$keychain_path"
           security list-keychains -d user -s "$keychain_path" login.keychain-db
-      - name: Build signed macOS package
+      - name: Build signed macOS installers
         env:
           VERSION: ${{ env.RELEASE_TAG }}
           MACOS_SIGN_APPLICATION_IDENTITY: "Developer ID Application: Daniel David Traynor (UL9B796XFN)"
           MACOS_SIGN_INSTALLER_IDENTITY: "Developer ID Installer: Daniel David Traynor (UL9B796XFN)"
         run: ./packaging/macos/build-pkg.sh
-      - name: Notarize and staple macOS package
+      - name: Notarize and staple macOS installers
         env:
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
@@ -258,7 +258,15 @@ jobs:
             --issuer "$APPLE_API_ISSUER_ID" \
             --wait
           xcrun stapler staple dist/tailchrome-helper-macos.pkg
-      - name: Verify final package and embedded repair app
+          xcrun notarytool submit dist/tailchrome-helper-macos-user.zip \
+            --key "$key_path" \
+            --key-id "$APPLE_API_KEY_ID" \
+            --issuer "$APPLE_API_ISSUER_ID" \
+            --wait
+          xcrun stapler staple "dist/Tailchrome Helper.app"
+          rm dist/tailchrome-helper-macos-user.zip
+          ditto -c -k --keepParent "dist/Tailchrome Helper.app" dist/tailchrome-helper-macos-user.zip
+      - name: Verify final macOS installers
         run: |
           set -euo pipefail
           pkg="dist/tailchrome-helper-macos.pkg"
@@ -270,12 +278,20 @@ jobs:
           test -x "$app/Contents/MacOS/tailchrome-helper"
           codesign --verify --deep --strict --verbose=2 "$app"
           spctl --assess --type execute --verbose=2 "$app"
-      - name: Upload final macOS package
+          ./packaging/macos/test-user-app.sh dist/tailchrome-helper-macos-user.zip "$RELEASE_TAG"
+          ditto -x -k dist/tailchrome-helper-macos-user.zip "$RUNNER_TEMP/tailchrome-user"
+          user_app="$RUNNER_TEMP/tailchrome-user/Tailchrome Helper.app"
+          codesign --verify --deep --strict --verbose=2 "$user_app"
+          xcrun stapler validate "$user_app"
+          spctl --assess --type execute --verbose=2 "$user_app"
+      - name: Upload final macOS installers
         uses: actions/upload-artifact@v6
         with:
           name: signed-macos-package
           retention-days: 7
-          path: dist/tailchrome-helper-macos.pkg
+          path: |
+            dist/tailchrome-helper-macos.pkg
+            dist/tailchrome-helper-macos-user.zip
 
   package-linux:
     needs: build
@@ -1258,6 +1274,7 @@ jobs:
           cp signed-darwin/tailscale-browser-ext-darwin-amd64 candidate/release/
           cp signed-darwin/tailscale-browser-ext-darwin-arm64 candidate/release/
           cp signed-macos-package/tailchrome-helper-macos.pkg candidate/release/
+          cp signed-macos-package/tailchrome-helper-macos-user.zip candidate/release/
           cp build-output/dist/tailscale-browser-ext-linux-amd64 candidate/release/
           cp build-output/dist/tailscale-browser-ext-linux-arm64 candidate/release/
           cp linux-packages/tailchrome-helper-linux-amd64.deb candidate/release/
@@ -1304,6 +1321,7 @@ jobs:
           firefox.zip
           tailchrome-helper-linux-amd64.deb
           tailchrome-helper-linux-x86_64.rpm
+          tailchrome-helper-macos-user.zip
           tailchrome-helper-macos.pkg
           tailchrome-helper-windows-x64.msi
           tailchrome-install.sh

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ host-all:
 	cd host && GOOS=linux   GOARCH=arm64 CGO_ENABLED=0 go build $(LDFLAGS) -o ../dist/tailscale-browser-ext-linux-arm64 .
 	cd host && GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build $(LDFLAGS) -o ../dist/tailscale-browser-ext-windows-amd64.exe .
 
-# macOS only: universal .pkg installer (requires lipo, pkgbuild)
+# macOS only: universal system package and per-user app (requires Xcode tools)
 macos-pkg:
 	./packaging/macos/build-pkg.sh
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The same UI renders in either surface.
 ## Install
 
 1. Get the extension from the [Chrome Web Store](https://chromewebstore.google.com/detail/tailchrome/bhfeceecialgilpedkoflminjgcjljll) (also installs in Brave, Edge, Vivaldi, Opera, and — on macOS — Arc) or [Firefox Add-ons](https://addons.mozilla.org/en-US/firefox/addon/tailchrome/)
-2. Install the native helper with [Homebrew](#homebrew-macos-and-linux) on macOS/Linux, or from the [latest release](https://github.com/dantraynor/tailchrome/releases/latest) — **`tailchrome-helper-macos.pkg`** on macOS, **`tailchrome-helper-windows-x64.msi`** on Windows, or the **`.deb`/`.rpm`** package on Linux amd64. Linux ARM64 and per-user repair flows can also use the release's checksum-verifying **`tailchrome-install.sh`**.
+2. Install the native helper with [Homebrew](#homebrew-macos-and-linux) on macOS/Linux, or from the [latest release](https://github.com/dantraynor/tailchrome/releases/latest) — **`tailchrome-helper-macos-user.zip`** on macOS, **`tailchrome-helper-windows-x64.msi`** on Windows, or the verified **`tailchrome-install.sh`** on Linux. These install for your account without administrator access. System packages are also available on macOS and Linux amd64.
 3. Log in to your Tailscale account
 
 ### Homebrew (macOS and Linux)
@@ -75,9 +75,13 @@ and removal. The browser extension is installed separately.
 
 ### Platform installers
 
-The platform release package is the primary installation path. The macOS
-installer is platform-signed. A Windows installer is release-quality only when
-the raw helper, embedded helper, and outer MSI pass the
+On macOS, open the downloaded ZIP and launch **Tailchrome Helper**. The app
+contains the helper and registers it for your account. The app and system
+package are signed and notarized. Organization browser policies can still
+block extensions or native messaging.
+
+A Windows installer is release-quality only when the raw helper, embedded
+helper, and outer MSI pass the
 [Windows code-signing policy](docs/WINDOWS_CODE_SIGNING_POLICY.md); older
 releases may predate that gate. Linux packages are covered by the release
 checksum and build-provenance attestation. If Tailchrome still cannot discover

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -83,12 +83,12 @@ Include your browser, OS, extension version, and steps to reproduce.
 
 - PRs run extension tests, Chrome checks, the full Firefox review gate, Go
   tests on Linux and Windows, fallback-installer tests, a macOS package smoke
-  build, Windows signature-verifier fixtures, and Linux package metadata
-  checks.
+  build with per-user launcher tests, Windows signature-verifier fixtures, and
+  Linux package metadata checks.
 - A helper release first produces one immutable candidate artifact containing
   the extension archives, signed macOS/Windows helpers and installers, existing
   verified amd64/x86_64 Linux packages, Linux amd64/arm64 raw helpers, the fallback
-  installer, final checksums, and signature summaries.
+  installer, per-user macOS app, final checksums, and signature summaries.
 - Publication is a separate protected workflow. It accepts the original
   candidate run ID, release tag, and checksum-manifest digest; downloads those
   exact bytes; repeats structural and signature checks; and waits for

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -615,26 +615,26 @@ does not participate in routing.
 **Chrome:**
 
 1. Install from the [Chrome Web Store](https://chromewebstore.google.com/detail/tailchrome/bhfeceecialgilpedkoflminjgcjljll)
-2. Install the native helper from [GitHub Releases](https://github.com/dantraynor/tailchrome/releases/latest): **`tailchrome-helper-macos.pkg`** on macOS, **`tailchrome-helper-windows-x64.msi`** on Windows, or the **`.deb`/`.rpm`** package on Linux amd64. Linux ARM64 uses the version-pinned verified repair installer.
+2. Install the native helper from [GitHub Releases](https://github.com/dantraynor/tailchrome/releases/latest): **`tailchrome-helper-macos-user.zip`** on macOS, **`tailchrome-helper-windows-x64.msi`** on Windows, or the verified **`tailchrome-install.sh`** on Linux. These install for your account without administrator access.
 3. Log in to your Tailscale account
 
 **Firefox:**
 
 1. Install from [Firefox Add-ons](https://addons.mozilla.org/en-US/firefox/addon/tailchrome/) or the matching [GitHub Release](https://github.com/dantraynor/tailchrome/releases/latest)
-2. Install the same native helper used for Chrome: **`.pkg`** on macOS, **`.msi`** on Windows, **`.deb`/`.rpm`** on Linux amd64, or the verified raw-helper installer on Linux ARM64.
+2. Install the same native helper used for Chrome: the helper app on macOS, **`.msi`** on Windows, or the verified per-user installer on Linux.
 3. Log in to your Tailscale account
 
 ### Native Host Installation
 
-The installer packages are the primary path:
+The popup offers installation for your account. macOS and Linux amd64 also have system packages:
 
-- **macOS:** `tailchrome-helper-macos.pkg` installs a universal binary and runs `tailscale-browser-ext -install-now` for the logged-in user during package postinstall. `Tailchrome Helper.app` remains in `/Applications` as a repair/re-run fallback.
+- **macOS:** open `tailchrome-helper-macos-user.zip`, then open the included **Tailchrome Helper** app to install for your account. The signed app includes a universal helper. For a system installation, `tailchrome-helper-macos.pkg` installs a universal binary and runs `tailscale-browser-ext -install-now` for the logged-in user during package postinstall. `Tailchrome Helper.app` remains in `/Applications` as a repair/re-run fallback.
 - **Windows:** the Authenticode-signed `tailchrome-helper-windows-x64.msi` embeds the identically signed raw EXE, installs a staged helper under `%LOCALAPPDATA%\Tailscale\BrowserExt\installer\`, and runs it with `-install-now`, which writes HKCU native messaging registrations. Windows ARM64 uses this package through x64 emulation. After downloading the MSI, repair from either Command Prompt or PowerShell with `powershell.exe -NoProfile -Command "msiexec.exe /fa (Join-Path ([Environment]::GetFolderPath('UserProfile')) 'Downloads\tailchrome-helper-windows-x64.msi')"`; uninstall through **Installed apps**.
 - **Linux amd64:** `.deb` and `.rpm` packages install `/usr/lib/tailchrome/tailscale-browser-ext` plus system-wide manifests for Chrome, Chromium, Edge, and Firefox. They do not write per-user state in package hooks.
-- **Linux ARM64:** download `tailchrome-install.sh` from the exact versioned release, inspect it, download `SHA256SUMS.txt`, and run `bash ~/Downloads/tailchrome-install.sh --version "vX.Y.Z"`. The script selects and verifies `tailscale-browser-ext-linux-arm64`, optionally verifies its GitHub attestation when `gh` is available and authenticated, invokes `-install-now`, and confirms the installed executable. Never pipe a remote script directly into a shell.
+- **Linux per-user (amd64/ARM64):** download `tailchrome-install.sh` from the exact versioned release, inspect it, download `SHA256SUMS.txt`, and run `bash ~/Downloads/tailchrome-install.sh --version "vX.Y.Z"`. The script selects and verifies the matching raw helper, optionally verifies its GitHub attestation when `gh` is available and authenticated, invokes `-install-now`, and confirms the installed executable. Never pipe a remote script directly into a shell.
 
-On macOS and Linux, the same version-pinned script is the advanced
-current-user repair path after package discovery fails. It selects the exact
+On macOS and Linux, the same version-pinned script also repairs current-user
+registration after package discovery fails. It selects the exact
 amd64/arm64 artifact for the machine. The raw native host binary remains
 available for advanced/manual installs. When run interactively in a terminal,
 or non-interactively via **`tailscale-browser-ext -install-now`**, it:

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -50,6 +50,7 @@ not apply.
   - `tailscale-browser-ext-darwin-amd64`
   - `tailscale-browser-ext-darwin-arm64`
   - `tailchrome-helper-macos.pkg`
+  - `tailchrome-helper-macos-user.zip`
   - `tailscale-browser-ext-linux-amd64`
   - `tailscale-browser-ext-linux-arm64`
   - `tailchrome-helper-linux-amd64.deb`
@@ -61,7 +62,7 @@ not apply.
 
 - [ ] Artifact attestations exist for the same final files.
 - [ ] The macOS raw helpers and repair app pass `codesign --verify --deep --strict` and Gatekeeper assessment.
-- [ ] The macOS package passes signature and stapling validation.
+- [ ] The macOS package and extracted per-user app pass signature and stapling validation.
 - [ ] The Linux raw helpers report the intended amd64 and arm64 architectures.
 - [ ] The DEB and RPM contain only their declared system paths and no per-user install hook.
 - [ ] The raw Windows EXE has one valid SHA-256 Authenticode signature, a timestamp, and the exact expected subject.

--- a/docs/firefox-smoke-test.md
+++ b/docs/firefox-smoke-test.md
@@ -6,7 +6,7 @@ Run the full checklist on:
 
 | OS | Architecture | Firefox | Helper installer |
 | --- | --- | --- | --- |
-| macOS 14+ | Intel and Apple Silicon | 140+ stable | `tailchrome-helper-macos.pkg` |
+| macOS 14+ | Intel and Apple Silicon | 140+ stable | `tailchrome-helper-macos.pkg` and `tailchrome-helper-macos-user.zip` |
 | Windows 11 | x64 | 140+ stable | `tailchrome-helper-windows-x64.msi` |
 | Ubuntu 24.04+ | amd64 | 140+ stable | `tailchrome-helper-linux-amd64.deb` |
 | Ubuntu 24.04+ | arm64 | 140+ stable | verified `tailscale-browser-ext-linux-arm64` fallback |

--- a/packages/shared/src/popup/views/install-helpers.test.ts
+++ b/packages/shared/src/popup/views/install-helpers.test.ts
@@ -256,6 +256,52 @@ describe("renderInstallFlow", () => {
     expect(root.textContent).toContain("sudo dnf install");
   });
 
+  it("offers a visible per-user Linux amd64 installer before system packages", async () => {
+    chrome.runtime.getPlatformInfo = vi.fn().mockResolvedValue({
+      os: "linux", arch: "x86-64",
+    }) as typeof chrome.runtime.getPlatformInfo;
+    const root = document.createElement("div");
+    await renderInstallFlow(root, {
+      mode: "install", state: baseState({ hostConnected: false }),
+    });
+
+    const section = root.querySelector<HTMLElement>(".install-advanced-section")!;
+    expect(section.classList.contains("hidden")).toBe(false);
+    expect(section.textContent).toContain("Install for this user — no administrator access required");
+    expect(section.textContent).toContain("sha256sum --check");
+    expect(section.textContent).toContain("tailscale-browser-ext-linux-amd64");
+    expect(root.querySelector(".install-advanced-toggle")).toBeNull();
+    expect(root.textContent!.indexOf("Install for this user")).toBeLessThan(
+      root.textContent!.indexOf("Or install for all users"),
+    );
+    section.querySelector<HTMLAnchorElement>("a")!.click();
+    expect(sendMessage).toHaveBeenCalledWith({ type: "retry-native-host", source: "fallback" });
+  });
+
+  it.each(["x86-64", "arm64"])("offers the per-user macOS app on %s before the system package", async (arch) => {
+    chrome.runtime.getPlatformInfo = vi.fn().mockResolvedValue({
+      os: "mac", arch,
+    }) as typeof chrome.runtime.getPlatformInfo;
+    const root = document.createElement("div");
+    await renderInstallFlow(root, {
+      mode: "install", state: baseState({ hostConnected: false }),
+    });
+
+    const link = root.querySelector<HTMLAnchorElement>(".install-per-user a")!;
+    expect(link.href).toBe("https://github.com/dantraynor/tailchrome/releases/download/v0.1.13/tailchrome-helper-macos-user.zip");
+    expect(link.closest(".hidden")).toBeNull();
+    expect(root.textContent).toContain("Install for this user — no administrator access required");
+    expect(root.textContent).toContain("Open the downloaded ZIP");
+    expect(root.textContent).toContain("browser policy may still block");
+    expect(root.querySelector('a[href$="/tailchrome-helper-macos.pkg"]')).not.toBeNull();
+    expect(root.textContent!.indexOf("Install for this user")).toBeLessThan(
+      root.textContent!.indexOf("Or install for all users"),
+    );
+    link.click();
+    expect(sendMessage).toHaveBeenCalledWith({ type: "retry-native-host", source: "package" });
+    expect(chrome.tabs.create).toHaveBeenCalledWith({ url: link.href });
+  });
+
   it.each(["arm64", "aarch64"])(
     "uses the verified Linux ARM64 path for runtime arch %s",
     async (arch) => {
@@ -278,6 +324,7 @@ describe("renderInstallFlow", () => {
         "https://github.com/dantraynor/tailchrome/releases/download/v0.1.13/tailchrome-install.sh",
       ]);
       expect(root.textContent).toContain("Linux ARM64");
+      expect(root.textContent).toContain("Install for this user — no administrator access required");
       expect(root.textContent).toContain("tailscale-browser-ext-linux-arm64");
       expect(root.textContent).not.toContain("sudo apt install");
       expect(root.textContent).not.toContain("sudo dnf install");
@@ -451,6 +498,7 @@ describe("renderInstallFlow", () => {
     });
 
     expect(root.textContent).toContain("x64 emulation");
+    expect(root.textContent).toContain("Install for this user — no administrator access required");
   });
 
   it("falls back to release information on unsupported Windows architectures", async () => {
@@ -513,6 +561,8 @@ describe("renderInstallFlow", () => {
       expect(root.textContent).not.toContain("complete the installer");
       expect(root.textContent).not.toContain("retry automatically");
       expect(root.querySelector(".install-advanced-toggle")).toBeNull();
+      expect(root.querySelector(".install-per-user")).toBeNull();
+      expect(root.textContent).not.toContain("no administrator access required");
     },
   );
 

--- a/packages/shared/src/popup/views/install-helpers.ts
+++ b/packages/shared/src/popup/views/install-helpers.ts
@@ -301,6 +301,20 @@ export async function renderInstallFlow(
     );
   }
 
+  if (platform === "macos" && !unsupported) {
+    content.appendChild(createPerUserMacInstall());
+  } else if (platform === "linux" && architecture === "amd64" && !repairProminent) {
+    content.appendChild(createVerifiedRepairFallback(platform, architecture, true, true));
+  }
+
+  if (!unsupported) {
+    const policy = document.createElement("p");
+    policy.className = "install-step-hint";
+    policy.textContent =
+      "Your organization’s browser policy may still block extensions or native messaging.";
+    content.appendChild(policy);
+  }
+
   const steps = document.createElement("div");
   steps.className = "install-steps";
   const showPackageInstall =
@@ -313,7 +327,9 @@ export async function renderInstallFlow(
       ? "Or reinstall the release package"
       : unsupported
         ? "Open release information"
-        : "Download the helper installer";
+        : platform === "macos" || (platform === "linux" && architecture === "amd64")
+          ? "Or install for all users (administrator access required)"
+          : "Install for this user — no administrator access required";
 
     const cta = document.createElement("div");
     cta.className = "install-pkg-cta";
@@ -360,7 +376,7 @@ export async function renderInstallFlow(
   if (
     !repairProminent &&
     repairActionAvailable &&
-    !(platform === "linux" && architecture === "arm64")
+    platform === "windows"
   ) {
     content.appendChild(
       createVerifiedRepairFallback(platform, architecture, false),
@@ -374,6 +390,27 @@ export async function renderInstallFlow(
   view.appendChild(content);
   renderUiSurfaceFooter(view);
   root.appendChild(view);
+}
+
+function createPerUserMacInstall(): HTMLElement {
+  const section = document.createElement("div");
+  section.className = "install-per-user install-advanced-section";
+  const heading = document.createElement("strong");
+  heading.textContent = "Install for this user — no administrator access required";
+  const body = document.createElement("p");
+  body.className = "install-step-body";
+  body.textContent =
+    "Open the downloaded ZIP, then open Tailchrome Helper. It installs and registers the helper for your account.";
+  section.append(
+    heading,
+    createDownloadButton({
+      filename: "tailchrome-helper-macos-user.zip",
+      label: "Download macOS helper app (.zip)",
+      url: releaseAssetURL("tailchrome-helper-macos-user.zip"),
+    }, "package"),
+    body,
+  );
+  return section;
 }
 
 function createDownloadButton(
@@ -444,7 +481,7 @@ function createInstallInstructions(
     strong.textContent = filename ?? "the downloaded installer";
     body.appendChild(strong);
     body.appendChild(
-      document.createTextNode(" in your Downloads folder and double-click it."),
+      document.createTextNode(" in your Downloads folder and double-click it. It installs for your account."),
     );
     if (architecture === "arm64") {
       body.appendChild(
@@ -554,6 +591,7 @@ function createVerifiedRepairFallback(
   platform: Platform,
   architecture: InstallerArchitecture,
   prominent: boolean,
+  installForUser = false,
 ): HTMLElement {
   const container = document.createElement("div");
 
@@ -568,7 +606,7 @@ function createVerifiedRepairFallback(
     const explanation = document.createElement("p");
     explanation.className = "install-step-body";
     explanation.textContent =
-      "Open /Applications/Tailchrome Helper.app to restore current-user registration, then retry discovery.";
+      "Open Tailchrome Helper where you saved it. For a package install, open /Applications/Tailchrome Helper.app. Then retry discovery.";
     advancedSection.append(heading, explanation);
     advancedSection.appendChild(
       createCodeBlock('open "/Applications/Tailchrome Helper.app"'),
@@ -596,7 +634,7 @@ function createVerifiedRepairFallback(
   download.textContent =
     platform === "windows"
       ? "Download signed installer for repair"
-      : "Download repair installer";
+      : installForUser ? "Download verified per-user installer" : "Download repair installer";
   download.addEventListener("click", (e) => {
     e.preventDefault();
     requestNativeHostRetries("fallback");
@@ -604,7 +642,9 @@ function createVerifiedRepairFallback(
   });
 
   const heading = document.createElement("strong");
-  heading.textContent = "Verify, inspect, then run";
+  heading.textContent = installForUser
+    ? "Install for this user — no administrator access required"
+    : "Verify, inspect, then run";
   advancedSection.appendChild(heading);
   advancedSection.appendChild(download);
 
@@ -614,7 +654,9 @@ function createVerifiedRepairFallback(
       const explanation = document.createElement("p");
       explanation.className = "install-step-body";
       explanation.textContent =
-        `The pinned installer downloads and verifies ${expectedAsset}, then restores current-user registration.`;
+        installForUser
+          ? `Verify and inspect the script, then run it to install ${expectedAsset} for your account.`
+          : `The pinned installer downloads and verifies ${expectedAsset}, then restores current-user registration.`;
       advancedSection.appendChild(explanation);
     }
     appendRepairScriptVerification(

--- a/packaging/linux/README.md
+++ b/packaging/linux/README.md
@@ -11,8 +11,7 @@ must also be run after upgrades.
 - `dist/tailchrome-helper-linux-amd64.deb`
 - `dist/tailchrome-helper-linux-x86_64.rpm`
 
-These amd64 packages are the primary installation method on compatible Linux
-systems. They install the helper binary at
+These amd64 packages require administrator access. They install the helper binary at
 `/usr/lib/tailchrome/tailscale-browser-ext` and system-wide native-messaging
 manifests for:
 
@@ -27,13 +26,12 @@ directory, so removing the package removes everything it owns.
 
 ARM64 `.deb` and `.rpm` packages are not published. Linux ARM64 users can use
 Homebrew or the verified `tailscale-browser-ext-linux-arm64` raw helper through
-the repair script described below.
+the per-user installer below.
 
-## Per-user registration repair
+## Install for this user — no administrator access required
 
-Use the release's `tailchrome-install.sh` only when a compatible system package
-is unavailable or the browser still cannot discover the package-installed
-helper. The script selects `linux-amd64` or `linux-arm64` from the runtime
+Use the release's `tailchrome-install.sh` to install or repair the helper for
+your account. The script selects `linux-amd64` or `linux-arm64` from the runtime
 architecture, verifies the raw helper, runs it with `-install-now`, and writes
 registration only for the current user.
 

--- a/packaging/macos/README.md
+++ b/packaging/macos/README.md
@@ -1,4 +1,15 @@
-# macOS Helper installer (.pkg)
+# macOS helper installation
+
+## Install for this user — no administrator access required
+
+Download `tailchrome-helper-macos-user.zip` from the matching release, unzip it,
+and open **Tailchrome Helper**. The signed, notarized app includes the universal
+helper and installs it for your account. Keep the app to run setup again later.
+It works on Apple Silicon and Intel Macs.
+
+Your organization’s browser policy may still block extensions or native messaging.
+
+## System package
 
 Homebrew users can install the same signed release package with the
 [Tailchrome cask](../homebrew/README.md#macos). It supports Apple Silicon and
@@ -7,7 +18,8 @@ The [source formula](../homebrew/README.md#source-formula-macos-and-linux) is al
 available for users who prefer to build the helper locally and register it
 without administrator privileges.
 
-The script `build-pkg.sh` produces `dist/tailchrome-helper-macos.pkg`, which installs:
+The script `build-pkg.sh` builds both installers. The system package
+`dist/tailchrome-helper-macos.pkg` requires administrator access and installs:
 
 1. **Universal** `tailscale-browser-ext` at  
    `/Library/Application Support/Tailscale/BrowserExt/tailscale-browser-ext`
@@ -22,7 +34,7 @@ native-messaging registrations.
 
 ## Unsigned builds
 
-CI and local runs produce an unsigned package. Gatekeeper may require **right-click → Open** the first time, or **System Settings → Privacy & Security**.
+CI and local runs without signing identities produce unsigned installers. Gatekeeper may require **right-click → Open** the first time, or **System Settings → Privacy & Security**.
 
 ## Signing and notarization (release quality)
 
@@ -41,7 +53,7 @@ Requirements: Apple Developer Program, **Developer ID Application** and **Develo
    ./packaging/macos/build-pkg.sh
    ```
 
-3. Notarize the **installer .pkg** (not the app alone):
+3. Notarize both installers and staple their tickets:
 
    ```bash
    xcrun notarytool submit dist/tailchrome-helper-macos.pkg \
@@ -50,6 +62,14 @@ Requirements: Apple Developer Program, **Developer ID Application** and **Develo
      --password "$APPLE_APP_SPECIFIC_PASSWORD" \
      --wait
    xcrun stapler staple dist/tailchrome-helper-macos.pkg
+   xcrun notarytool submit dist/tailchrome-helper-macos-user.zip \
+     --apple-id "$APPLE_ID" \
+     --team-id "$APPLE_TEAM_ID" \
+     --password "$APPLE_APP_SPECIFIC_PASSWORD" \
+     --wait
+   xcrun stapler staple "dist/Tailchrome Helper.app"
+   rm dist/tailchrome-helper-macos-user.zip
+   ditto -c -k --keepParent "dist/Tailchrome Helper.app" dist/tailchrome-helper-macos-user.zip
    ```
 
 Store Apple credentials in GitHub Actions secrets for automated release; do not commit them.
@@ -68,17 +88,15 @@ spctl --assess --type execute --verbose=2 \
 
 ## GitHub Actions
 
-Pull-request CI builds an unsigned package, expands it, and asserts that the
-repair app and executable launcher are present. The release workflow runs
-`build-pkg.sh` on `macos-latest`, signs and notarizes the app and package,
-staples the package, and stages the final `.pkg` with the other immutable
-release candidates. Publication does not rebuild or replace the cleared
-package.
+Pull-request CI builds and inspects both installers and tests the per-user
+launcher. Release CI signs and notarizes both, staples the package and app,
+and includes the final archive in release checksums and provenance attestations.
+Publication rechecks signatures and tickets without rebuilding.
 
 ## Per-user fallback
 
-The package and repair app remain the preferred paths. If they cannot be used,
-the release also contains a version-pinned `tailchrome-install.sh` fallback.
+For terminal setup or repair, the release also contains a version-pinned
+`tailchrome-install.sh` installer.
 Replace `vX.Y.Z` below with the exact extension release, then download, verify,
 inspect, and run the script:
 
@@ -133,13 +151,15 @@ sudo pkgutil --forget org.tesseras.tailchrome.helper
 
 Run the first command once in each macOS user account that used Tailchrome, because native-messaging registrations are per user.
 
-For a per-user fallback install, use the actual installed helper:
+For a per-user app or script install, remove the installed helper and its registrations:
 
 ```bash
 "$HOME/Library/Application Support/Tailscale/BrowserExt/tailscale-browser-ext" -uninstall
 ```
 
-The fallback script can invoke the same command after validating the requested
+You can then move the downloaded app to the Trash.
+
+The script can invoke the same command after validating the requested
 release version:
 
 ```bash

--- a/packaging/macos/build-pkg.sh
+++ b/packaging/macos/build-pkg.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build tailscale-browser-ext as a universal macOS binary, then a flat .pkg that installs:
+# Build a self-contained per-user app archive and a flat .pkg that installs:
 #   - /Library/Application Support/Tailscale/BrowserExt/tailscale-browser-ext
 #   - /Applications/Tailchrome Helper.app  (repair/re-run fallback)
 # and runs a postinstall script that registers native messaging for the logged-in user.
@@ -54,6 +54,19 @@ APP_PLIST="$STAGE/pkgroot/Applications/Tailchrome Helper.app/Contents/Info.plist
 /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $VERSION_PKG" "$APP_PLIST"
 /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $VERSION_PKG" "$APP_PLIST"
 
+echo "Staging per-user helper app..."
+USER_APP="$STAGE/user/Tailchrome Helper.app"
+mkdir -p "$STAGE/user"
+cp -R "$STAGE/pkgroot/Applications/Tailchrome Helper.app" "$USER_APP"
+xcrun clang -arch arm64 -arch x86_64 -mmacosx-version-min=12.0 \
+  -fobjc-arc -Wall -Wextra -framework Cocoa \
+  "$ROOT/packaging/macos/per-user-launcher.m" -o "$USER_APP/Contents/MacOS/tailchrome-helper"
+cp "$STAGE/pkgroot/Library/Application Support/Tailscale/BrowserExt/tailscale-browser-ext" \
+  "$USER_APP/Contents/MacOS/tailscale-browser-ext"
+chmod 755 "$USER_APP/Contents/MacOS/"*
+/usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier org.tesseras.tailchrome.helper.user" \
+  "$USER_APP/Contents/Info.plist"
+
 echo "Staging postinstall script..."
 cp "$ROOT/packaging/macos/scripts/postinstall" "$STAGE/scripts/postinstall"
 chmod 755 "$STAGE/scripts/postinstall"
@@ -65,19 +78,24 @@ if [[ -n "${MACOS_SIGN_APPLICATION_IDENTITY:-}" ]]; then
     "$STAGE/pkgroot/Library/Application Support/Tailscale/BrowserExt/tailscale-browser-ext"
   codesign --force --options runtime --timestamp --deep --sign "$MACOS_SIGN_APPLICATION_IDENTITY" \
     "$STAGE/pkgroot/Applications/Tailchrome Helper.app"
+  codesign --force --options runtime --timestamp --sign "$MACOS_SIGN_APPLICATION_IDENTITY" \
+    "$USER_APP/Contents/MacOS/tailscale-browser-ext"
+  codesign --force --options runtime --timestamp --sign "$MACOS_SIGN_APPLICATION_IDENTITY" \
+    "$USER_APP"
 fi
 
 # Avoid packaging AppleDouble sidecar files when local files have extended
 # attributes or resource forks. Run after signing too, because signing tools can
 # touch extended attributes.
 if command -v xattr >/dev/null 2>&1; then
-  xattr -cr "$STAGE/pkgroot" "$STAGE/scripts"
+  xattr -cr "$STAGE/pkgroot" "$STAGE/scripts" "$STAGE/user"
 fi
 if command -v dot_clean >/dev/null 2>&1; then
   dot_clean -m "$STAGE/pkgroot"
   dot_clean -m "$STAGE/scripts"
+  dot_clean -m "$STAGE/user"
 fi
-find "$STAGE/pkgroot" "$STAGE/scripts" -name '._*' -type f -delete
+find "$STAGE/pkgroot" "$STAGE/scripts" "$STAGE/user" -name '._*' -type f -delete
 
 PKG_PATH="$DIST_DIR/$OUT_NAME"
 echo "Writing $PKG_PATH ..."
@@ -110,4 +128,8 @@ if [[ -n "${MACOS_SIGN_INSTALLER_IDENTITY:-}" ]]; then
   rm -f "$UNSIGNED"
 fi
 
-echo "Done: $PKG_PATH"
+rm -rf "$DIST_DIR/Tailchrome Helper.app"
+cp -R "$USER_APP" "$DIST_DIR/Tailchrome Helper.app"
+ditto -c -k --keepParent "$DIST_DIR/Tailchrome Helper.app" "$DIST_DIR/tailchrome-helper-macos-user.zip"
+
+echo "Done: $PKG_PATH and $DIST_DIR/tailchrome-helper-macos-user.zip"

--- a/packaging/macos/per-user-launcher.m
+++ b/packaging/macos/per-user-launcher.m
@@ -1,0 +1,38 @@
+#import <Cocoa/Cocoa.h>
+
+static BOOL installHelper(NSURL *bundleURL, NSError **error) {
+    NSURL *helperURL = [bundleURL URLByAppendingPathComponent:@"Contents/MacOS/tailscale-browser-ext"];
+    NSTask *task = [[NSTask alloc] init];
+    task.executableURL = helperURL;
+    task.arguments = @[@"-install-now"];
+    task.standardInput = [NSFileHandle fileHandleWithNullDevice];
+    if (![task launchAndReturnError:error]) {
+        return NO;
+    }
+    [task waitUntilExit];
+    return task.terminationReason == NSTaskTerminationReasonExit && task.terminationStatus == 0;
+}
+
+#ifndef TAILCHROME_LAUNCHER_TEST
+int main(void) {
+    @autoreleasepool {
+        [NSApplication sharedApplication];
+        [NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];
+        NSError *error = nil;
+        BOOL installed = installHelper([NSBundle mainBundle].bundleURL, &error);
+        if (error) {
+            NSLog(@"Helper setup failed: %@", error);
+        }
+        NSAlert *alert = [[NSAlert alloc] init];
+        alert.messageText = installed ? @"Setup is complete" : @"Setup could not finish";
+        alert.informativeText = installed
+            ? @"Return to your browser and open Tailchrome."
+            : @"Close your browsers and try again. If the app is incomplete, download Tailchrome Helper again from GitHub Releases.";
+        alert.alertStyle = installed ? NSAlertStyleInformational : NSAlertStyleCritical;
+        [alert addButtonWithTitle:@"OK"];
+        [NSApp activateIgnoringOtherApps:YES];
+        [alert runModal];
+        return installed ? 0 : 1;
+    }
+}
+#endif

--- a/packaging/macos/per-user-launcher.test.m
+++ b/packaging/macos/per-user-launcher.test.m
@@ -1,0 +1,38 @@
+#define TAILCHROME_LAUNCHER_TEST
+#import "per-user-launcher.m"
+#include <assert.h>
+
+static void writeHelper(NSURL *url, NSString *script, NSNumber *mode) {
+    [[NSFileManager defaultManager] removeItemAtURL:url error:NULL];
+    assert([[NSFileManager defaultManager] createFileAtPath:url.path
+        contents:[script dataUsingEncoding:NSUTF8StringEncoding]
+        attributes:@{NSFilePosixPermissions: mode}]);
+}
+
+int main(void) {
+    @autoreleasepool {
+        NSFileManager *fm = [NSFileManager defaultManager];
+        NSURL *root = [NSURL fileURLWithPath:[NSTemporaryDirectory()
+            stringByAppendingPathComponent:[NSUUID UUID].UUIDString]];
+        NSURL *bundle = [root URLByAppendingPathComponent:@"A user's Downloads/Tailchrome Helper.app"];
+        NSURL *macOS = [bundle URLByAppendingPathComponent:@"Contents/MacOS"];
+        assert([fm createDirectoryAtURL:macOS withIntermediateDirectories:YES attributes:nil error:NULL]);
+        NSURL *helper = [macOS URLByAppendingPathComponent:@"tailscale-browser-ext"];
+        NSError *error = nil;
+
+        assert(!installHelper(bundle, &error));
+        assert(error != nil);
+
+        writeHelper(helper, @"#!/bin/bash\n[[ $# == 1 && $1 == -install-now ]] || exit 9\n! read -r line\n", @0755);
+        assert(installHelper(bundle, NULL));
+
+        writeHelper(helper, @"#!/bin/bash\nexit 7\n", @0755);
+        assert(!installHelper(bundle, NULL));
+
+        writeHelper(helper, @"#!/bin/bash\nexit 0\n", @0644);
+        assert(!installHelper(bundle, NULL));
+        assert([fm removeItemAtURL:root error:NULL]);
+        puts("Per-user launcher tests passed.");
+    }
+    return 0;
+}

--- a/packaging/macos/test-user-app.sh
+++ b/packaging/macos/test-user-app.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+TEST_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+ditto -x -k "${1:-$ROOT/dist/tailchrome-helper-macos-user.zip}" "$TEST_DIR/extracted"
+APP="$TEST_DIR/extracted/Tailchrome Helper.app"
+test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$APP/Contents/Info.plist")" = \
+  org.tesseras.tailchrome.helper.user
+test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$APP/Contents/Info.plist")" = \
+  tailchrome-helper
+for bin in tailchrome-helper tailscale-browser-ext; do
+  test -x "$APP/Contents/MacOS/$bin"
+  lipo -verify_arch arm64 x86_64 "$APP/Contents/MacOS/$bin"
+done
+test "$("$APP/Contents/MacOS/tailscale-browser-ext" -version)" = "${2:-0.0.0}"
+xcrun clang -fobjc-arc -Wall -Wextra -framework Cocoa \
+  "$ROOT/packaging/macos/per-user-launcher.test.m" -o "$TEST_DIR/launcher-test"
+"$TEST_DIR/launcher-test"

--- a/packaging/macos/test-user-app.sh
+++ b/packaging/macos/test-user-app.sh
@@ -13,7 +13,7 @@ test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$APP/Contents/In
   tailchrome-helper
 for bin in tailchrome-helper tailscale-browser-ext; do
   test -x "$APP/Contents/MacOS/$bin"
-  lipo -verify_arch arm64 x86_64 "$APP/Contents/MacOS/$bin"
+  lipo "$APP/Contents/MacOS/$bin" -verify_arch arm64 x86_64
 done
 test "$("$APP/Contents/MacOS/tailscale-browser-ext" -version)" = "${2:-0.0.0}"
 xcrun clang -fobjc-arc -Wall -Wextra -framework Cocoa \


### PR DESCRIPTION
## What
Make no-admin installation visible and add a self-contained macOS helper app for per-user setup. Include the new archive in signing, notarization, checksums, and release verification.

## Why
Users without administrator access should have a clear installation path on each supported platform.

## How to Test
Typecheck, unit tests, installer tests, Homebrew tests, Go race tests/vet, and workflow validation pass locally. CI checks macOS launcher compilation and both installer packages.
