### PR TITLE
Keep protected browsing blocked during connection failures

### DIFF
--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -411,24 +411,24 @@ Chrome uses a dynamically generated PAC (Proxy Auto-Config) script set via `chro
 3. **MagicDNS suffix** (e.g., `*.ts.net`) -> proxy before any `isInNet()` call, avoiding local DNS resolution of ordinary hostnames
 4. **Tailscale IPv6 prefix** (`fd7a:115c:a1e0::/48`) -> proxy
 5. **Subnet routes** (from subnet router peers) -> proxy via `isInNet()` only for IPv4 literals
-6. **Exit node active** -> all traffic through proxy
+6. **Exit node selected** -> protected traffic stays proxied, or blocked while the node is unavailable
 7. **Otherwise** -> `DIRECT`
 
 The proxy target is `SOCKS5 127.0.0.1:<port>`.
 
-PAC script regeneration is skipped if proxy-relevant fields have not changed. A fresh service worker also clears browser proxy state once before trusting its in-memory enabled flag, preventing a PAC left behind by an unclean shutdown.
-
-On service worker suspension, `chrome.proxy.settings.set({ mode: "direct" })` is called to prevent stale routing.
+Successful PAC settings are reused until routing changes. Worker suspension preserves the browser settings; reconnecting replaces the helper endpoint after confirmation.
 
 ### Firefox: proxy.onRequest
 
 Firefox uses the `browser.proxy.onRequest` API with an event listener that evaluates each request URL:
 
 1. Same routing logic as Chrome (service IP, CGNAT, Tailscale IPv6, MagicDNS, subnets, exit node)
-2. Returns `{ type: "socks", host: "127.0.0.1", port, proxyDNS: true }` or `{ type: "direct" }`
+2. Protected requests use a SOCKS proxy chain ending in `null`, preventing browser proxy fallback. Other requests use the normal browser connection.
 3. IP matching uses numeric comparison (`ipToNum()`) instead of PAC's `isInNet()`
 
-**Session storage persistence:** Firefox suspends background event pages aggressively. The proxy config (port, suffix, exit node state, subnet ranges, and split-domain rules) is persisted to `browser.storage.session` under the key `"proxyConfig"`. On wake, the listener returns a `Promise` that waits for both storage restoration and an authoritative reconnect state; transient `NoState`/`Starting` updates do not release requests to the direct network.
+**Routing protection:** Both browsers retain a sanitized routing snapshot across restarts, without helper ports or credentials. Exit-node choices are scoped to the account and coordination server. Helper loss or an unavailable exit node blocks protected requests while preserving split-tunnel exceptions. Chrome uses mandatory PAC settings and checks effective proxy ownership.
+
+The popup reports routing failures separately from the Tailscale connection. Choose **Disconnect and browse normally** to release protection when the helper cannot respond.
 
 ---
 

--- a/docs/puppeteer-testing-suite.md
+++ b/docs/puppeteer-testing-suite.md
@@ -59,6 +59,7 @@ An array provides sequential replies for repeated commands. Every request is sti
 
 - `popup-loads`: packaged popup renders without page or console errors.
 - `proxy-routing`: Chrome installs a PAC containing service IP, IPv4/IPv6 tailnet ranges, MagicDNS, and subnet routes.
+- `routing-failclosed-network`: real HTTP requests stay blocked when an exit node or helper disappears; recovery uses the proxy and an explicit bypass goes direct.
 - `connection-states`: install, update, login, stopped, and machine-approval views.
 - `toggle-commands`: `up`/`down` commands plus their resulting UI transitions.
 - `connected-dashboard`: identity, helper version, health warnings, peers, and search.

--- a/packages/extension/src/__test__/browser-mock.ts
+++ b/packages/extension/src/__test__/browser-mock.ts
@@ -9,6 +9,7 @@ const sessionStore: Record<string, unknown> = {};
 
 const browserMock = {
   proxy: {
+    onError: { addListener: (_fn: () => void) => {} },
     onRequest: {
       addListener: (listener: ProxyListener, _filter: { urls: string[] }) => {
         listeners.push(listener);

--- a/packages/extension/src/background/chrome-proxy-manager.test.ts
+++ b/packages/extension/src/background/chrome-proxy-manager.test.ts
@@ -3,12 +3,17 @@ import { baseState, makePeer } from "@tailchrome/shared/__test__/fixtures";
 import type { TailscaleState } from "@tailchrome/shared/types";
 import { ChromeProxyManager } from "./chrome-proxy-manager";
 
-function capturePAC(pm: ChromeProxyManager, state: TailscaleState): string | null {
+function capturePAC(
+  pm: ChromeProxyManager,
+  state: TailscaleState,
+): string | null {
   let captured: string | null = null;
   const original = chrome.proxy.settings.set;
 
   chrome.proxy.settings.set = ((details: unknown, cb?: () => void) => {
-    const typedDetails = details as { value?: { pacScript?: { data?: string } } };
+    const typedDetails = details as {
+      value?: { pacScript?: { data?: string } };
+    };
     captured = typedDetails.value?.pacScript?.data ?? null;
     cb?.();
     return Promise.resolve();
@@ -39,31 +44,27 @@ describe("ChromeProxyManager", () => {
       expect(args.value.mode).toBe("pac_script");
     });
 
-    it("clears proxy when backend is not running", () => {
-      const spy = vi.spyOn(chrome.proxy.settings, "set");
+    it("releases its proxy setting after an explicit direct policy", () => {
+      const spy = vi.spyOn(chrome.proxy.settings, "clear");
       pm.apply(baseState());
       pm.apply(baseState({ backendState: "Stopped" }));
-      const lastCall = spy.mock.calls.at(-1)![0] as { value: { mode: string } };
-      expect(lastCall.value.mode).toBe("direct");
+      expect(spy).toHaveBeenCalledWith(
+        { scope: "regular" },
+        expect.any(Function),
+      );
     });
 
-    it("clears proxy when proxyEnabled is false", () => {
+    it("makes PAC mandatory", () => {
       const spy = vi.spyOn(chrome.proxy.settings, "set");
       pm.apply(baseState());
-      pm.apply(baseState({ proxyEnabled: false }));
-      const lastCall = spy.mock.calls.at(-1)![0] as { value: { mode: string } };
-      expect(lastCall.value.mode).toBe("direct");
-    });
-
-    it("clears a potentially persisted PAC on the first stopped state", () => {
-      const spy = vi.spyOn(chrome.proxy.settings, "set");
-      pm.apply(baseState({ backendState: "Stopped" }));
-      expect(spy).toHaveBeenCalledTimes(1);
-      const call = spy.mock.calls[0]![0] as { value: { mode: string } };
-      expect(call.value.mode).toBe("direct");
-
-      pm.apply(baseState({ backendState: "Stopped" }));
-      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          value: expect.objectContaining({
+            pacScript: expect.objectContaining({ mandatory: true }),
+          }),
+        }),
+        expect.any(Function),
+      );
     });
   });
 
@@ -158,9 +159,9 @@ describe("ChromeProxyManager", () => {
 
     it("routes MagicDNS names through proxy", () => {
       const route = evalPAC(pm, baseState());
-      expect(route("http://my-server.example.ts.net", "my-server.example.ts.net")).toBe(
-        "SOCKS5 127.0.0.1:1055",
-      );
+      expect(
+        route("http://my-server.example.ts.net", "my-server.example.ts.net"),
+      ).toBe("SOCKS5 127.0.0.1:1055");
       expect(route("http://example.ts.net", "example.ts.net")).toBe(
         "SOCKS5 127.0.0.1:1055",
       );
@@ -172,10 +173,7 @@ describe("ChromeProxyManager", () => {
     it("routes Tailscale IPv6 literals through the proxy", () => {
       const route = evalPAC(pm, baseState());
       expect(
-        route(
-          "http://[fd7a:115c:a1e0::1234]/",
-          "fd7a:115c:a1e0::1234",
-        ),
+        route("http://[fd7a:115c:a1e0::1234]/", "fd7a:115c:a1e0::1234"),
       ).toBe("SOCKS5 127.0.0.1:1055");
     });
 
@@ -291,9 +289,9 @@ describe("ChromeProxyManager", () => {
       expect(route("http://100.100.100.100", "100.100.100.100")).toBe(
         "SOCKS5 127.0.0.1:1055",
       );
-      expect(
-        route("http://srv.example.ts.net", "srv.example.ts.net"),
-      ).toBe("SOCKS5 127.0.0.1:1055");
+      expect(route("http://srv.example.ts.net", "srv.example.ts.net")).toBe(
+        "SOCKS5 127.0.0.1:1055",
+      );
     });
 
     it("only mode with empty list: catch-all is DIRECT", () => {
@@ -307,9 +305,9 @@ describe("ChromeProxyManager", () => {
       expect(route("http://100.100.100.100", "100.100.100.100")).toBe(
         "SOCKS5 127.0.0.1:1055",
       );
-      expect(
-        route("http://srv.example.ts.net", "srv.example.ts.net"),
-      ).toBe("SOCKS5 127.0.0.1:1055");
+      expect(route("http://srv.example.ts.net", "srv.example.ts.net")).toBe(
+        "SOCKS5 127.0.0.1:1055",
+      );
     });
 
     it("bypass mode with empty list: catch-all is full proxy (no rules to apply)", () => {
@@ -361,6 +359,120 @@ describe("ChromeProxyManager", () => {
       expect(pac).toContain('"ok.example.com"');
     });
   });
+  it("does not cache a rejected configuration and retries the next application", () => {
+    const report = vi.fn();
+    pm.setRoutingHealthListener(report);
+    const original = chrome.proxy.settings.set;
+    const set = vi
+      .spyOn(chrome.proxy.settings, "set")
+      .mockImplementationOnce((_details, callback) => {
+        Object.assign(chrome.runtime, { lastError: { message: "rejected" } });
+        callback?.();
+        Object.assign(chrome.runtime, { lastError: undefined });
+        return Promise.resolve();
+      });
+    pm.apply(baseState());
+    expect(report).toHaveBeenLastCalledWith(
+      expect.objectContaining({ status: "unavailable" }),
+    );
+    set.mockImplementation(original);
+    pm.apply(baseState());
+    expect(set).toHaveBeenCalledTimes(2);
+    expect(report).toHaveBeenLastCalledWith({ status: "active", message: "" });
+  });
+
+  it("reports ownership conflicts without claiming an active route", () => {
+    const report = vi.fn();
+    pm.setRoutingHealthListener(report);
+    vi.spyOn(chrome.proxy.settings, "get").mockImplementation(
+      (_details, callback) => {
+        callback({
+          levelOfControl: "controlled_by_other_extensions",
+          value: { mode: "direct" },
+        });
+        return Promise.resolve({});
+      },
+    );
+    const set = vi.spyOn(chrome.proxy.settings, "set");
+    pm.apply(baseState());
+    expect(set).not.toHaveBeenCalled();
+    expect(report).toHaveBeenLastCalledWith(
+      expect.objectContaining({ status: "conflicted" }),
+    );
+  });
+
+  it("keeps proxy errors visible through reentrant state notifications", () => {
+    let onError:
+      | ((details: { error: string; details: string; fatal: boolean }) => void)
+      | undefined;
+    vi.spyOn(chrome.proxy.onProxyError, "addListener").mockImplementation(
+      (listener) => {
+        onError = listener;
+      },
+    );
+    const manager = new ChromeProxyManager();
+    const reports: string[] = [];
+    manager.setRoutingHealthListener((health) => {
+      reports.push(health.status);
+      if (health.status === "blocked") manager.apply(baseState());
+    });
+    manager.apply(baseState());
+    onError?.({ error: "connection failed", details: "", fatal: true });
+    expect(reports.at(-1)).toBe("blocked");
+  });
+
+  it("recovers the original route after an error and an intervening blocked policy", () => {
+    let onError:
+      | ((details: { error: string; details: string; fatal: boolean }) => void)
+      | undefined;
+    vi.spyOn(chrome.proxy.onProxyError, "addListener").mockImplementation(
+      (listener) => {
+        onError = listener;
+      },
+    );
+    const manager = new ChromeProxyManager();
+    const report = vi.fn();
+    manager.setRoutingHealthListener(report);
+    manager.apply(baseState());
+    onError?.({ error: "failed", details: "", fatal: true });
+    manager.apply(
+      baseState({
+        prefs: {
+          exitNodeID: "missing",
+          corpDNS: true,
+          shieldsUp: false,
+          exitNodeAllowLANAccess: false,
+        },
+      }),
+    );
+    manager.apply(baseState());
+    expect(report).toHaveBeenLastCalledWith({ status: "active", message: "" });
+  });
+
+  it("accepts Chrome's canonical PAC property order", () => {
+    let value: chrome.proxy.ProxyConfig = { mode: "system" };
+    vi.spyOn(chrome.proxy.settings, "set").mockImplementation(
+      (details, callback) => {
+        const config = details.value as chrome.proxy.ProxyConfig;
+        value = {
+          mode: config.mode,
+          pacScript: { data: config.pacScript?.data, mandatory: true },
+        };
+        callback?.();
+        return Promise.resolve();
+      },
+    );
+    vi.spyOn(chrome.proxy.settings, "get").mockImplementation(
+      (_details, callback) => {
+        callback({ value, levelOfControl: "controlled_by_this_extension" });
+        return Promise.resolve({});
+      },
+    );
+    const health = vi.fn();
+    pm.setRoutingHealthListener(health);
+    pm.apply(baseState());
+    expect(health).toHaveBeenLastCalledWith({ status: "active", message: "" });
+  });
 });
 
 function evalPAC(
@@ -379,6 +491,10 @@ function evalPAC(
   const dnsDomainIs = (host: string, suffix: string): boolean =>
     host === suffix.slice(1) || host.endsWith(suffix);
 
-  const fn = new Function("isInNet", "dnsDomainIs", `${pac}\nreturn FindProxyForURL;`);
+  const fn = new Function(
+    "isInNet",
+    "dnsDomainIs",
+    `${pac}\nreturn FindProxyForURL;`,
+  );
   return fn(isInNet, dnsDomainIs) as (url: string, host: string) => string;
 }

--- a/packages/extension/src/background/chrome-proxy-manager.ts
+++ b/packages/extension/src/background/chrome-proxy-manager.ts
@@ -1,4 +1,8 @@
-import type { DomainSplitConfig, TailscaleState } from "@tailchrome/shared/types";
+import type {
+  DomainSplitConfig,
+  TailscaleState,
+  RoutingHealth,
+} from "@tailchrome/shared/types";
 import {
   TAILSCALE_IPV6_PREFIX,
   TAILSCALE_SERVICE_IP,
@@ -11,87 +15,189 @@ import {
   shouldProxyState,
 } from "@tailchrome/shared/background/proxy-utils";
 
+import {
+  policyFromState,
+  BLOCKED_PROXY_PORT,
+} from "@tailchrome/shared/background/routing-protection";
+
 export class ChromeProxyManager {
-  private currentlyEnabled = false;
-  private lastProxyKey = "";
-  private reconciledBrowserState = false;
+  private desired: chrome.proxy.ProxyConfig | null = null;
+  private desiredKey = "";
+  private appliedKey = "";
+  private inFlight = false;
+  private errorKey = "";
+  private changeEpoch = 0;
+  private healthListener: ((health: RoutingHealth) => void) | null = null;
+  private desiredHealth: RoutingHealth = { status: "inactive", message: "" };
+
+  constructor() {
+    chrome.proxy.settings.onChange.addListener((details) => {
+      this.changeEpoch += 1;
+      if (this.inFlight || !this.desired) return;
+      if (
+        details.levelOfControl === "controlled_by_other_extensions" ||
+        details.levelOfControl === "not_controllable"
+      ) {
+        this.appliedKey = "";
+        this.report({
+          status: "conflicted",
+          message:
+            "Browser routing is controlled by another extension or a browser policy.",
+        });
+      } else if (
+        this.desired &&
+        !sameProxyConfig(details.value, this.desired)
+      ) {
+        this.appliedKey = "";
+        this.flush();
+      } else {
+        this.flush();
+      }
+    });
+    chrome.proxy.onProxyError.addListener((details) => {
+      if (!this.desired) return;
+      this.errorKey = this.desiredKey;
+      this.appliedKey = "";
+      this.report({
+        status: details.fatal ? "blocked" : "unavailable",
+        message: details.fatal
+          ? "The proxy is unavailable — protected browsing is blocked."
+          : "Browser routing failed. Traffic may use your normal connection.",
+      });
+    });
+  }
+
+  setRoutingHealthListener(listener: (health: RoutingHealth) => void): void {
+    this.healthListener = listener;
+  }
 
   apply(state: TailscaleState): void {
-    if (!shouldProxyState(state)) {
-      // A service-worker restart loses the in-memory enabled flag while Chrome
-      // can retain the PAC setting. Reconcile browser state once on startup.
-      if (this.currentlyEnabled || !this.reconciledBrowserState) {
-        this.clear();
-      }
-      this.reconciledBrowserState = true;
+    const policy = policyFromState(state);
+    if (policy.mode === "direct") {
+      this.clear();
       return;
     }
-
-    this.reconciledBrowserState = true;
-
-    const port = state.proxyPort!;
-    const magicDNSSuffix = state.magicDNSSuffix;
-    const exitNodeActive = state.exitNode !== null;
-    const subnets = collectSubnetCIDRs(state.peers);
-    const splitDomains = sanitizeSplitDomains(state.domainSplit);
-    const splitMode = state.domainSplit.mode;
-
-    // Skip regeneration if proxy-relevant fields haven't changed
-    const proxyKey = `${port}:${magicDNSSuffix ?? ""}:${exitNodeActive}:${[...subnets].sort().join(",")}:${splitMode}:${splitDomains.join(",")}`;
-    if (proxyKey === this.lastProxyKey) {
-      return;
-    }
-    this.lastProxyKey = proxyKey;
-
-    const pacScript = this.generatePACScript(
-      port,
-      magicDNSSuffix,
-      exitNodeActive,
-      subnets,
-      splitMode,
-      splitDomains,
-    );
-
-    chrome.proxy.settings.set(
-      {
-        value: {
-          mode: "pac_script",
-          pacScript: {
-            data: pacScript,
-          },
-        },
-        scope: "regular",
-      },
-      () => {
-        if (chrome.runtime.lastError) {
-          console.error(
-            "[ProxyManager] Failed to set proxy:",
-            chrome.runtime.lastError.message,
-          );
+    const blocked = policy.mode === "blocked";
+    const port = blocked ? BLOCKED_PROXY_PORT : policy.proxyPort!;
+    this.desiredHealth = blocked
+      ? {
+          status: "blocked",
+          message: policy.selectedExitNodeID
+            ? "Exit node unavailable — protected browsing is blocked."
+            : "Connection unavailable — tailnet browsing is blocked.",
         }
+      : { status: "active", message: "" };
+    this.desired = {
+      mode: "pac_script",
+      pacScript: {
+        mandatory: true,
+        data: this.generatePACScript(
+          port,
+          policy.magicDNSSuffix,
+          policy.blockAll || policy.selectedExitNodeID !== null,
+          policy.subnetCIDRs,
+          policy.domainSplit.mode,
+          sanitizeSplitDomains(policy.domainSplit),
+        ),
       },
-    );
-
-    this.currentlyEnabled = true;
+    };
+    const nextKey = JSON.stringify(this.desired);
+    if (nextKey !== this.desiredKey) this.errorKey = "";
+    this.desiredKey = nextKey;
+    this.flush();
   }
 
   clear(): void {
-    chrome.proxy.settings.set(
-      {
-        value: { mode: "direct" },
-        scope: "regular",
-      },
-      () => {
+    this.desired = null;
+    if (this.desiredKey !== "clear") this.errorKey = "";
+    this.desiredKey = "clear";
+    this.desiredHealth = { status: "inactive", message: "" };
+    this.flush();
+  }
+
+  private report(health: RoutingHealth): void {
+    this.healthListener?.(health);
+  }
+
+  private flush(): void {
+    if (!this.desiredKey || this.inFlight || this.errorKey === this.desiredKey)
+      return;
+    if (this.appliedKey === this.desiredKey) {
+      this.report(this.desiredHealth);
+      return;
+    }
+    this.inFlight = true;
+    const key = this.desiredKey;
+    const value = this.desired;
+    const fail = (message: string, conflicted = false): void => {
+      this.appliedKey = "";
+      // Keep reentrant state notifications from immediately retrying a rejection.
+      this.report({
+        status: conflicted ? "conflicted" : "unavailable",
+        message,
+      });
+      this.inFlight = false;
+      if (key !== this.desiredKey) this.flush();
+    };
+    chrome.proxy.settings.get({ incognito: false }, (current) => {
+      if (key !== this.desiredKey) {
+        this.inFlight = false;
+        this.flush();
+        return;
+      }
+      if (chrome.runtime.lastError) {
+        fail("Could not check browser routing.");
+        return;
+      }
+      if (
+        value &&
+        (current.levelOfControl === "not_controllable" ||
+          current.levelOfControl === "controlled_by_other_extensions")
+      ) {
+        fail(
+          "Browser routing is controlled by another extension or a browser policy.",
+          true,
+        );
+        return;
+      }
+      const done = (): void => {
         if (chrome.runtime.lastError) {
-          console.error(
-            "[ProxyManager] Failed to clear proxy:",
-            chrome.runtime.lastError.message,
-          );
+          fail("The browser rejected the routing settings.");
+          return;
         }
-      },
-    );
-    this.currentlyEnabled = false;
-    this.lastProxyKey = "";
+        const verify = (): void => {
+          const epoch = this.changeEpoch;
+          chrome.proxy.settings.get({ incognito: false }, (effective) => {
+            if (epoch !== this.changeEpoch) {
+              verify();
+              return;
+            }
+            if (chrome.runtime.lastError) {
+              fail("Could not verify browser routing.");
+              return;
+            }
+            if (
+              value &&
+              (effective.levelOfControl !== "controlled_by_this_extension" ||
+                !sameProxyConfig(effective.value, value))
+            ) {
+              fail(
+                "Browser routing is controlled by another extension or a browser policy.",
+                true,
+              );
+              return;
+            }
+            this.appliedKey = key;
+            if (key === this.desiredKey) this.report(this.desiredHealth);
+            this.inFlight = false;
+            if (key !== this.desiredKey) this.flush();
+          });
+        };
+        verify();
+      };
+      if (value) chrome.proxy.settings.set({ value, scope: "regular" }, done);
+      else chrome.proxy.settings.clear({ scope: "regular" }, done);
+    });
   }
 
   private generatePACScript(
@@ -158,4 +264,16 @@ function sanitizeSplitDomains(config: DomainSplitConfig): string[] {
     out.push(cleaned);
   }
   return out;
+}
+
+function sameProxyConfig(
+  actual: chrome.proxy.ProxyConfig,
+  expected: chrome.proxy.ProxyConfig,
+): boolean {
+  return (
+    actual.mode === expected.mode &&
+    actual.pacScript?.data === expected.pacScript?.data &&
+    (actual.pacScript?.mandatory === true) ===
+      (expected.pacScript?.mandatory === true)
+  );
 }

--- a/packages/extension/src/background/chrome.test.ts
+++ b/packages/extension/src/background/chrome.test.ts
@@ -85,12 +85,12 @@ describe("startChromeBackground", () => {
     );
   });
 
-  it("clears proxy settings on suspend", () => {
+  it("preserves proxy settings on suspend", () => {
     startChromeBackground();
 
-    expect(onSuspendAddListener).toHaveBeenCalledTimes(1);
+    expect(onSuspendAddListener).not.toHaveBeenCalled();
     suspendListener?.();
-    expect(proxyManagerInstance.clear).toHaveBeenCalledTimes(1);
+    expect(proxyManagerInstance.clear).not.toHaveBeenCalled();
   });
 
   it("rehydrates a pending helper retry during MV3 startup", () => {

--- a/packages/extension/src/background/chrome.ts
+++ b/packages/extension/src/background/chrome.ts
@@ -18,7 +18,6 @@ export function startChromeBackground(): void {
       timerService: new ChromeAlarmTimerService(),
     },
   );
-  const { proxyManager } = background;
   void background.rehydrateHelperRetries().catch((err) => {
     console.warn(
       "[Chrome] Could not restore pending helper discovery retry:",
@@ -26,7 +25,4 @@ export function startChromeBackground(): void {
     );
   });
 
-  chrome.runtime.onSuspend?.addListener(() => {
-    proxyManager.clear();
-  });
 }

--- a/packages/extension/src/background/firefox-proxy-manager.test.ts
+++ b/packages/extension/src/background/firefox-proxy-manager.test.ts
@@ -1,11 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { baseState, makePeer } from "@tailchrome/shared/__test__/fixtures";
-import type { HelperFailureKind } from "@tailchrome/shared/types";
 import { resetSessionStorage } from "../__test__/browser-mock";
-import {
-  FirefoxProxyManager,
-  RECONNECT_GATE_TIMEOUT_MS,
-} from "./firefox-proxy-manager";
+import { FirefoxProxyManager } from "./firefox-proxy-manager";
+
+function first(pm: FirefoxProxyManager, url: string) {
+  const result = pm.listener({ url });
+  return Array.isArray(result) ? result[0] : result;
+}
 
 describe("FirefoxProxyManager", () => {
   let pm: FirefoxProxyManager;
@@ -47,7 +48,7 @@ describe("FirefoxProxyManager", () => {
         }),
       );
 
-      expect(pm.listener({ url: "http://100.64.0.5" })).toMatchObject({
+      expect(first(pm, "http://100.64.0.5")).toMatchObject({
         type: "socks",
       });
     });
@@ -55,8 +56,7 @@ describe("FirefoxProxyManager", () => {
     it("clear() resets routing state so everything routes direct", () => {
       pm.apply(baseState());
       pm.clear();
-      const resolve = (url: string) =>
-        (pm as unknown as { resolveProxy(url: string): { type: string } }).resolveProxy(url);
+      const resolve = (url: string) => first(pm, url);
 
       expect(resolve("http://100.64.0.5").type).toBe("direct");
       expect(resolve("http://100.100.100.100").type).toBe("direct");
@@ -85,8 +85,7 @@ describe("FirefoxProxyManager", () => {
   describe("routing decisions", () => {
     it("routes Tailscale IPs through proxy, regular sites direct", () => {
       pm.apply(baseState());
-      const resolve = (url: string) =>
-        (pm as unknown as { resolveProxy(url: string): { type: string; port?: number } }).resolveProxy(url);
+      const resolve = (url: string) => first(pm, url);
 
       expect(resolve("http://google.com").type).toBe("direct");
       expect(resolve("http://100.64.0.5").type).toBe("socks");
@@ -95,8 +94,7 @@ describe("FirefoxProxyManager", () => {
 
     it("routes MagicDNS names through proxy", () => {
       pm.apply(baseState());
-      const resolve = (url: string) =>
-        (pm as unknown as { resolveProxy(url: string): { type: string } }).resolveProxy(url);
+      const resolve = (url: string) => first(pm, url);
 
       expect(resolve("http://my-server.example.ts.net").type).toBe("socks");
       expect(resolve("http://notexample.ts.net").type).toBe("direct");
@@ -104,8 +102,7 @@ describe("FirefoxProxyManager", () => {
 
     it("routes Tailscale IPv6 literals through the proxy", () => {
       pm.apply(baseState());
-      const resolve = (url: string) =>
-        (pm as unknown as { resolveProxy(url: string): { type: string } }).resolveProxy(url);
+      const resolve = (url: string) => first(pm, url);
 
       expect(resolve("http://[fd7a:115c:a1e0::1234]/").type).toBe("socks");
     });
@@ -116,56 +113,10 @@ describe("FirefoxProxyManager", () => {
           peers: [makePeer({ subnets: ["10.0.0.0/24", "172.16.0.0/12"] })],
         }),
       );
-      const resolve = (url: string) =>
-        (pm as unknown as { resolveProxy(url: string): { type: string } }).resolveProxy(url);
+      const resolve = (url: string) => first(pm, url);
 
       expect(resolve("http://10.0.0.50").type).toBe("socks");
       expect(resolve("http://172.32.0.1").type).toBe("direct");
-    });
-  });
-
-  describe("session storage persistence", () => {
-    it("persists proxy config to session storage on apply", async () => {
-      pm.apply(baseState({ proxyPort: 5555 }));
-
-      const restored = new FirefoxProxyManager();
-      expect(await restored.restoreFromStorage()).toBe(true);
-      expect(
-        (
-          restored as unknown as {
-            proxyPort: number;
-            magicDNSSuffix: string;
-            reconnectPromise: Promise<void> | null;
-          }
-        ).proxyPort,
-      ).toBe(0);
-      expect(
-        (
-          restored as unknown as {
-            proxyPort: number;
-            magicDNSSuffix: string;
-            reconnectPromise: Promise<void> | null;
-          }
-        ).magicDNSSuffix,
-      ).toBe("example.ts.net");
-      restored.clear();
-    });
-
-    it("preserves stored config through the disconnect path", async () => {
-      pm.apply(baseState());
-      pm.apply(
-        baseState({
-          hostConnected: false,
-          proxyEnabled: false,
-          proxyPort: null,
-          backendState: "NoState",
-        }),
-      );
-
-      const restored = new FirefoxProxyManager();
-      expect(await restored.restoreFromStorage()).toBe(true);
-      restored.clear();
-      pm.clear();
     });
   });
 
@@ -181,9 +132,8 @@ describe("FirefoxProxyManager", () => {
         },
         ...overrides,
       });
-    const resolveOf = (manager: FirefoxProxyManager) =>
-      (url: string) =>
-        (manager as unknown as { resolveProxy(url: string): { type: string } }).resolveProxy(url);
+    const resolveOf = (manager: FirefoxProxyManager) => (url: string) =>
+      first(manager, url);
 
     it("bypass mode: listed domain goes direct, others go through proxy", () => {
       pm.apply(
@@ -261,185 +211,34 @@ describe("FirefoxProxyManager", () => {
     });
   });
 
-  describe("listener wake flow", () => {
-    it("defers to restore and reconnect promises during wake", async () => {
-      pm.apply(baseState({ proxyPort: 3333 }));
-
-      const woken = new FirefoxProxyManager();
-      const restorePromise = woken.restoreFromStorage();
-      const result = woken.listener({ url: "http://100.64.0.5" });
-
-      expect(result).toBeInstanceOf(Promise);
-
-      await restorePromise;
-      woken.apply(baseState({ proxyPort: 4444 }));
-
-      const resolved = await result;
-      expect(resolved.type).toBe("socks");
-      expect((resolved as { port?: number }).port).toBe(4444);
-    });
-
-    it("keeps requests held through transient NoState updates", async () => {
-      pm.apply(baseState({ proxyPort: 3333 }));
-
-      const woken = new FirefoxProxyManager();
-      await woken.restoreFromStorage();
-      const result = woken.listener({ url: "http://100.64.0.5" });
-      expect(result).toBeInstanceOf(Promise);
-
-      woken.apply(
-        baseState({
-          hostConnected: false,
-          proxyEnabled: false,
-          proxyPort: null,
-          backendState: "NoState",
-        }),
-      );
-      let settled = false;
-      void Promise.resolve(result).then(() => {
-        settled = true;
-      });
-      await Promise.resolve();
-      expect(settled).toBe(false);
-
-      woken.apply(baseState({ proxyPort: 4444 }));
-      await expect(result).resolves.toMatchObject({ type: "socks", port: 4444 });
-    });
-
-    it("releases held requests on an authoritative stopped state", async () => {
-      pm.apply(baseState({ proxyPort: 3333 }));
-
-      const woken = new FirefoxProxyManager();
-      await woken.restoreFromStorage();
-      const result = woken.listener({ url: "http://100.64.0.5" });
-      woken.apply(
-        baseState({
-          hostConnected: true,
-          proxyEnabled: false,
-          proxyPort: null,
-          backendState: "Stopped",
-        }),
-      );
-
-      await expect(result).resolves.toMatchObject({ type: "direct" });
-    });
+  it("blocks requests before routing restoration completes", () => {
+    expect(pm.listener({ url: "https://example.com/" })).toEqual([
+      { type: "socks", host: "127.0.0.1", port: 1, proxyDNS: true },
+      null,
+    ]);
   });
 
-  describe("reconnect gate escape hatches", () => {
-    const transientDisconnect = () =>
+  it("terminates protected proxy chains without browser fallback", () => {
+    pm.apply(baseState());
+    expect(pm.listener({ url: "https://100.64.0.5/" })).toEqual([
+      { type: "socks", host: "127.0.0.1", port: 1055, proxyDNS: true },
+      null,
+    ]);
+  });
+
+  it("keeps protected traffic blocked after ten seconds", () => {
+    vi.useFakeTimers();
+    pm.apply(
       baseState({
-        hostConnected: false,
-        proxyEnabled: false,
-        proxyPort: null,
-        backendState: "NoState" as const,
-      });
-
-    it("fails open when the helper does not return before the gate deadline", async () => {
-      vi.useFakeTimers();
-      pm.apply(baseState({ proxyPort: 3333 }));
-
-      const woken = new FirefoxProxyManager();
-      await woken.restoreFromStorage();
-      const result = woken.listener({ url: "http://100.64.0.5" });
-      expect(result).toBeInstanceOf(Promise);
-
-      vi.advanceTimersByTime(RECONNECT_GATE_TIMEOUT_MS);
-      await expect(result).resolves.toMatchObject({ type: "direct" });
-
-      // The stored config is wiped so a later event-page restart cannot
-      // re-gate on it, and further transient updates do not re-arm the gate.
-      const restored = new FirefoxProxyManager();
-      expect(await restored.restoreFromStorage()).toBe(false);
-      woken.apply(transientDisconnect());
-      expect(
-        (woken as unknown as { reconnectPromise: Promise<void> | null })
-          .reconnectPromise,
-      ).toBeNull();
-      await expect(
-        Promise.resolve(woken.listener({ url: "http://100.64.0.5" })),
-      ).resolves.toMatchObject({ type: "direct" });
-    });
-
-    it("cancels the gate deadline once the proxy config is reapplied", async () => {
-      vi.useFakeTimers();
-      pm.apply(baseState({ proxyPort: 3333 }));
-
-      const woken = new FirefoxProxyManager();
-      await woken.restoreFromStorage();
-      const result = woken.listener({ url: "http://100.64.0.5" });
-
-      woken.apply(baseState({ proxyPort: 4444 }));
-      vi.advanceTimersByTime(RECONNECT_GATE_TIMEOUT_MS);
-
-      await expect(result).resolves.toMatchObject({
-        type: "socks",
-        port: 4444,
-      });
-      // The canceled deadline must not wipe the live or stored config.
-      expect(
-        (woken as unknown as { resolveProxy(url: string): { type: string } })
-          .resolveProxy("http://100.64.0.5").type,
-      ).toBe("socks");
-      const restored = new FirefoxProxyManager();
-      expect(await restored.restoreFromStorage()).toBe(true);
-    });
-
-    it.each([
-      "helper-unavailable",
-      "helper-not-allowed",
-      "helper-reported-error",
-      "helper-incompatible",
-    ] satisfies HelperFailureKind[])(
-      "releases held requests for authoritative %s failures",
-      async (kind) => {
-      pm.apply(baseState({ proxyPort: 3333 }));
-
-      const woken = new FirefoxProxyManager();
-      await woken.restoreFromStorage();
-      const result = woken.listener({ url: "http://100.64.0.5" });
-
-        woken.apply({
-          ...transientDisconnect(),
-          helperFailure: {
-            kind,
-            diagnosticCode: "fixture-authoritative-failure",
-            diagnosticMessage: null,
-          },
-        });
-
-      await expect(result).resolves.toMatchObject({ type: "direct" });
-      const restored = new FirefoxProxyManager();
-      expect(await restored.restoreFromStorage()).toBe(false);
-      },
+        prefs: {
+          exitNodeID: "missing",
+          exitNodeAllowLANAccess: false,
+          corpDNS: true,
+          shieldsUp: false,
+        },
+      }),
     );
-
-    it.each([
-      "helper-start-failed",
-      "helper-stopped",
-    ] satisfies HelperFailureKind[])(
-      "keeps held requests behind the reconnect deadline for transient %s",
-      async (kind) => {
-        pm.apply(baseState({ proxyPort: 3333 }));
-
-        const woken = new FirefoxProxyManager();
-        await woken.restoreFromStorage();
-        const result = woken.listener({ url: "http://100.64.0.5" });
-        woken.apply({
-          ...transientDisconnect(),
-          reconnecting: true,
-          helperFailure: {
-            kind,
-            diagnosticCode: "fixture-transient-failure",
-            diagnosticMessage: null,
-          },
-        });
-
-        woken.apply(baseState({ proxyPort: 4444 }));
-        await expect(result).resolves.toMatchObject({
-          type: "socks",
-          port: 4444,
-        });
-      },
-    );
+    vi.advanceTimersByTime(60_000);
+    expect(first(pm, "https://example.com/").port).toBe(1);
   });
 });

--- a/packages/extension/src/background/firefox-proxy-manager.ts
+++ b/packages/extension/src/background/firefox-proxy-manager.ts
@@ -18,6 +18,12 @@ import {
   CGNAT_MASK,
 } from "@tailchrome/shared/background/proxy-utils";
 
+import type { RoutingHealth } from "@tailchrome/shared/types";
+import {
+  BLOCKED_PROXY_PORT,
+  policyFromState,
+} from "@tailchrome/shared/background/routing-protection";
+
 export interface FirefoxProxyInfo {
   type: "socks" | "direct";
   host?: string;
@@ -25,244 +31,114 @@ export interface FirefoxProxyInfo {
   proxyDNS?: boolean;
 }
 
-type FirefoxProxyResult = FirefoxProxyInfo | Promise<FirefoxProxyInfo>;
-
 declare const browser: {
   proxy: {
     onRequest: {
       addListener(
-        listener: (details: { url: string }) => FirefoxProxyResult,
+        listener: (details: { url: string }) => unknown,
         filter: { urls: string[] },
       ): void;
-      removeListener(
-        listener: (details: { url: string }) => FirefoxProxyResult,
-      ): void;
-      hasListener(
-        listener: (details: { url: string }) => FirefoxProxyResult,
-      ): boolean;
+      hasListener(listener: (details: { url: string }) => unknown): boolean;
     };
-  };
-  storage: {
-    session: {
-      get(key: string): Promise<Record<string, unknown>>;
-      set(items: Record<string, unknown>): Promise<void>;
-      remove(key: string): Promise<void>;
-    };
+    onError: { addListener(listener: () => void): void };
   };
 };
 
-const STORAGE_KEY = "proxyConfig";
-
-// Upper bound on how long held requests wait for the helper to come back.
-// Reconnection retries forever (1s base backoff), so without a deadline a
-// helper that is gone for good would hold every browser request until the
-// user disables the extension. Past the deadline the gate fails open and
-// requests go direct, matching the authoritative stopped state.
-export const RECONNECT_GATE_TIMEOUT_MS = 10_000;
-
-interface StoredProxyConfig {
-  proxyPort: number;
-  magicDNSSuffix: string;
-  exitNodeActive: boolean;
-  subnetRanges: Array<{ network: number; mask: number }>;
-  splitMode: DomainSplitMode;
-  splitDomains: string[];
-}
-
 export class FirefoxProxyManager {
-  private proxyPort = 0;
+  private proxyPort = BLOCKED_PROXY_PORT;
   private magicDNSSuffix = "";
-  private exitNodeActive = false;
+  private exitNodeActive = true;
   private subnetRanges: Array<{ network: number; mask: number }> = [];
   private splitMode: DomainSplitMode = "bypass";
   private splitDomains: string[] = [];
-  private restorePromise: Promise<void> | null = null;
-  private reconnectPromise: Promise<void> | null = null;
-  private reconnectResolve: (() => void) | null = null;
-  private restoreGeneration = 0;
-  private restoreInFlight = false;
-  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private mode: "active" | "blocked" | "direct" = "blocked";
+  private failedKey = "";
+  private policyKey = "";
+  private healthListener: ((health: RoutingHealth) => void) | null = null;
 
-  readonly listener = (
-    details: { url: string },
-  ): FirefoxProxyInfo | Promise<FirefoxProxyInfo> => {
-    if (this.proxyPort === 0 && this.restorePromise) {
-      return this.restorePromise.then(() => {
-        if (this.reconnectPromise) {
-          return this.reconnectPromise.then(() =>
-            this.resolveProxy(details.url),
-          );
-        }
-        return this.resolveProxy(details.url);
+  constructor() {
+    browser.proxy.onError.addListener(() => {
+      this.failedKey = this.policyKey;
+      this.healthListener?.({
+        status: "unavailable",
+        message: "Firefox could not apply the routing settings.",
       });
-    }
+    });
+  }
 
-    if (this.reconnectPromise) {
-      return this.reconnectPromise.then(() => this.resolveProxy(details.url));
-    }
+  readonly listener = (details: {
+    url: string;
+  }): FirefoxProxyInfo | [FirefoxProxyInfo, null] =>
+    this.resolveProxy(details.url);
 
-    return this.resolveProxy(details.url);
-  };
+  setRoutingHealthListener(listener: (health: RoutingHealth) => void): void {
+    this.healthListener = listener;
+  }
 
   apply(state: TailscaleState): void {
-    if (!shouldProxyState(state)) {
-      const failureKind = state.helperFailure?.kind;
-      const authoritativeFailure =
-        failureKind === "helper-unavailable" ||
-        failureKind === "helper-not-allowed" ||
-        failureKind === "helper-reported-error" ||
-        failureKind === "helper-incompatible";
-      const transient =
-        !authoritativeFailure &&
-        (!state.hostConnected ||
-          state.backendState === "NoState" ||
-          state.backendState === "Starting");
-
-      if (transient) {
-        // During startup/reconnect, preserve the last known configuration and
-        // hold requests until Running, an authoritative stopped/login state,
-        // or the gate deadline.
-        if (
-          this.restoreInFlight ||
-          this.reconnectPromise ||
-          this.proxyPort !== 0 ||
-          this.magicDNSSuffix !== ""
-        ) {
-          this.proxyPort = 0;
-          this.beginReconnectGate();
-        }
-        return;
-      }
-
-      this.restoreGeneration += 1;
-      this.clear();
-      void browser.storage.session.remove(STORAGE_KEY);
-      return;
-    }
-
-    this.restoreGeneration += 1;
-    this.proxyPort = state.proxyPort!;
-    this.exitNodeActive = state.exitNode !== null;
-    this.magicDNSSuffix = sanitizeMagicDNSSuffix(state.magicDNSSuffix);
-    this.subnetRanges = collectSubnetCIDRs(state.peers)
+    const policy = policyFromState(state);
+    const nextKey = JSON.stringify(policy);
+    if (nextKey !== this.policyKey) this.failedKey = "";
+    this.policyKey = nextKey;
+    if (this.failedKey === this.policyKey) return;
+    this.mode = policy.mode;
+    this.proxyPort = policy.proxyPort ?? BLOCKED_PROXY_PORT;
+    this.exitNodeActive =
+      policy.blockAll === true || policy.selectedExitNodeID !== null;
+    this.magicDNSSuffix = sanitizeMagicDNSSuffix(policy.magicDNSSuffix);
+    this.subnetRanges = policy.subnetCIDRs
       .map((cidr) => parseCIDR(cidr))
       .filter((r): r is { network: number; mask: number } => r !== null);
-    this.splitMode = state.domainSplit.mode;
-    this.splitDomains = sanitizeSplitDomains(state.domainSplit);
-    this.releaseReconnectGate();
-
-    if (!browser.proxy.onRequest.hasListener(this.listener)) {
-      browser.proxy.onRequest.addListener(this.listener, {
-        urls: ["<all_urls>"],
+    this.splitMode = policy.domainSplit.mode;
+    this.splitDomains = sanitizeSplitDomains(policy.domainSplit);
+    try {
+      if (!browser.proxy.onRequest.hasListener(this.listener)) {
+        browser.proxy.onRequest.addListener(this.listener, {
+          urls: ["<all_urls>"],
+        });
+      }
+      this.healthListener?.(
+        this.mode === "blocked"
+          ? {
+              status: "blocked",
+              message: this.exitNodeActive
+                ? "Exit node unavailable — protected browsing is blocked."
+                : "Connection unavailable — tailnet browsing is blocked.",
+            }
+          : {
+              status: this.mode === "active" ? "active" : "inactive",
+              message: "",
+            },
+      );
+    } catch {
+      this.healthListener?.({
+        status: "unavailable",
+        message: "Firefox could not apply the routing settings.",
       });
     }
-
-    void this.persistToStorage();
   }
 
   clear(): void {
-    this.proxyPort = 0;
-    this.magicDNSSuffix = "";
-    this.exitNodeActive = false;
-    this.subnetRanges = [];
-    this.splitMode = "bypass";
-    this.splitDomains = [];
-    this.releaseReconnectGate();
+    this.mode = "direct";
+    this.healthListener?.({ status: "inactive", message: "" });
   }
 
-  restoreFromStorage(): Promise<boolean> {
-    const generation = this.restoreGeneration;
-    this.restoreInFlight = true;
-    const restore = async (): Promise<boolean> => {
-      const result = await browser.storage.session.get(STORAGE_KEY);
-      if (generation !== this.restoreGeneration) {
-        return false;
-      }
-      const config = result[STORAGE_KEY] as StoredProxyConfig | undefined;
-      if (!config || !config.proxyPort) {
-        return false;
-      }
-
-      this.magicDNSSuffix = config.magicDNSSuffix;
-      this.exitNodeActive = config.exitNodeActive;
-      this.subnetRanges = config.subnetRanges;
-      this.splitMode = config.splitMode ?? "bypass";
-      this.splitDomains = Array.isArray(config.splitDomains)
-        ? config.splitDomains
-        : [];
-      this.beginReconnectGate();
-      return true;
-    };
-
-    const promise = restore();
-    // Request listeners only need to wait until the attempt is finished. Keep
-    // restoration failures on the original promise so the startup logger owns
-    // them instead of creating a second unhandled rejection here.
-    this.restorePromise = promise.then(
-      () => {},
-      () => {},
-    );
-    void promise.then(
-      () => {
-        this.restoreInFlight = false;
-      },
-      () => {
-        this.restoreInFlight = false;
-      },
-    );
-    return promise;
-  }
-
-  private beginReconnectGate(): void {
-    if (this.reconnectPromise) return;
-    this.reconnectPromise = new Promise<void>((resolve) => {
-      this.reconnectResolve = resolve;
-    });
-    // The gate and its held promises are in-memory, so they cannot outlive
-    // the event page — a plain timer is enough, no alarm needed.
-    this.reconnectTimer = setTimeout(() => {
-      this.reconnectTimer = null;
-      this.restoreGeneration += 1;
-      this.clear();
-      void browser.storage.session.remove(STORAGE_KEY);
-    }, RECONNECT_GATE_TIMEOUT_MS);
-  }
-
-  private releaseReconnectGate(): void {
-    if (this.reconnectTimer !== null) {
-      clearTimeout(this.reconnectTimer);
-      this.reconnectTimer = null;
-    }
-    if (this.reconnectResolve) {
-      this.reconnectResolve();
-      this.reconnectResolve = null;
-    }
-    this.reconnectPromise = null;
-  }
-
-  private async persistToStorage(): Promise<void> {
-    const config: StoredProxyConfig = {
-      proxyPort: this.proxyPort,
-      magicDNSSuffix: this.magicDNSSuffix,
-      exitNodeActive: this.exitNodeActive,
-      subnetRanges: this.subnetRanges,
-      splitMode: this.splitMode,
-      splitDomains: this.splitDomains,
-    };
-    await browser.storage.session.set({ [STORAGE_KEY]: config });
-  }
-
-  private resolveProxy(url: string): FirefoxProxyInfo {
+  private resolveProxy(
+    url: string,
+  ): FirefoxProxyInfo | [FirefoxProxyInfo, null] {
     const direct: FirefoxProxyInfo = { type: "direct" };
 
-    if (this.proxyPort === 0) return direct;
+    if (this.mode === "direct") return direct;
 
-    const proxy: FirefoxProxyInfo = {
-      type: "socks",
-      host: "127.0.0.1",
-      port: this.proxyPort,
-      proxyDNS: true,
-    };
+    const proxy: [FirefoxProxyInfo, null] = [
+      {
+        type: "socks",
+        host: "127.0.0.1",
+        port: this.mode === "blocked" ? BLOCKED_PROXY_PORT : this.proxyPort,
+        proxyDNS: true,
+      },
+      null,
+    ];
 
     let host: string;
     try {
@@ -284,8 +160,7 @@ export class FirefoxProxyManager {
 
     if (
       this.magicDNSSuffix &&
-      (host === this.magicDNSSuffix ||
-        host.endsWith(`.${this.magicDNSSuffix}`))
+      (host === this.magicDNSSuffix || host.endsWith(`.${this.magicDNSSuffix}`))
     ) {
       return proxy;
     }

--- a/packages/extension/src/background/firefox.test.ts
+++ b/packages/extension/src/background/firefox.test.ts
@@ -208,22 +208,6 @@ describe("startFirefoxBackground", () => {
     expect(mocks.sendKeepalive).toHaveBeenCalledTimes(1);
   });
 
-  it("logs startup failures when restoreFromStorage rejects", async () => {
-    const error = new Error("restore failed");
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    mocks.restoreFromStorage.mockRejectedValue(error);
-
-    startFirefoxBackground();
-    await flushMicrotasks();
-
-    expect(errorSpy).toHaveBeenCalledWith(
-      "[Firefox] Background start failed:",
-      "restore failed",
-    );
-
-    errorSpy.mockRestore();
-  });
-
   it("logs sanitized helper retry restoration failures", async () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     mocks.restoreFromStorage.mockResolvedValue(true);

--- a/packages/extension/src/background/firefox.ts
+++ b/packages/extension/src/background/firefox.ts
@@ -52,11 +52,7 @@ export function startFirefoxBackground(): void {
     }
   });
 
-  // Begin restoration before the shared background can emit state, but
-  // register every runtime listener synchronously during initial evaluation.
-  // Startup/installed events dispatch after this tick, so the shared
-  // background's own synchronously registered listeners observe them all.
-  const restorePromise = proxyManager.restoreFromStorage();
+  // The listener blocks until the shared background restores routing intent.
   backgroundHandle = initBackground(proxyManager, FIREFOX_NATIVE_HOST_ID, {
     skipKeepalive: true,
     browserKind: "firefox",
@@ -67,7 +63,7 @@ export function startFirefoxBackground(): void {
     periodInMinutes: KEEPALIVE_PERIOD_MINUTES,
   });
 
-  void Promise.all([restorePromise, retryRestorePromise])
+  void Promise.all([retryRestorePromise])
     .catch((err) => {
       console.error(
         "[Firefox] Background start failed:",

--- a/packages/shared/src/__test__/chrome-mock.ts
+++ b/packages/shared/src/__test__/chrome-mock.ts
@@ -6,6 +6,7 @@ const storageChangedListeners: Array<
   (changes: Record<string, { oldValue?: unknown; newValue?: unknown }>, area: string) => void
 > = [];
 
+let proxyValue: unknown = { mode: "system" };
 const chromeMock = {
   action: {
     setIcon: (_details: unknown) => Promise.resolve(),
@@ -18,10 +19,15 @@ const chromeMock = {
     },
   },
   proxy: {
+    onProxyError: { addListener: (_fn: (details: unknown) => void) => {} },
     settings: {
-      set: (_details: unknown, cb?: () => void) => {
+      set: (details: { value: unknown }, cb?: () => void) => {
+        proxyValue = details.value;
         cb?.();
       },
+      get: (_details: unknown, cb: (details: unknown) => void) => cb({ value: proxyValue, levelOfControl: "controlled_by_this_extension" }),
+      clear: (_details: unknown, cb?: () => void) => { proxyValue = { mode: "system" }; cb?.(); },
+      onChange: { addListener: (_fn: (details: unknown) => void) => {} },
     },
   },
   runtime: {

--- a/packages/shared/src/background/background.test.ts
+++ b/packages/shared/src/background/background.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import type { ProxyManager, TailscaleState, NativeReply } from "../types";
+import type { ProxyManager, TailscaleState, NativeReply, RoutingHealth } from "../types";
 import {
   getHelperVersionNotice,
   initBackground,
@@ -1064,6 +1064,84 @@ describe("initBackground", () => {
         expect.objectContaining({ pendingExitNodeID: "" }),
       );
       expect(chrome.storage.local.remove).toHaveBeenCalledWith("lastExitNodeID");
+    });
+
+    it.each([true, false])("waits for normal routing before login (existing URL: %s)", async (existingURL) => {
+      let reportHealth!: (health: RoutingHealth) => void;
+      proxyManager.setRoutingHealthListener = (listener) => { reportHealth = listener; };
+      await setupBackground();
+      advertiseLoginSupport();
+      sendNativeMessage({ status: {
+        backendState: "NeedsLogin", running: false, tailnet: null,
+        magicDNSSuffix: "", selfNode: null, needsLogin: true,
+        browseToURL: existingURL ? "https://login.tailscale.com/auth/xyz" : "",
+        exitNode: null, peers: [], prefs: null, health: [], error: null,
+      } });
+      const popupPort = createPopupPort();
+      connectListeners[0]!(popupPort);
+      nativePort.postMessage.mockClear();
+      popupPort.onMessage._listeners[0]!({ type: "disconnect-and-login" });
+      expect(proxyManager.apply).toHaveBeenLastCalledWith(expect.objectContaining({
+        routingPolicy: expect.objectContaining({ mode: "direct" }),
+      }));
+      expect(chrome.tabs.create).not.toHaveBeenCalled();
+      expect(nativePort.postMessage).not.toHaveBeenCalledWith({ cmd: "login" });
+      reportHealth({ status: "blocked", message: "Waiting for settings" });
+      expect(chrome.tabs.create).not.toHaveBeenCalled();
+      reportHealth({ status: "inactive", message: "" });
+      if (existingURL) {
+        expect(chrome.tabs.create).toHaveBeenCalledExactlyOnceWith({ url: "https://login.tailscale.com/auth/xyz" });
+      } else {
+        expect(nativePort.postMessage).toHaveBeenCalledExactlyOnceWith({ cmd: "login" });
+      }
+    });
+
+    it("cancels a waiting login when the user disconnects", async () => {
+      let reportHealth!: (health: RoutingHealth) => void;
+      proxyManager.setRoutingHealthListener = (listener) => { reportHealth = listener; };
+      await setupBackground();
+      sendNativeMessage({ status: {
+        backendState: "NeedsLogin", running: false, tailnet: null,
+        magicDNSSuffix: "", selfNode: null, needsLogin: true,
+        browseToURL: "https://login.tailscale.com/auth/xyz",
+        exitNode: null, peers: [], prefs: null, health: [], error: null,
+      } });
+      const popupPort = createPopupPort();
+      connectListeners[0]!(popupPort);
+      popupPort.onMessage._listeners[0]!({ type: "disconnect-and-login" });
+      popupPort.onMessage._listeners[0]!({ type: "release-routing" });
+      reportHealth({ status: "inactive", message: "" });
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(chrome.tabs.create).not.toHaveBeenCalled();
+      expect(popupPort.postMessage).not.toHaveBeenCalledWith(expect.objectContaining({
+        type: "toast", message: "Could not restore normal browsing. Check browser routing and try again.",
+      }));
+    });
+
+    it("does not open login when restoring normal routing times out", async () => {
+      let reportHealth!: (health: RoutingHealth) => void;
+      proxyManager.setRoutingHealthListener = (listener) => { reportHealth = listener; };
+      await setupBackground();
+      sendNativeMessage({ status: {
+        backendState: "NeedsLogin", running: false, tailnet: null,
+        magicDNSSuffix: "", selfNode: null, needsLogin: true,
+        browseToURL: "https://login.tailscale.com/auth/xyz",
+        exitNode: null, peers: [], prefs: null, health: [], error: null,
+      } });
+      const popupPort = createPopupPort();
+      connectListeners[0]!(popupPort);
+      popupPort.onMessage._listeners[0]!({ type: "disconnect-and-login" });
+      reportHealth({ status: "unavailable", message: "Browser rejected settings" });
+      await vi.advanceTimersByTimeAsync(5_000);
+      reportHealth({ status: "inactive", message: "" });
+      expect(chrome.tabs.create).not.toHaveBeenCalled();
+      expect(popupPort.postMessage).toHaveBeenCalledWith(expect.objectContaining({
+        type: "toast", message: "Could not restore normal browsing. Check browser routing and try again.",
+      }));
+      popupPort.onMessage._listeners[0]!({ type: "login" });
+      expect(chrome.tabs.create).not.toHaveBeenCalled();
+      reportHealth({ status: "inactive", message: "" });
+      expect(chrome.tabs.create).toHaveBeenCalledExactlyOnceWith({ url: "https://login.tailscale.com/auth/xyz" });
     });
 
     it("handles login with valid URL", async () => {

--- a/packages/shared/src/background/background.test.ts
+++ b/packages/shared/src/background/background.test.ts
@@ -1045,7 +1045,7 @@ describe("initBackground", () => {
       expect(proxyManager.apply).toHaveBeenCalledWith(
         expect.objectContaining({ pendingExitNodeID: "node123" }),
       );
-      expect(chrome.storage.local.set).toHaveBeenCalledWith({ lastExitNodeID: "node123" });
+      expect(chrome.storage.local.set).not.toHaveBeenCalledWith({ lastExitNodeID: "node123" });
     });
 
     it("handles clear-exit-node message", async () => {
@@ -2276,7 +2276,7 @@ describe("initBackground", () => {
   });
 
   describe("exit node restoration", () => {
-    it("restores saved exit node on first Running status without exit node", async () => {
+    it("does not restore an unscoped legacy exit node into an unknown account", async () => {
       (chrome.storage.local.get as ReturnType<typeof vi.fn>).mockResolvedValue({
         profileId: "test-id",
         lastExitNodeID: "saved-exit-node",
@@ -2305,7 +2305,7 @@ describe("initBackground", () => {
       // Let storage.get promise resolve
       await vi.advanceTimersByTimeAsync(0);
 
-      expect(nativePort.postMessage).toHaveBeenCalledWith({
+      expect(nativePort.postMessage).not.toHaveBeenCalledWith({
         cmd: "set-exit-node",
         nodeID: "saved-exit-node",
       });

--- a/packages/shared/src/background/background.test.ts
+++ b/packages/shared/src/background/background.test.ts
@@ -3088,6 +3088,26 @@ describe("initBackground", () => {
         );
       });
 
+      it("blocks while deleting the current profile and ignores unrelated command errors", async () => {
+        await setupBackground();
+        sendNativeMessage({
+          profiles: {
+            current: { id: "p1", name: "A" },
+            profiles: [{ id: "p1", name: "A" }],
+          },
+        });
+        const popupPort = createPopupPort();
+        connectListeners[0]!(popupPort);
+        popupPort.onMessage._listeners[0]!({ type: "delete-profile", profileID: "p1" });
+        expect(proxyManager.apply).toHaveBeenLastCalledWith(expect.objectContaining({
+          routingPolicy: expect.objectContaining({ mode: "blocked", blockAll: true }),
+        }));
+        sendNativeMessage({ error: { cmd: "set-prefs", message: "Earlier preference update failed" } });
+        expect(proxyManager.apply).toHaveBeenLastCalledWith(expect.objectContaining({
+          routingPolicy: expect.objectContaining({ mode: "blocked", blockAll: true }),
+        }));
+      });
+
       it("keeps the stay-down intent when deleting a non-current profile", async () => {
         (chrome.storage.session.get as ReturnType<typeof vi.fn>).mockResolvedValue({
           desiredWantRunning: false,

--- a/packages/shared/src/background/background.ts
+++ b/packages/shared/src/background/background.ts
@@ -17,6 +17,7 @@ import {
   isValidControlURL,
 } from "../constants";
 import { StateStore } from "./state-store";
+import { RoutingProtection } from "./routing-protection";
 import {
   NativeHostConnection,
   type NativeConnectionEvent,
@@ -337,8 +338,10 @@ export function initBackground(
     .catch(logUiSurfaceFailure);
 
   const store = new StateStore();
+  const routing = new RoutingProtection();
+  const routingReady = routing.restore();
 
-  void readDomainSplit()
+  const domainSplitReady = readDomainSplit()
     .then((config) => {
       if (!domainSplitEquals(store.getState().domainSplit, config)) {
         store.update({ domainSplit: config });
@@ -546,10 +549,21 @@ export function initBackground(
     );
   }
 
+  proxyManager.setRoutingHealthListener?.((health) => {
+    if (JSON.stringify(store.getState().routingHealth) !== JSON.stringify(health)) {
+      store.update({ routingHealth: health });
+    }
+  });
   store.subscribe((state: TailscaleState) => {
-    proxyManager.apply(state);
-    badgeManager.update(state);
-    broadcastToPopup(state);
+    const routed = routing.decorate(state);
+    proxyManager.apply(routed);
+    const current = routing.decorate(store.getState());
+    badgeManager.update(current);
+    broadcastToPopup(current);
+  });
+  proxyManager.apply(routing.decorate(store.getState()));
+  void Promise.all([routingReady, domainSplitReady]).then(() => {
+    proxyManager.apply(routing.decorate(store.getState()));
   });
 
   function diagnosticFrom(
@@ -684,6 +698,7 @@ export function initBackground(
     // Status update
     if (msg.status) {
       latestBackendState = msg.status.backendState;
+      routing.confirmStatus(msg.status, store.getState());
       store.applyStatusUpdate(msg.status);
 
       // Drop the saved exit node once the host confirms a real coordination
@@ -697,6 +712,7 @@ export function initBackground(
         controlServerChanged(confirmedControlURL, lastConfirmedControlURL)
       ) {
         lastConfirmedControlURL = confirmedControlURL;
+        exitNodeRestoreAttempted = false;
         void chrome.storage.local.remove("lastExitNodeID");
       }
 
@@ -728,29 +744,13 @@ export function initBackground(
         }
       }
 
-      // Restore saved exit node after reconnection
-      if (
-        !exitNodeRestoreAttempted &&
-        msg.status.backendState === "Running" &&
-        !msg.status.exitNode
-      ) {
+      // Restore only the saved selection for this confirmed account.
+      const selected = routing.decorate(store.getState()).selectedExitNodeID;
+      if (!exitNodeRestoreAttempted && msg.status.backendState === "Running" && selected) {
         exitNodeRestoreAttempted = true;
-        chrome.storage.local.get("lastExitNodeID").then((result) => {
-          const lastExitNodeID = result["lastExitNodeID"];
-          if (typeof lastExitNodeID === "string" && lastExitNodeID) {
-            console.log(
-              "[Background] Restoring saved exit node:",
-              lastExitNodeID
-            );
-            nativeHost.send({
-              cmd: "set-exit-node",
-              nodeID: lastExitNodeID,
-            });
-          }
-        });
-      } else if (msg.status.backendState === "Running" && msg.status.exitNode) {
-        // Mark as attempted if already has an exit node
-        exitNodeRestoreAttempted = true;
+        if (selected !== (msg.status.prefs?.exitNodeID || msg.status.exitNode?.id)) {
+          nativeHost.send({ cmd: "set-exit-node", nodeID: selected });
+        }
       }
 
       maybeAutoConnect(msg.status.backendState);
@@ -805,6 +805,7 @@ export function initBackground(
 
     // Error from native host
     if (msg.error) {
+      if (["switch-profile", "new-profile", "set-prefs"].includes(msg.error.cmd)) routing.cancelTransition();
       const safeCommand = /^[a-z][a-z0-9-]{0,48}$/.test(msg.error.cmd)
         ? msg.error.cmd
         : "unknown";
@@ -977,9 +978,13 @@ export function initBackground(
     handleNativeConnectionEvent,
     timerService,
     async () => {
+      await Promise.all([routingReady, domainSplitReady]);
       // A decision already made this lifetime is fresher than storage — a
       // reconnect must restore it even when the session write had failed.
-      if (sessionIntentMirror !== undefined) return sessionIntentMirror;
+      if (sessionIntentMirror !== undefined) {
+        if (sessionIntentMirror) routing.reconnect();
+        return sessionIntentMirror;
+      }
       const sessionIntent = await readSessionIntent();
       let resolved: boolean;
       if (sessionIntent !== undefined) {
@@ -1006,6 +1011,8 @@ export function initBackground(
       }
       // A user action that landed while the resolution was in flight wins.
       sessionIntentMirror ??= resolved;
+      if (sessionIntentMirror) routing.reconnect();
+      proxyManager.apply(routing.decorate(store.getState()));
       await enqueueIntentWrite(false);
       return sessionIntentMirror;
     },
@@ -1068,6 +1075,7 @@ export function initBackground(
         return markAutoConnectHandled().then(() => {
           // Record the intent before sending so the auto-disconnect fallback
           // can never read a stale "stay down" while this `up` is in flight.
+          routing.reconnect();
           recordIntent(true);
           if (!nativeHost.send({ cmd: "up" })) {
             sendToastToPopup(NATIVE_HOST_UNREACHABLE, "error");
@@ -1257,7 +1265,7 @@ export function initBackground(
     // Immediately send current state to the newly connected popup
     const stateMsg: PopupMessage = {
       type: "state",
-      state: store.getState(),
+      state: routing.decorate(store.getState()),
     };
     try {
       port.postMessage(stateMsg);
@@ -1279,6 +1287,13 @@ export function initBackground(
     const state = store.getState();
 
     switch (msg.type) {
+      case "release-routing": {
+        routing.release();
+        recordIntent(false);
+        nativeHost.send({ cmd: "down" });
+        store.update({ routingHealth: { status: "unavailable", message: "Restoring normal browsing…" } });
+        break;
+      }
       case "toggle": {
         if (state.backendState === "Running") {
           // Treat manual disconnect as an explicit decision so a later SW
@@ -1286,6 +1301,7 @@ export function initBackground(
           void markAutoConnectHandled().catch((err) => {
             console.warn("[Background] markAutoConnectHandled failed:", err);
           });
+          routing.requestDisconnect();
           recordIntent(false);
           if (!nativeHost.send({ cmd: "down" })) {
             sendToastToPopup(NATIVE_HOST_UNREACHABLE, "error");
@@ -1294,6 +1310,7 @@ export function initBackground(
           state.backendState === "Stopped" ||
           state.backendState === "NoState"
         ) {
+          routing.reconnect();
           recordIntent(true);
           if (!nativeHost.send({ cmd: "up" })) {
             sendToastToPopup(NATIVE_HOST_UNREACHABLE, "error");
@@ -1319,6 +1336,7 @@ export function initBackground(
         // helpers that predate the wantRunning hint connect right after auth.
         // Record the intent so a later host respawn or the auto-disconnect
         // fallback doesn't yank a freshly logged-in user offline.
+        routing.reconnect();
         recordIntent(true);
         if (
           state.browseToURL &&
@@ -1363,13 +1381,14 @@ export function initBackground(
       }
 
       case "set-exit-node": {
+        routing.selectExitNode(msg.nodeID);
         store.update({ pendingExitNodeID: msg.nodeID });
         nativeHost.send({ cmd: "set-exit-node", nodeID: msg.nodeID });
-        chrome.storage.local.set({ lastExitNodeID: msg.nodeID });
         break;
       }
 
       case "clear-exit-node": {
+        routing.selectExitNode("");
         store.update({ pendingExitNodeID: "" });
         nativeHost.send({ cmd: "set-exit-node", nodeID: "" });
         chrome.storage.local.remove("lastExitNodeID");
@@ -1401,6 +1420,7 @@ export function initBackground(
           // *confirms* the change (see the status handler) rather than here, so
           // a rolled-back switch doesn't permanently lose it.
           if (controlServerChanged(msg.value, state.prefs?.controlURL)) {
+            routing.switchProfile();
             store.update({ browseToURL: "" });
           }
         }
@@ -1412,12 +1432,19 @@ export function initBackground(
       }
 
       case "switch-profile": {
+        if (msg.profileID === state.currentProfile?.id) break;
+        exitNodeRestoreAttempted = false;
+        routing.switchProfile();
+        store.update({ routingHealth: { status: "blocked", message: "Switching accounts — browsing is blocked." } });
         clearIntent();
         nativeHost.send({ cmd: "switch-profile", profileID: msg.profileID });
         break;
       }
 
       case "new-profile": {
+        exitNodeRestoreAttempted = false;
+        routing.switchProfile();
+        store.update({ routingHealth: { status: "blocked", message: "Switching accounts — browsing is blocked." } });
         clearIntent();
         nativeHost.send({ cmd: "new-profile" });
         break;

--- a/packages/shared/src/background/background.ts
+++ b/packages/shared/src/background/background.ts
@@ -73,6 +73,7 @@ export interface InitBackgroundOptions {
 
 const LOGIN_OPEN_TIMEOUT_MS = 30_000;
 const LOGIN_OPEN_TIMEOUT_NAME = "login-open-timeout";
+const LOGIN_ROUTING_TIMEOUT_NAME = "login-routing-timeout";
 
 // How long the update corrector waits for onStartup before trusting that an
 // onInstalled("update") happened mid-session. Both events of one service-worker
@@ -527,6 +528,7 @@ export function initBackground(
       console.warn("[Background] readAutoConnectPref failed:", err);
     });
   let pendingLoginOpen = false;
+  let pendingLoginRouting = false;
 
   function clearPendingLoginOpen(): void {
     pendingLoginOpen = false;
@@ -552,6 +554,18 @@ export function initBackground(
   proxyManager.setRoutingHealthListener?.((health) => {
     if (JSON.stringify(store.getState().routingHealth) !== JSON.stringify(health)) {
       store.update({ routingHealth: health });
+    }
+    if (
+      pendingLoginRouting &&
+      (!routing.isLoginPending() ||
+        (health.status === "inactive" &&
+          routing.decorate(store.getState()).routingPolicy?.mode === "direct"))
+    ) {
+      pendingLoginRouting = false;
+      timerService.clear(LOGIN_ROUTING_TIMEOUT_NAME);
+      if (routing.isLoginPending() && store.getState().backendState === "NeedsLogin") {
+        requestLogin();
+      }
     }
   });
   store.subscribe((state: TailscaleState) => {
@@ -1284,6 +1298,35 @@ export function initBackground(
     });
   });
 
+  function requestLogin(): void {
+    const state = store.getState();
+    // Logging in is an explicit request to bring the node online, and
+    // helpers that predate the wantRunning hint connect right after auth.
+    // Record the intent so a later host respawn or the auto-disconnect
+    // fallback doesn't yank a freshly logged-in user offline.
+    routing.reconnect();
+    recordIntent(true);
+    if (
+      state.browseToURL &&
+      isValidLoginURL(state.browseToURL, state.prefs?.controlURL ?? null)
+    ) {
+      chrome.tabs.create({ url: state.browseToURL });
+    } else if (!state.supportsLogin) {
+      sendToastToPopup(
+        "Please update the native helper to request a fresh Tailscale login URL.",
+        "error",
+      );
+    } else if (!nativeHost.send({ cmd: "login" })) {
+      clearPendingLoginOpen();
+      sendToastToPopup(
+        "Could not request a Tailscale login URL. Please check that the native host is installed.",
+        "error",
+      );
+    } else {
+      startPendingLoginOpen();
+    }
+  }
+
   function handlePopupMessage(msg: BackgroundMessage): void {
     const state = store.getState();
 
@@ -1328,35 +1371,27 @@ export function initBackground(
         break;
       }
 
+      case "disconnect-and-login":
       case "login": {
-        if (pendingLoginOpen) {
+        if (pendingLoginOpen || pendingLoginRouting) {
           sendToastToPopup("Still waiting for Tailscale to return a login URL.", "info");
           break;
         }
-        // Logging in is an explicit request to bring the node online, and
-        // helpers that predate the wantRunning hint connect right after auth.
-        // Record the intent so a later host respawn or the auto-disconnect
-        // fallback doesn't yank a freshly logged-in user offline.
-        routing.reconnect();
-        recordIntent(true);
-        if (
-          state.browseToURL &&
-          isValidLoginURL(state.browseToURL, state.prefs?.controlURL ?? null)
-        ) {
-          chrome.tabs.create({ url: state.browseToURL });
-        } else if (!state.supportsLogin) {
-          sendToastToPopup(
-            "Please update the native helper to request a fresh Tailscale login URL.",
-            "error",
-          );
-        } else if (!nativeHost.send({ cmd: "login" })) {
-          clearPendingLoginOpen();
-          sendToastToPopup(
-            "Could not request a Tailscale login URL. Please check that the native host is installed.",
-            "error",
-          );
+        if (msg.type === "disconnect-and-login") {
+          if (state.backendState !== "NeedsLogin") break;
+          routing.startLogin();
+          recordIntent(true);
+        }
+        if (routing.isLoginPending()) {
+          pendingLoginRouting = true;
+          timerService.setTimeout(LOGIN_ROUTING_TIMEOUT_NAME, () => {
+            pendingLoginRouting = false;
+            sendToastToPopup("Could not restore normal browsing. Check browser routing and try again.", "error");
+          }, 5_000);
+          // Chrome confirms the cleared settings before opening the login tab.
+          proxyManager.apply(routing.decorate(store.getState()));
         } else {
-          startPendingLoginOpen();
+          requestLogin();
         }
         break;
       }

--- a/packages/shared/src/background/background.ts
+++ b/packages/shared/src/background/background.ts
@@ -805,7 +805,8 @@ export function initBackground(
 
     // Error from native host
     if (msg.error) {
-      if (["switch-profile", "new-profile", "set-prefs"].includes(msg.error.cmd)) routing.cancelTransition();
+      // Errors carry no request ID, so an older failure must not release a
+      // newer account transition. Wait for a confirmed account or user release.
       const safeCommand = /^[a-z][a-z0-9-]{0,48}$/.test(msg.error.cmd)
         ? msg.error.cmd
         : "unknown";
@@ -1361,6 +1362,8 @@ export function initBackground(
       }
 
       case "logout": {
+        routing.requestDisconnect();
+        recordIntent(false);
         nativeHost.send({ cmd: "logout" });
         break;
       }
@@ -1454,6 +1457,9 @@ export function initBackground(
         // Deleting the current profile implicitly switches profiles; deleting
         // another profile leaves the current decision in force.
         if (state.currentProfile?.id === msg.profileID) {
+          exitNodeRestoreAttempted = false;
+          routing.switchProfile();
+          store.update({ routingHealth: { status: "blocked", message: "Switching accounts — browsing is blocked." } });
           clearIntent();
         }
         nativeHost.send({

--- a/packages/shared/src/background/badge-manager.ts
+++ b/packages/shared/src/background/badge-manager.ts
@@ -35,7 +35,7 @@ export class BadgeManager {
     if (badgeKey === this.lastBadgeKey) return;
     this.lastBadgeKey = badgeKey;
 
-    if (state.helperFailure) {
+    if (state.helperFailure || (state.routingHealth && !["active", "inactive"].includes(state.routingHealth.status))) {
       this.setIcon(WARNING_ICONS);
       this.setBadge("!", BADGE_COLOR_ORANGE);
       return;
@@ -80,6 +80,7 @@ export class BadgeManager {
   private computeBadgeKey(state: TailscaleState): string {
     return [
       state.helperFailure?.kind ?? "",
+      state.routingHealth?.status ?? "",
       state.hostConnected ? "conn" : "disc",
       state.backendState,
       state.exitNode !== null ? "exit" : "noexit",

--- a/packages/shared/src/background/routing-protection.test.ts
+++ b/packages/shared/src/background/routing-protection.test.ts
@@ -1,0 +1,332 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import type { StatusUpdate, TailscaleState } from "../types";
+import { baseState, makePeer } from "../__test__/fixtures";
+import { RoutingProtection, ROUTING_STORAGE_KEY } from "./routing-protection";
+
+const prefs = {
+  exitNodeID: "exit1",
+  exitNodeAllowLANAccess: false,
+  corpDNS: true,
+  shieldsUp: false,
+};
+function connected(overrides: Partial<TailscaleState> = {}): TailscaleState {
+  return baseState({
+    selfNode: { ...makePeer(), keyExpiry: null, id: "self1" },
+    prefs,
+    exitNode: {
+      id: "exit1",
+      hostname: "exit",
+      dnsName: "exit.example.ts.net",
+      online: true,
+      location: null,
+    },
+    ...overrides,
+  });
+}
+function status(state: TailscaleState): StatusUpdate {
+  return {
+    ...state,
+    running: state.backendState === "Running",
+    needsLogin: false,
+    browseToURL: "",
+    magicDNSSuffix: state.magicDNSSuffix || "",
+  };
+}
+const offline = () =>
+  connected({
+    hostConnected: false,
+    proxyEnabled: false,
+    proxyPort: null,
+    backendState: "NoState",
+  });
+const flush = async () => {
+  for (let i = 0; i < 10; i++) await Promise.resolve();
+};
+
+describe("routing protection", () => {
+  let saved: Record<string, unknown>;
+  beforeEach(() => {
+    saved = {};
+    vi.spyOn(chrome.storage.local, "get").mockImplementation(async (key) => ({
+      [key as string]: saved[key as string],
+    }));
+    vi.spyOn(chrome.storage.local, "set").mockImplementation(async (value) => {
+      Object.assign(saved, value);
+    });
+  });
+  afterEach(() => vi.restoreAllMocks());
+  it("blocks during startup before storage resolves", () => {
+    const routing = new RoutingProtection();
+    expect(routing.decorate(baseState()).routingPolicy).toMatchObject({
+      mode: "blocked",
+      domainSplit: { mode: "bypass", domains: [] },
+    });
+  });
+  it("preserves selection when the selected node disappears from status", async () => {
+    const routing = new RoutingProtection();
+    await routing.restore();
+    routing.confirmStatus(status(connected()), connected());
+    const missing = connected({ exitNode: null });
+    routing.confirmStatus(status(missing), missing);
+    expect(routing.decorate(missing)).toMatchObject({
+      selectedExitNodeID: "exit1",
+      routingPolicy: { mode: "blocked" },
+    });
+  });
+  it("restores protection across worker and browser restarts without a stale port", async () => {
+    const routing = new RoutingProtection();
+    await routing.restore();
+    routing.confirmStatus(status(connected()), connected());
+    await flush();
+    expect(JSON.stringify(saved)).not.toContain("proxyPort");
+    const restored = new RoutingProtection();
+    await restored.restore();
+    expect(restored.decorate(offline()).routingPolicy).toMatchObject({
+      mode: "blocked",
+      selectedExitNodeID: "exit1",
+      proxyPort: null,
+    });
+  });
+  it("does not release protection on Stopped, login, or helper errors", async () => {
+    const routing = new RoutingProtection();
+    await routing.restore();
+    routing.confirmStatus(status(connected()), connected());
+    for (const backendState of [
+      "Stopped",
+      "NeedsLogin",
+      "NoState",
+      "Starting",
+    ] as const) {
+      const state = connected({ backendState });
+      routing.confirmStatus(status(state), state);
+      expect(routing.decorate(state).routingPolicy?.mode).toBe("blocked");
+    }
+  });
+  it("does not apply one account's saved selection to another", async () => {
+    const routing = new RoutingProtection();
+    await routing.restore();
+    routing.confirmStatus(status(connected()), connected());
+    const other = connected({
+      selfNode: { ...makePeer(), keyExpiry: null, id: "self2" },
+      prefs: { ...prefs, exitNodeID: "" },
+      exitNode: null,
+    });
+    routing.confirmStatus(status(other), other);
+    expect(routing.decorate(other).selectedExitNodeID).toBeNull();
+    const returned = connected({
+      prefs: { ...prefs, exitNodeID: "" },
+      exitNode: null,
+    });
+    routing.confirmStatus(status(returned), returned);
+    expect(routing.decorate(returned).selectedExitNodeID).toBe("exit1");
+  });
+  it("scopes saved selection to the coordination server too", async () => {
+    const routing = new RoutingProtection();
+    await routing.restore();
+    routing.confirmStatus(status(connected()), connected());
+    const other = connected({
+      prefs: {
+        ...prefs,
+        exitNodeID: "",
+        controlURL: "https://headscale.example",
+      },
+      exitNode: null,
+    });
+    routing.confirmStatus(status(other), other);
+    expect(routing.decorate(other).selectedExitNodeID).toBeNull();
+  });
+  it("keeps protection until None is confirmed by the helper", async () => {
+    const routing = new RoutingProtection();
+    await routing.restore();
+    routing.confirmStatus(status(connected()), connected());
+    routing.selectExitNode("");
+    expect(routing.decorate(offline()).selectedExitNodeID).toBe("exit1");
+    const cleared = connected({
+      prefs: { ...prefs, exitNodeID: "" },
+      exitNode: null,
+    });
+    routing.confirmStatus(status(cleared), cleared);
+    expect(routing.decorate(cleared).selectedExitNodeID).toBeNull();
+  });
+  it("blocks while a newly selected node is not confirmed", async () => {
+    const routing = new RoutingProtection();
+    await routing.restore();
+    routing.confirmStatus(status(connected()), connected());
+    routing.selectExitNode("exit2");
+    routing.confirmStatus(status(connected()), connected());
+    expect(routing.decorate(connected()).routingPolicy).toMatchObject({
+      mode: "blocked",
+      selectedExitNodeID: "exit2",
+    });
+  });
+  it("keeps split-tunnel exclusions while the helper is unavailable", async () => {
+    const state = connected({
+      domainSplit: { mode: "only", domains: ["work.example"] },
+      peers: [makePeer({ subnets: ["10.10.0.0/16"] })],
+    });
+    const routing = new RoutingProtection();
+    await routing.restore();
+    routing.confirmStatus(status(state), state);
+    expect(
+      routing.decorate({
+        ...state,
+        ...offline(),
+        domainSplit: state.domainSplit,
+      }).routingPolicy,
+    ).toMatchObject({
+      mode: "blocked",
+      subnetCIDRs: ["10.10.0.0/16"],
+      domainSplit: { mode: "only", domains: ["work.example"] },
+    });
+  });
+  it("releases protection after a confirmed manual disconnect", async () => {
+    const routing = new RoutingProtection();
+    await routing.restore();
+    routing.confirmStatus(status(connected()), connected());
+    routing.requestDisconnect();
+    const stopped = connected({ backendState: "Stopped" });
+    routing.confirmStatus(status(stopped), stopped);
+    expect(routing.decorate(stopped).routingPolicy?.mode).toBe("direct");
+  });
+  it("allows an explicit local release when the helper cannot respond", async () => {
+    const routing = new RoutingProtection();
+    await routing.restore();
+    routing.confirmStatus(status(connected()), connected());
+    routing.release();
+    await flush();
+    expect(routing.decorate(offline()).routingPolicy?.mode).toBe("direct");
+    expect(saved[ROUTING_STORAGE_KEY]).toMatchObject({ released: true });
+  });
+  it("blocks if the saved protection cannot be read", async () => {
+    vi.mocked(chrome.storage.local.get).mockRejectedValue(
+      new Error("storage unavailable"),
+    );
+    const routing = new RoutingProtection();
+    await routing.restore();
+    expect(routing.decorate(offline()).routingPolicy?.mode).toBe("blocked");
+  });
+  it("keeps an explicit disconnect released after a worker restart", async () => {
+    const routing = new RoutingProtection();
+    await routing.restore();
+    routing.confirmStatus(status(connected()), connected());
+    routing.release();
+    await flush();
+    const restored = new RoutingProtection();
+    await restored.restore();
+    const stopped = connected({ backendState: "Stopped" });
+    restored.confirmStatus(status(stopped), stopped);
+    expect(restored.decorate(stopped).routingPolicy?.mode).toBe("direct");
+  });
+  it("does not carry pending commands across an account change", async () => {
+    const routing = new RoutingProtection();
+    await routing.restore();
+    routing.confirmStatus(status(connected()), connected());
+    routing.selectExitNode("other-exit");
+    routing.requestDisconnect();
+    const other = connected({
+      selfNode: { ...makePeer(), keyExpiry: null, id: "self2" },
+      prefs: { ...prefs, exitNodeID: "" },
+      exitNode: null,
+    });
+    routing.confirmStatus(status(other), other);
+    expect(routing.decorate(other).routingPolicy).toMatchObject({
+      mode: "active",
+      selectedExitNodeID: null,
+    });
+  });
+
+  it("restores protection before reconnecting a previously released account", async () => {
+    const routing = new RoutingProtection();
+    await routing.restore();
+    routing.confirmStatus(status(connected()), connected());
+    routing.release();
+    await flush();
+    const restored = new RoutingProtection();
+    await restored.restore();
+    restored.reconnect();
+    expect(restored.decorate(offline()).routingPolicy).toMatchObject({
+      mode: "blocked",
+      selectedExitNodeID: "exit1",
+    });
+  });
+  it("blocks an account switch immediately and ignores status from the old account", async () => {
+    const routing = new RoutingProtection();
+    await routing.restore();
+    routing.confirmStatus(status(connected()), connected());
+    routing.switchProfile();
+    routing.confirmStatus(status(connected()), connected());
+    expect(routing.decorate(connected()).routingPolicy).toMatchObject({
+      mode: "blocked",
+      blockAll: true,
+    });
+  });
+
+  it("does not discard protected routes on restore", async () => {
+    const peers = [
+      makePeer({
+        subnets: Array.from(
+          { length: 4097 },
+          (_, i) => `10.${Math.floor(i / 256)}.${i % 256}.0/24`,
+        ),
+      }),
+    ];
+    const state = connected({
+      peers,
+      prefs: { ...prefs, exitNodeID: "" },
+      exitNode: null,
+    });
+    const routing = new RoutingProtection();
+    await routing.restore();
+    routing.confirmStatus(status(state), state);
+    await flush();
+    const restored = new RoutingProtection();
+    await restored.restore();
+    expect(
+      restored.decorate(offline()).routingPolicy?.subnetCIDRs,
+    ).toHaveLength(4097);
+  });
+  it("blocks all traffic for malformed saved constraints", async () => {
+    const routing = new RoutingProtection();
+    await routing.restore();
+    routing.confirmStatus(status(connected()), connected());
+    await flush();
+    const value = saved[ROUTING_STORAGE_KEY] as {
+      active: { subnetCIDRs: unknown[] };
+    };
+    value.active.subnetCIDRs.push("invalid/24");
+    const restored = new RoutingProtection();
+    await restored.restore();
+    expect(restored.decorate(offline()).routingPolicy).toMatchObject({
+      mode: "blocked",
+      blockAll: true,
+    });
+  });
+
+  it("preserves a pending None confirmation across a worker restart", async () => {
+    const routing = new RoutingProtection();
+    await routing.restore();
+    routing.confirmStatus(status(connected()), connected());
+    routing.selectExitNode("");
+    await flush();
+    const restored = new RoutingProtection();
+    await restored.restore();
+    const cleared = connected({
+      prefs: { ...prefs, exitNodeID: "" },
+      exitNode: null,
+    });
+    restored.confirmStatus(status(cleared), cleared);
+    expect(restored.decorate(cleared).selectedExitNodeID).toBeNull();
+  });
+  it("preserves a pending disconnect confirmation across a worker restart", async () => {
+    const routing = new RoutingProtection();
+    await routing.restore();
+    routing.confirmStatus(status(connected()), connected());
+    routing.requestDisconnect();
+    await flush();
+    const restored = new RoutingProtection();
+    await restored.restore();
+    const stopped = connected({ backendState: "Stopped" });
+    restored.confirmStatus(status(stopped), stopped);
+    expect(restored.decorate(stopped).routingPolicy?.mode).toBe("direct");
+  });
+});

--- a/packages/shared/src/background/routing-protection.test.ts
+++ b/packages/shared/src/background/routing-protection.test.ts
@@ -73,6 +73,19 @@ describe("routing protection", () => {
       routingPolicy: { mode: "blocked" },
     });
   });
+  it.each(["prefs", "selfNode"] as const)("blocks an initial Running status without %s", async (field) => {
+    const routing = new RoutingProtection();
+    await routing.restore();
+    const incomplete = connected({ [field]: null, exitNode: null });
+    routing.confirmStatus(status(incomplete), incomplete);
+    expect(routing.decorate(incomplete).routingPolicy).toMatchObject({
+      mode: "blocked", blockAll: true,
+    });
+    routing.confirmStatus(status(connected()), connected());
+    expect(routing.decorate(connected()).routingPolicy).toMatchObject({
+      mode: "active", selectedExitNodeID: "exit1",
+    });
+  });
   it("restores protection across worker and browser restarts without a stale port", async () => {
     const routing = new RoutingProtection();
     await routing.restore();

--- a/packages/shared/src/background/routing-protection.test.ts
+++ b/packages/shared/src/background/routing-protection.test.ts
@@ -179,12 +179,12 @@ describe("routing protection", () => {
       domainSplit: { mode: "only", domains: ["work.example"] },
     });
   });
-  it("releases protection after a confirmed manual disconnect", async () => {
+  it.each(["Stopped", "NeedsLogin"] as const)("releases a requested disconnect after %s is confirmed", async (backendState) => {
     const routing = new RoutingProtection();
     await routing.restore();
     routing.confirmStatus(status(connected()), connected());
     routing.requestDisconnect();
-    const stopped = connected({ backendState: "Stopped" });
+    const stopped = connected({ backendState });
     routing.confirmStatus(status(stopped), stopped);
     expect(routing.decorate(stopped).routingPolicy?.mode).toBe("direct");
   });

--- a/packages/shared/src/background/routing-protection.test.ts
+++ b/packages/shared/src/background/routing-protection.test.ts
@@ -115,6 +115,49 @@ describe("routing protection", () => {
       expect(routing.decorate(state).routingPolicy?.mode).toBe("blocked");
     }
   });
+  it("releases an explicit login until a complete Running status survives restart", async () => {
+    const routing = new RoutingProtection();
+    await routing.restore();
+    routing.confirmStatus(status(connected()), connected());
+    routing.switchProfile();
+    const needsLogin = connected({ backendState: "NeedsLogin", selfNode: null, prefs: null, exitNode: null });
+    routing.confirmStatus(status(needsLogin), needsLogin);
+    expect(routing.decorate(needsLogin).routingPolicy?.mode).toBe("blocked");
+    routing.startLogin();
+    await flush();
+
+    const restored = new RoutingProtection();
+    await restored.restore();
+    restored.reconnect();
+    for (const state of [
+      needsLogin,
+      connected({ backendState: "Starting" }),
+      connected({ selfNode: null }),
+      connected({ prefs: null }),
+    ]) {
+      restored.confirmStatus(status(state), state);
+      expect(restored.decorate(state).routingPolicy?.mode).toBe("direct");
+    }
+    const other = connected({
+      selfNode: { ...makePeer(), keyExpiry: null, id: "self2" },
+      prefs: { ...prefs, exitNodeID: "" },
+      exitNode: null,
+    });
+    restored.confirmStatus(status(other), other);
+    expect(restored.decorate(other).routingPolicy).toMatchObject({ mode: "active", selectedExitNodeID: null });
+    expect(restored.isLoginPending()).toBe(false);
+    restored.confirmStatus(status(connected()), connected());
+    expect(restored.decorate(connected()).selectedExitNodeID).toBe("exit1");
+  });
+  it("restores the same account's protected selection after explicit login", async () => {
+    const routing = new RoutingProtection();
+    await routing.restore();
+    routing.confirmStatus(status(connected()), connected());
+    routing.startLogin();
+    const returned = connected({ exitNode: null, prefs: { ...prefs, exitNodeID: "" } });
+    routing.confirmStatus(status(returned), returned);
+    expect(routing.decorate(returned).routingPolicy).toMatchObject({ mode: "blocked", selectedExitNodeID: "exit1" });
+  });
   it("does not apply one account's saved selection to another", async () => {
     const routing = new RoutingProtection();
     await routing.restore();

--- a/packages/shared/src/background/routing-protection.ts
+++ b/packages/shared/src/background/routing-protection.ts
@@ -292,6 +292,13 @@ export class RoutingProtection {
         mode: live ? "active" : "blocked",
         proxyPort: live ? state.proxyPort : null,
       };
+    } else if (
+      state.backendState === "Running" &&
+      (!state.selfNode?.id || !state.prefs)
+    ) {
+      // The first IPN update can precede the account's preferences. Its exit
+      // choice is unknown until both arrive, including after an upgrade.
+      policy = { ...emptyPolicy(), mode: "blocked", blockAll: true };
     } else if (!shouldProxyState(state)) {
       policy = emptyPolicy();
     }

--- a/packages/shared/src/background/routing-protection.ts
+++ b/packages/shared/src/background/routing-protection.ts
@@ -1,0 +1,325 @@
+import type { RoutingPolicy, StatusUpdate, TailscaleState } from "../types";
+import { normalizeDomainSplit } from "./domain-split";
+import {
+  collectSubnetCIDRs,
+  parseCIDR,
+  sanitizeMagicDNSSuffix,
+  shouldProxyState,
+} from "./proxy-utils";
+
+export const ROUTING_STORAGE_KEY = "routingProtectionV1";
+// Use a closed loopback endpoint, never a previous helper's reusable port.
+export const BLOCKED_PROXY_PORT = 1;
+
+type Snapshot = Omit<RoutingPolicy, "mode" | "proxyPort"> & { scope: string };
+interface SavedRouting {
+  active: Snapshot | null;
+  profiles: Snapshot[];
+  released?: boolean;
+  transitioning?: boolean;
+  pendingExit?: string | null;
+  pendingDisconnect?: boolean;
+}
+
+function strings(value: unknown, valid: (s: string) => boolean): string[] {
+  return Array.isArray(value)
+    ? [
+        ...new Set(
+          value.filter((s): s is string => typeof s === "string" && valid(s)),
+        ),
+      ]
+    : [];
+}
+function snapshot(value: unknown): Snapshot | null {
+  if (!value || typeof value !== "object") return null;
+  const raw = value as Record<string, unknown>;
+  if (typeof raw.scope !== "string" || raw.scope.length > 4096) return null;
+  if (
+    raw.selectedExitNodeID !== null &&
+    (typeof raw.selectedExitNodeID !== "string" ||
+      raw.selectedExitNodeID.length > 256)
+  )
+    return null;
+  const subnetCIDRs = strings(
+    raw.subnetCIDRs,
+    (s) => /\/\d{1,2}$/.test(s) && parseCIDR(s) !== null,
+  );
+  const shortNames = strings(raw.shortNames, (s) =>
+    /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/.test(s),
+  );
+  const dnsRoutes = strings(
+    raw.dnsRoutes,
+    (s) =>
+      s.length < 254 &&
+      s
+        .split(".")
+        .every((label) => /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/.test(label)),
+  );
+  for (const [key, clean] of [
+    ["subnetCIDRs", subnetCIDRs],
+    ["shortNames", shortNames],
+    ["dnsRoutes", dnsRoutes],
+  ] as const) {
+    if (
+      !Array.isArray(raw[key]) ||
+      (raw[key] as unknown[]).length > 8192 ||
+      clean.length !== new Set(raw[key] as unknown[]).size
+    )
+      return null;
+  }
+  if (
+    typeof raw.magicDNSSuffix !== "string" ||
+    sanitizeMagicDNSSuffix(raw.magicDNSSuffix) !== raw.magicDNSSuffix
+  )
+    return null;
+  const split = normalizeDomainSplit(raw.domainSplit);
+  if (JSON.stringify(split) !== JSON.stringify(raw.domainSplit)) return null;
+  return {
+    scope: raw.scope,
+    selectedExitNodeID: raw.selectedExitNodeID as string | null,
+    magicDNSSuffix: sanitizeMagicDNSSuffix(
+      typeof raw.magicDNSSuffix === "string" ? raw.magicDNSSuffix : "",
+    ),
+    subnetCIDRs,
+    shortNames,
+    dnsRoutes,
+    domainSplit: split,
+  };
+}
+function emptyPolicy(): RoutingPolicy {
+  return {
+    mode: "direct",
+    proxyPort: null,
+    selectedExitNodeID: null,
+    magicDNSSuffix: "",
+    subnetCIDRs: [],
+    shortNames: [],
+    dnsRoutes: [],
+    domainSplit: { mode: "bypass", domains: [] },
+  };
+}
+export function policyFromState(state: TailscaleState): RoutingPolicy {
+  if (state.routingPolicy) return state.routingPolicy;
+  const selectedExitNodeID =
+    state.pendingExitNodeID ||
+    state.prefs?.exitNodeID ||
+    state.exitNode?.id ||
+    null;
+  return {
+    ...emptyPolicy(),
+    mode: shouldProxyState(state)
+      ? selectedExitNodeID &&
+        (!state.exitNode?.online || state.exitNode.id !== selectedExitNodeID)
+        ? "blocked"
+        : "active"
+      : "direct",
+    proxyPort: state.proxyPort,
+    selectedExitNodeID,
+    magicDNSSuffix: sanitizeMagicDNSSuffix(state.magicDNSSuffix),
+    subnetCIDRs: collectSubnetCIDRs(state.peers).filter(
+      (s) => parseCIDR(s) !== null,
+    ),
+    domainSplit: normalizeDomainSplit(state.domainSplit),
+  };
+}
+
+export class RoutingProtection {
+  private active: Snapshot | null = null;
+  private profiles = new Map<string, Snapshot>();
+  private ready = false;
+  private uncertain = false;
+  private released = false;
+  private transitioning = false;
+  private pendingExit: string | null = null;
+  private pendingDisconnect = false;
+  private writeChain = Promise.resolve();
+  private savedKey = "";
+  private revision = 0;
+
+  async restore(): Promise<void> {
+    const revision = this.revision;
+    try {
+      const result = await chrome.storage.local.get(ROUTING_STORAGE_KEY);
+      if (revision !== this.revision) {
+        this.ready = true;
+        return;
+      }
+      const saved = result[ROUTING_STORAGE_KEY] as SavedRouting | undefined;
+      if (saved) {
+        this.released = saved.released === true;
+        this.transitioning = saved.transitioning === true;
+        this.active = snapshot(saved.active);
+        if (this.active) {
+          this.pendingExit =
+            typeof saved.pendingExit === "string" &&
+            saved.pendingExit.length <= 256
+              ? saved.pendingExit
+              : null;
+          this.pendingDisconnect = saved.pendingDisconnect === true;
+        }
+        this.uncertain = saved.active !== null && !this.active;
+        if (Array.isArray(saved.profiles)) {
+          for (const raw of saved.profiles.slice(-32)) {
+            const value = snapshot(raw);
+            if (value) this.profiles.set(value.scope, value);
+          }
+        }
+      }
+    } catch {
+      if (revision === this.revision) this.uncertain = true;
+    }
+    this.ready = true;
+  }
+
+  selectExitNode(id: string): void {
+    this.revision += 1;
+    this.pendingExit = id;
+    this.released = false;
+    if (id && this.active) {
+      this.active = { ...this.active, selectedExitNodeID: id };
+    }
+    this.save();
+  }
+  requestDisconnect(): void {
+    this.pendingDisconnect = true;
+    this.save();
+  }
+  reconnect(): void {
+    this.released = false;
+  }
+  switchProfile(): void {
+    this.released = false;
+    this.pendingExit = null;
+    this.pendingDisconnect = false;
+    this.transitioning = true;
+    this.save();
+  }
+  cancelTransition(): void {
+    this.transitioning = false;
+    this.save();
+  }
+  release(): void {
+    this.revision += 1;
+    this.transitioning = false;
+    this.uncertain = false;
+    this.pendingExit = null;
+    this.pendingDisconnect = false;
+    this.released = true;
+    this.save();
+  }
+
+  confirmStatus(status: StatusUpdate, state: TailscaleState): void {
+    const incomingScope =
+      status.selfNode?.id && status.prefs
+        ? JSON.stringify([status.prefs.controlURL || "", status.selfNode.id])
+        : null;
+    if (
+      incomingScope &&
+      (!this.active || incomingScope !== this.active.scope)
+    ) {
+      this.transitioning = false;
+      this.pendingExit = null;
+      this.pendingDisconnect = false;
+    }
+    if (this.pendingDisconnect && status.backendState === "Stopped") {
+      this.release();
+      return;
+    }
+    if (this.released || !status.selfNode?.id || !status.prefs) return;
+    const scope = JSON.stringify([
+      status.prefs.controlURL || "",
+      status.selfNode.id,
+    ]);
+    const prior =
+      this.active?.scope === scope ? this.active : this.profiles.get(scope);
+    const confirmed = status.prefs.exitNodeID || status.exitNode?.id || null;
+    let selected =
+      this.pendingExit || confirmed || prior?.selectedExitNodeID || null;
+    if (this.pendingExit === "" && !confirmed) selected = null;
+    if (this.pendingExit !== null && (this.pendingExit || null) === confirmed)
+      this.pendingExit = null;
+    if (!prior && !selected && status.backendState !== "Running") return;
+    const policy = policyFromState({
+      ...state,
+      ...status,
+      routingPolicy: undefined,
+      pendingExitNodeID: null,
+    });
+    this.active = {
+      scope,
+      selectedExitNodeID: selected,
+      magicDNSSuffix: policy.magicDNSSuffix || prior?.magicDNSSuffix || "",
+      subnetCIDRs: [
+        ...new Set([...(prior?.subnetCIDRs ?? []), ...policy.subnetCIDRs]),
+      ],
+      shortNames: [
+        ...new Set([...(prior?.shortNames ?? []), ...policy.shortNames]),
+      ],
+      dnsRoutes: [
+        ...new Set([...(prior?.dnsRoutes ?? []), ...policy.dnsRoutes]),
+      ],
+      domainSplit: policy.domainSplit,
+    };
+    this.save();
+  }
+
+  decorate(state: TailscaleState): TailscaleState {
+    let policy = policyFromState(state);
+    if (!this.ready || this.uncertain || this.transitioning) {
+      policy = { ...emptyPolicy(), mode: "blocked", blockAll: true };
+    } else if (this.released) {
+      policy = emptyPolicy();
+    } else if (this.active) {
+      const domainSplit = normalizeDomainSplit(state.domainSplit);
+      if (
+        JSON.stringify(domainSplit) !== JSON.stringify(this.active.domainSplit)
+      ) {
+        this.active = { ...this.active, domainSplit };
+        this.save();
+      }
+      const scope =
+        state.selfNode?.id && state.prefs
+          ? JSON.stringify([state.prefs.controlURL || "", state.selfNode.id])
+          : null;
+      const selected = this.active.selectedExitNodeID;
+      const live =
+        shouldProxyState(state) &&
+        scope === this.active.scope &&
+        (!selected ||
+          (state.exitNode?.id === selected && state.exitNode.online));
+      policy = {
+        ...this.active,
+        domainSplit: normalizeDomainSplit(state.domainSplit),
+        mode: live ? "active" : "blocked",
+        proxyPort: live ? state.proxyPort : null,
+      };
+    } else if (!shouldProxyState(state)) {
+      policy = emptyPolicy();
+    }
+    return {
+      ...state,
+      routingPolicy: policy,
+      selectedExitNodeID: policy.selectedExitNodeID,
+    };
+  }
+
+  private save(): void {
+    if (this.active) this.profiles.set(this.active.scope, this.active);
+    const value: SavedRouting = {
+      active: this.active,
+      released: this.released,
+      transitioning: this.transitioning,
+      pendingExit: this.pendingExit,
+      pendingDisconnect: this.pendingDisconnect,
+      profiles: [...this.profiles.values()].slice(-32),
+    };
+    const key = JSON.stringify(value);
+    if (key === this.savedKey) return;
+    this.savedKey = key;
+    this.writeChain = this.writeChain
+      .then(() => chrome.storage.local.set({ [ROUTING_STORAGE_KEY]: value }))
+      .catch(() => {
+        this.savedKey = "";
+      });
+  }
+}

--- a/packages/shared/src/background/routing-protection.ts
+++ b/packages/shared/src/background/routing-protection.ts
@@ -19,6 +19,7 @@ interface SavedRouting {
   transitioning?: boolean;
   pendingExit?: string | null;
   pendingDisconnect?: boolean;
+  pendingLogin?: boolean;
 }
 
 function strings(value: unknown, valid: (s: string) => boolean): string[] {
@@ -132,6 +133,7 @@ export class RoutingProtection {
   private transitioning = false;
   private pendingExit: string | null = null;
   private pendingDisconnect = false;
+  private pendingLogin = false;
   private writeChain = Promise.resolve();
   private savedKey = "";
   private revision = 0;
@@ -147,6 +149,7 @@ export class RoutingProtection {
       const saved = result[ROUTING_STORAGE_KEY] as SavedRouting | undefined;
       if (saved) {
         this.released = saved.released === true;
+        this.pendingLogin = this.released && saved.pendingLogin === true;
         this.transitioning = saved.transitioning === true;
         this.active = snapshot(saved.active);
         if (this.active) {
@@ -185,26 +188,46 @@ export class RoutingProtection {
     this.save();
   }
   reconnect(): void {
-    this.released = false;
+    if (!this.pendingLogin) this.released = false;
+  }
+  startLogin(): void {
+    this.releaseRouting(true);
+  }
+  isLoginPending(): boolean {
+    return this.pendingLogin;
   }
   switchProfile(): void {
     this.released = false;
+    this.pendingLogin = false;
     this.pendingExit = null;
     this.pendingDisconnect = false;
     this.transitioning = true;
     this.save();
   }
   release(): void {
+    this.releaseRouting(false);
+  }
+  private releaseRouting(pendingLogin: boolean): void {
     this.revision += 1;
     this.transitioning = false;
     this.uncertain = false;
     this.pendingExit = null;
     this.pendingDisconnect = false;
+    this.pendingLogin = pendingLogin;
     this.released = true;
     this.save();
   }
 
   confirmStatus(status: StatusUpdate, state: TailscaleState): void {
+    if (
+      this.pendingLogin &&
+      status.backendState === "Running" &&
+      status.selfNode?.id &&
+      status.prefs
+    ) {
+      this.pendingLogin = false;
+      this.released = false;
+    }
     const incomingScope =
       status.selfNode?.id && status.prefs
         ? JSON.stringify([status.prefs.controlURL || "", status.selfNode.id])
@@ -317,6 +340,7 @@ export class RoutingProtection {
       transitioning: this.transitioning,
       pendingExit: this.pendingExit,
       pendingDisconnect: this.pendingDisconnect,
+      pendingLogin: this.pendingLogin,
       profiles: [...this.profiles.values()].slice(-32),
     };
     const key = JSON.stringify(value);

--- a/packages/shared/src/background/routing-protection.ts
+++ b/packages/shared/src/background/routing-protection.ts
@@ -194,10 +194,6 @@ export class RoutingProtection {
     this.transitioning = true;
     this.save();
   }
-  cancelTransition(): void {
-    this.transitioning = false;
-    this.save();
-  }
   release(): void {
     this.revision += 1;
     this.transitioning = false;
@@ -221,7 +217,10 @@ export class RoutingProtection {
       this.pendingExit = null;
       this.pendingDisconnect = false;
     }
-    if (this.pendingDisconnect && status.backendState === "Stopped") {
+    if (
+      this.pendingDisconnect &&
+      (status.backendState === "Stopped" || status.backendState === "NeedsLogin")
+    ) {
       this.release();
       return;
     }

--- a/packages/shared/src/popup/popup.ts
+++ b/packages/shared/src/popup/popup.ts
@@ -159,10 +159,33 @@ export function render(state: TailscaleState): void {
   syncHelperVersionNotice(root, state);
 }
 
+function syncRoutingNotice(root: HTMLElement, state: TailscaleState): void {
+  root.querySelector(".routing-notice")?.remove();
+  const health = state.routingHealth;
+  if (!health || health.status === "active" || health.status === "inactive") return;
+  const view = root.querySelector<HTMLElement>(".view");
+  if (!view) return;
+  const notice = document.createElement("section");
+  notice.className = "routing-notice";
+  notice.setAttribute("role", "alert");
+  const text = document.createElement("p");
+  text.textContent = health.message;
+  notice.appendChild(text);
+  if (state.routingPolicy?.mode !== "direct") {
+    const release = document.createElement("button");
+    release.className = "btn btn-secondary";
+    release.textContent = "Disconnect and browse normally";
+    release.addEventListener("click", () => sendMessage({ type: "release-routing" }));
+    notice.appendChild(release);
+  }
+  view.prepend(notice);
+}
+
 function syncHelperVersionNotice(
   root: HTMLElement,
   state: TailscaleState,
 ): void {
+  syncRoutingNotice(root, state);
   root.querySelector(".helper-version-notice")?.remove();
   const notice = state.helperVersionNotice;
   if (!notice || helperVersionNoticeDismissed) return;

--- a/packages/shared/src/popup/styles/components.css
+++ b/packages/shared/src/popup/styles/components.css
@@ -854,6 +854,7 @@ button.setting-row {
   max-width: 280px;
 }
 
+.routing-notice,
 .helper-version-notice {
   position: relative;
   padding: var(--space-md) calc(var(--space-xl) + var(--space-lg))

--- a/packages/shared/src/popup/views/connected.ts
+++ b/packages/shared/src/popup/views/connected.ts
@@ -161,7 +161,7 @@ export function renderConnected(root: HTMLElement, state: TailscaleState): void 
       "countryCode",
     );
   } else {
-    exitValue.textContent = "None";
+    exitValue.textContent = state.selectedExitNodeID ? "Unavailable" : "None";
   }
 
   const chevron = document.createElement("span");
@@ -703,7 +703,7 @@ function exitNodeDisplayText(state: TailscaleState): string {
       "countryCode",
     );
   }
-  return "None";
+  return state.selectedExitNodeID ? "Unavailable" : "None";
 }
 
 /**

--- a/packages/shared/src/popup/views/exit-nodes.ts
+++ b/packages/shared/src/popup/views/exit-nodes.ts
@@ -515,7 +515,7 @@ function effectiveSelectedExitNodeID(state: TailscaleState): string | null {
     return state.pendingExitNodeID || null;
   }
 
-  return state.exitNode?.id ?? state.prefs?.exitNodeID ?? null;
+  return state.selectedExitNodeID ?? (state.prefs?.exitNodeID || state.exitNode?.id || null);
 }
 
 function sameExitNodeLocation(

--- a/packages/shared/src/popup/views/needs-login.test.ts
+++ b/packages/shared/src/popup/views/needs-login.test.ts
@@ -1,0 +1,23 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { baseState } from "../../__test__/fixtures";
+import { policyFromState } from "../../background/routing-protection";
+import { renderNeedsLogin } from "./needs-login";
+import { sendMessage } from "../popup";
+
+vi.mock("../popup", () => ({ sendMessage: vi.fn() }));
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("login recovery", () => {
+  it.each(["blocked", "active", "direct"] as const)("explains the login action with %s routing", (mode) => {
+    const root = document.createElement("div");
+    const state = baseState({ backendState: "NeedsLogin" });
+    state.routingPolicy = { ...policyFromState(state), mode };
+    renderNeedsLogin(root, state);
+    const button = root.querySelector<HTMLButtonElement>(".btn-primary")!;
+    expect(button.textContent).toBe(mode === "direct" ? "Log In" : "Disconnect and log in");
+    button.click();
+    expect(sendMessage).toHaveBeenCalledWith({ type: mode === "direct" ? "login" : "disconnect-and-login" });
+  });
+});

--- a/packages/shared/src/popup/views/needs-login.ts
+++ b/packages/shared/src/popup/views/needs-login.ts
@@ -35,17 +35,20 @@ export function renderNeedsLogin(root: HTMLElement, state: TailscaleState): void
   title.className = "centered-view-title";
   title.textContent = "Log in to Tailscale";
 
+  const protectedRouting =
+    state.routingPolicy != null && state.routingPolicy.mode !== "direct";
   const description = document.createElement("p");
   description.className = "centered-view-text";
-  description.textContent =
-    "You need to authenticate to connect this browser to your tailnet.";
+  description.textContent = protectedRouting
+    ? "Disconnect protected browsing to sign in using your normal connection."
+    : "You need to authenticate to connect this browser to your tailnet.";
 
   const loginBtn = document.createElement("button");
   loginBtn.className = "btn btn-primary btn-lg";
-  loginBtn.textContent = "Log In";
+  loginBtn.textContent = protectedRouting ? "Disconnect and log in" : "Log In";
   loginBtn.addEventListener("click", () => {
     // Notify background to open the validated login URL
-    sendMessage({ type: "login" });
+    sendMessage({ type: protectedRouting ? "disconnect-and-login" : "login" });
   });
 
   content.appendChild(icon);

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -219,6 +219,9 @@ export interface HelperVersionNotice {
 }
 
 export interface TailscaleState {
+  routingPolicy?: RoutingPolicy;
+  routingHealth?: RoutingHealth;
+  selectedExitNodeID?: string | null;
   /** Monotonically increasing counter, incremented on every state update. */
   stateVersion: number;
   hostConnected: boolean;
@@ -290,6 +293,7 @@ type SetPrefMessage = {
 
 // Messages from popup to background
 export type BackgroundMessage =
+  | { type: "release-routing" }
   | { type: "toggle" }
   | { type: "login" }
   | { type: "logout" }
@@ -327,4 +331,22 @@ export type BackgroundMessage =
 export interface ProxyManager {
   apply(state: TailscaleState): void;
   clear(): void;
+  setRoutingHealthListener?(listener: (health: RoutingHealth) => void): void;
+}
+
+export interface RoutingHealth {
+  status: "active" | "blocked" | "conflicted" | "unavailable" | "inactive";
+  message: string;
+}
+
+export interface RoutingPolicy {
+  blockAll?: boolean;
+  mode: "active" | "blocked" | "direct";
+  proxyPort: number | null;
+  selectedExitNodeID: string | null;
+  magicDNSSuffix: string;
+  subnetCIDRs: string[];
+  shortNames: string[];
+  dnsRoutes: string[];
+  domainSplit: DomainSplitConfig;
 }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -296,6 +296,7 @@ export type BackgroundMessage =
   | { type: "release-routing" }
   | { type: "toggle" }
   | { type: "login" }
+  | { type: "disconnect-and-login" }
   | { type: "logout" }
   | {
       type: "retry-native-host";

--- a/scripts/e2e/launch.mjs
+++ b/scripts/e2e/launch.mjs
@@ -94,7 +94,7 @@ function isNavigationTimeout(err) {
   );
 }
 
-async function launchChrome(extensionDir) {
+async function launchChrome(extensionDir, { chromeArgs = [] } = {}) {
   await ensureChromeInstalled();
 
   const headless = process.env.HEADLESS !== "false";
@@ -108,6 +108,7 @@ async function launchChrome(extensionDir) {
       `--load-extension=${extensionDir}`,
       "--no-first-run",
       "--no-default-browser-check",
+      ...chromeArgs,
       // CI runners restrict unprivileged user namespaces (AppArmor on current
       // Ubuntu images), which crashes Chrome's sandbox at launch. The suite
       // only visits extension pages and localhost, so dropping the sandbox
@@ -131,7 +132,7 @@ async function launchChrome(extensionDir) {
   };
 }
 
-async function launchFirefox(extensionDir) {
+async function launchFirefox(extensionDir, { firefoxPrefs = {} } = {}) {
   const executablePath = ensureFirefoxInstalled();
   const headless = process.env.HEADLESS !== "false";
   const userDataDir = mkdtempSync(resolve(tmpdir(), "tailchrome-firefox-profile-"));
@@ -141,6 +142,7 @@ async function launchFirefox(extensionDir) {
     headless,
     userDataDir,
     extraPrefsFirefox: {
+      ...firefoxPrefs,
       "extensions.webextensions.uuids": JSON.stringify({
         [firefoxAddonId]: firefoxExtensionUuid,
       }),
@@ -168,12 +170,12 @@ async function launchFirefox(extensionDir) {
   };
 }
 
-export async function launch(extensionDir, { browserName = "chrome" } = {}) {
+export async function launch(extensionDir, { browserName = "chrome", ...options } = {}) {
   if (browserName === "chrome") {
-    return launchChrome(extensionDir);
+    return launchChrome(extensionDir, options);
   }
   if (browserName === "firefox") {
-    return launchFirefox(extensionDir);
+    return launchFirefox(extensionDir, options);
   }
 
   throw new Error(`Unsupported e2e browser: ${browserName}`);

--- a/scripts/e2e/native-host.mjs
+++ b/scripts/e2e/native-host.mjs
@@ -140,6 +140,20 @@ function mockSource(baseUrl, initialControl) {
   const commandReplyIndexes = Object.create(null);
   let connectionAttempt = 0;
   let manualRecoveryRequested = false;
+  let currentNativePort = null;
+
+  if (control.allowRuntimeUpdates) {
+    chrome.runtime.onMessage.addListener((message, _sender, reply) => {
+      const update = message?.tailchromeE2ENative;
+      if (!update) return;
+      if (update.control) Object.assign(control, update.control);
+      if (update.reply?.status) control.status = update.reply.status;
+      if (update.reply) currentNativePort?.onMessage.dispatch(update.reply);
+      if (update.disconnect) currentNativePort?.disconnect();
+      reply({ ok: true });
+    });
+  }
+
 
   // The incompatible kind is intentionally defensive-only in production until
   // a future protocol supplies explicit evidence. Transform background state
@@ -310,6 +324,8 @@ function mockSource(baseUrl, initialControl) {
         queueMicrotask(() => onDisconnect.dispatch(port));
       },
     };
+
+    currentNativePort = port;
 
     // Dispatch procRunning synchronously from the inlined snapshot so it
     // reaches the background before the popup connects. The fetch

--- a/scripts/e2e/network-fixture.mjs
+++ b/scripts/e2e/network-fixture.mjs
@@ -1,0 +1,152 @@
+import { createServer as createHTTPServer, request } from "node:http";
+import { createServer, createConnection } from "node:net";
+
+export const routingTestHost = "routing.tailchrome.test";
+export const proxyCredentials = {
+  version: 1,
+  username: "fixture",
+  password: "fixture-credential-".repeat(3),
+};
+
+function listen(server) {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve(server.address().port));
+  });
+}
+
+// Real local HTTP and proxy sockets make direct fallback observable. Only this
+// fixture's origin is accepted as a proxy destination.
+export async function createRoutingNetwork() {
+  const hits = [];
+  const sockets = new Set();
+  const forwardedPorts = new Set();
+  const track = (socket) => {
+    sockets.add(socket);
+    socket.once("close", () => sockets.delete(socket));
+    socket.on("error", () => {});
+    return socket;
+  };
+  const origin = createHTTPServer((req, res) => {
+    hits.push({
+      path: req.url,
+      proxied: forwardedPorts.has(req.socket.remotePort) || req.headers["x-tailchrome-test-proxy"] === "yes",
+    });
+    res.writeHead(200, { "Content-Type": "text/plain", "Cache-Control": "no-store" });
+    res.end("routing origin reached");
+  });
+  origin.on("connection", track);
+  const originPort = await listen(origin);
+  const baseURL = `http://${routingTestHost}:${originPort}`;
+  const allowedTarget = (host, port) => host === routingTestHost && Number(port) === originPort;
+  const basic = `Basic ${Buffer.from(`${proxyCredentials.username}:${proxyCredentials.password}`).toString("base64")}`;
+
+  function tunnel(client, head = Buffer.alloc(0)) {
+    client.pause();
+    const upstream = track(createConnection(originPort, "127.0.0.1"));
+    upstream.once("connect", () => {
+      const port = upstream.localPort;
+      forwardedPorts.add(port);
+      upstream.once("close", () => forwardedPorts.delete(port));
+      if (head.length) upstream.write(head);
+      client.pipe(upstream).pipe(client);
+    });
+    client.once("close", () => upstream.destroy());
+    upstream.once("error", () => client.destroy());
+    return upstream;
+  }
+
+  const httpProxy = createHTTPServer((req, res) => {
+    if (req.headers["proxy-authorization"] !== basic) {
+      res.writeHead(407, { "Proxy-Authenticate": 'Basic realm="Tailchrome"' });
+      res.end();
+      return;
+    }
+    let url;
+    try { url = new URL(req.url); } catch { res.writeHead(400).end(); return; }
+    if (!allowedTarget(url.hostname, url.port)) { res.writeHead(403).end(); return; }
+    const upstream = request({
+      hostname: "127.0.0.1", port: originPort, path: url.pathname + url.search,
+      method: req.method,
+      headers: { "x-tailchrome-test-proxy": "yes" },
+    }, (response) => {
+      res.writeHead(response.statusCode, response.headers);
+      response.pipe(res);
+    });
+    upstream.on("error", () => { res.writeHead(502).end(); });
+    req.pipe(upstream);
+  });
+  httpProxy.on("connect", (req, client, head) => {
+    if (req.headers["proxy-authorization"] !== basic) {
+      client.end('HTTP/1.1 407 Proxy Authentication Required\r\nProxy-Authenticate: Basic realm="Tailchrome"\r\nContent-Length: 0\r\n\r\n');
+      return;
+    }
+    if (req.url !== `${routingTestHost}:${originPort}`) { client.destroy(); return; }
+    tunnel(client, head).once("connect", () => client.write("HTTP/1.1 200 Connection Established\r\n\r\n"));
+  });
+
+  function socks(client, first) {
+    let buffer = first;
+    let stage = "hello";
+    const receive = (chunk = Buffer.alloc(0)) => {
+      buffer = Buffer.concat([buffer, chunk]);
+      while (true) {
+        if (stage === "hello") {
+          if (buffer.length < 2 || buffer.length < buffer[1] + 2) return;
+          const methods = buffer.subarray(2, buffer[1] + 2);
+          const method = methods.includes(2) ? 2 : methods.includes(0) ? 0 : 255;
+          buffer = buffer.subarray(buffer[1] + 2);
+          client.write(Buffer.from([5, method]));
+          if (method === 255) { client.end(); return; }
+          stage = method === 2 ? "auth" : "connect";
+        } else if (stage === "auth") {
+          if (buffer.length < 2 || buffer.length < 3 + buffer[1]) return;
+          const passwordOffset = 2 + buffer[1];
+          const end = passwordOffset + 1 + buffer[passwordOffset];
+          if (buffer.length < end) return;
+          const valid = buffer.subarray(2, passwordOffset).toString() === proxyCredentials.username &&
+            buffer.subarray(passwordOffset + 1, end).toString() === proxyCredentials.password;
+          client.write(Buffer.from([1, valid ? 0 : 1]));
+          if (!valid) { client.end(); return; }
+          buffer = buffer.subarray(end);
+          stage = "connect";
+        } else {
+          if (buffer.length < 5) return;
+          // proxyDNS is enabled in both browsers, so require a domain target.
+          if (buffer[0] !== 5 || buffer[1] !== 1 || buffer[3] !== 3) { client.destroy(); return; }
+          const end = 5 + buffer[4];
+          if (buffer.length < end + 2) return;
+          const host = buffer.subarray(5, end).toString();
+          if (!allowedTarget(host, buffer.readUInt16BE(end))) { client.destroy(); return; }
+          client.removeListener("data", receive);
+          client.write(Buffer.from([5, 0, 0, 1, 127, 0, 0, 1, 0, 0]));
+          tunnel(client, buffer.subarray(end + 2));
+          return;
+        }
+      }
+    };
+    client.on("data", receive);
+    receive();
+  }
+
+  const proxy = createServer((client) => {
+    track(client);
+    client.once("data", (first) => {
+      if (first[0] === 5) socks(client, first);
+      else {
+        client.pause();
+        client.unshift(first);
+        httpProxy.emit("connection", client);
+        client.resume();
+      }
+    });
+  });
+  const proxyPort = await listen(proxy);
+  return {
+    baseURL, proxyPort, hits,
+    async close() {
+      for (const socket of sockets) socket.destroy();
+      await Promise.all([origin, proxy].map((server) => new Promise((resolve) => server.close(resolve))));
+    },
+  };
+}

--- a/scripts/e2e/run.mjs
+++ b/scripts/e2e/run.mjs
@@ -108,6 +108,7 @@ async function loadCases({ browserName, suite, grep }) {
         name: mod.name ?? file.replace(/\.mjs$/, ""),
         control: mod.control,
         nativeHost: mod.nativeHost,
+        launchOptions: mod.launchOptions,
         run: mod.run,
       },
     ];
@@ -135,7 +136,7 @@ async function runCase({ browserName, extensionDir, item }) {
   let failed = false;
   try {
     const caseExtensionDir = await nativeHost.prepareExtension(extensionDir);
-    const launched = await launch(caseExtensionDir, { browserName });
+    const launched = await launch(caseExtensionDir, { ...testCase.launchOptions, browserName });
     browser = launched.browser;
     await testCase.run({
       browser,

--- a/scripts/e2e/scenarios/routing-failclosed-network.mjs
+++ b/scripts/e2e/scenarios/routing-failclosed-network.mjs
@@ -3,7 +3,7 @@ import { waitForPopup } from "../assertions.mjs";
 import { makeControl, makeExitNodePeer, makeRunningState, expectedHostVersion } from "../fixtures.mjs";
 import { createRoutingNetwork, routingTestHost, proxyCredentials } from "../network-fixture.mjs";
 
-export const suite = "full";
+export const suite = "smoke";
 export const browsers = ["chrome", "firefox"];
 export const launchOptions = {
   chromeArgs: [`--host-resolver-rules=MAP ${routingTestHost} 127.0.0.1`],

--- a/scripts/e2e/scenarios/routing-failclosed-network.mjs
+++ b/scripts/e2e/scenarios/routing-failclosed-network.mjs
@@ -95,6 +95,43 @@ export async function run({ browser, openPopup }) {
     await waitForRouting(popup, "active");
     await navigate(browser, network, "/recovered-through-proxy", { proxied: true });
 
+    await popup.evaluate(() => window.routingTestPort.postMessage({ type: "new-profile" }));
+    await waitForRouting(popup, "blocked");
+    const loginURL = network.baseURL + "/login";
+    const needsLogin = {
+      ...running, backendState: "NeedsLogin", running: false, needsLogin: true,
+      selfNode: null, exitNode: null, browseToURL: loginURL,
+      prefs: { ...running.prefs, controlURL: network.baseURL },
+    };
+    await nativeUpdate(popup, { control: { status: needsLogin }, reply: { status: needsLogin } });
+    await waitForRouting(popup, "blocked");
+    await navigate(browser, network, "/before-explicit-login", { blocked: true });
+    await popup.waitForFunction(() => [...document.querySelectorAll("button")]
+      .some((button) => button.textContent === "Disconnect and log in"));
+    const loginTarget = browser.waitForTarget((target) => target.url() === loginURL, { timeout: 10_000 });
+    await popup.evaluate(() => [...document.querySelectorAll("button")]
+      .find((button) => button.textContent === "Disconnect and log in").click());
+    const loginPage = await (await loginTarget).page();
+    await loginPage.waitForFunction(() => document.body?.textContent.includes("routing origin reached"));
+    await loginPage.close();
+    await waitForRouting(popup, "direct");
+    const loginHits = network.hits.filter((hit) => hit.path === "/login");
+    assert.ok(loginHits.length > 0 && loginHits.every((hit) => !hit.proxied), "Login did not use normal routing");
+
+    const newAccount = {
+      ...running, selfNode: { ...running.selfNode, id: "new-account" },
+      prefs: { ...running.prefs, controlURL: network.baseURL },
+    };
+    await nativeUpdate(popup, { control: { status: newAccount }, reply: { status: newAccount } });
+    await waitForRouting(popup, "active");
+    assert.equal(await popup.evaluate(() => window.routingTestState.selectedExitNodeID), null);
+    await navigate(browser, network, "/new-account-direct");
+    await popup.evaluate(() => window.routingTestPort.postMessage({ type: "switch-profile", profileID: "original-account" }));
+    await nativeUpdate(popup, { control: { status: recovered }, reply: { status: recovered } });
+    await waitForRouting(popup, "active");
+    assert.equal(await popup.evaluate(() => window.routingTestState.selectedExitNodeID), exit.id);
+    await navigate(browser, network, "/original-account-restored", { proxied: true });
+
     await nativeUpdate(popup, { control: { nativeFailure: "unavailable" }, disconnect: true });
     await waitForRouting(popup, "blocked");
     await navigate(browser, network, "/helper-disconnected", { blocked: true });
@@ -105,7 +142,7 @@ export async function run({ browser, openPopup }) {
     await waitForRouting(popup, "blocked", routingTestHost);
     await navigate(browser, network, "/requested-bypass");
 
-    assert.equal(network.hits.filter((hit) => ["/missing-exit", "/offline-exit", "/helper-disconnected"].includes(hit.path)).length, 0);
+    assert.equal(network.hits.filter((hit) => ["/missing-exit", "/offline-exit", "/before-explicit-login", "/helper-disconnected"].includes(hit.path)).length, 0);
   } finally {
     await popup?.close();
     await network.close();

--- a/scripts/e2e/scenarios/routing-failclosed-network.mjs
+++ b/scripts/e2e/scenarios/routing-failclosed-network.mjs
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import { waitForPopup } from "../assertions.mjs";
+import { makeControl, makeExitNodePeer, makeRunningState, expectedHostVersion } from "../fixtures.mjs";
+import { createRoutingNetwork, routingTestHost, proxyCredentials } from "../network-fixture.mjs";
+
+export const suite = "full";
+export const browsers = ["chrome", "firefox"];
+export const launchOptions = {
+  chromeArgs: [`--host-resolver-rules=MAP ${routingTestHost} 127.0.0.1`],
+  firefoxPrefs: { "network.dns.localDomains": routingTestHost },
+};
+export const control = () => makeControl({ allowRuntimeUpdates: true, proxyAuth: proxyCredentials });
+
+async function nativeUpdate(page, update) {
+  await page.evaluate((value) => chrome.runtime.sendMessage({ tailchromeE2ENative: value }), update);
+}
+
+async function waitForRouting(page, mode, domain) {
+  await page.waitForFunction((expectedMode, expectedDomain) => {
+    const state = window.routingTestState;
+    return state?.routingPolicy?.mode === expectedMode &&
+      (expectedMode === "blocked"
+        ? ["blocked", "unavailable"].includes(state.routingHealth?.status)
+        : state.routingHealth?.status === (expectedMode === "direct" ? "inactive" : expectedMode)) &&
+      (expectedDomain === undefined || state.domainSplit.domains.includes(expectedDomain));
+  }, { timeout: 10_000 }, mode, domain).catch(async (err) => {
+    const state = await page.evaluate(() => ({
+      policy: window.routingTestState?.routingPolicy,
+      health: window.routingTestState?.routingHealth,
+      backend: window.routingTestState?.backendState,
+    }));
+    throw new Error(`Waiting for ${mode} routing: ${JSON.stringify(state)}`, { cause: err });
+  });
+}
+
+async function navigate(browser, network, path, { blocked = false, proxied = false } = {}) {
+  const page = await browser.newPage();
+  let response;
+  let error;
+  try {
+    response = await page.goto(network.baseURL + path, { waitUntil: "domcontentloaded", timeout: 4_000 });
+  } catch (err) {
+    error = err;
+  } finally {
+    await page.close();
+  }
+  const matching = network.hits.filter((hit) => hit.path === path);
+  if (blocked) {
+    assert.equal(matching.length, 0, `Protected request ${path} reached the origin: ${JSON.stringify(matching)}`);
+    assert.ok(error || !response?.ok(), `Protected navigation ${path} unexpectedly succeeded`);
+  } else {
+    if (error) throw error;
+    assert.equal(response?.status(), 200, `Navigation ${path} did not reach the origin`);
+    assert.ok(matching.length > 0, `Origin saw no request for ${path}`);
+    assert.ok(matching.every((hit) => hit.proxied === proxied), `Wrong route for ${path}: ${JSON.stringify(matching)}`);
+  }
+}
+
+export async function run({ browser, openPopup }) {
+  const network = await createRoutingNetwork();
+  let popup;
+  try {
+    popup = await openPopup();
+    await waitForPopup(popup);
+    await popup.evaluate(() => {
+      const port = chrome.runtime.connect({ name: "popup" });
+      window.routingTestPort = port;
+      port.onMessage.addListener((message) => {
+        if (message.type === "state") window.routingTestState = message.state;
+      });
+    });
+    await waitForRouting(popup, "active");
+    await navigate(browser, network, "/direct-positive-control");
+
+    const exit = makeExitNodePeer({ exitNode: true });
+    const running = makeRunningState();
+    const selected = makeRunningState({
+      exitNode: null,
+      prefs: { ...running.prefs, exitNodeID: exit.id },
+    });
+    await nativeUpdate(popup, { reply: { status: selected } });
+    await waitForRouting(popup, "blocked");
+    await navigate(browser, network, "/missing-exit", { blocked: true });
+
+    await nativeUpdate(popup, { reply: { status: { ...selected, exitNode: { ...exit, online: false } } } });
+    await waitForRouting(popup, "blocked");
+    await navigate(browser, network, "/offline-exit", { blocked: true });
+
+    const recovered = { ...selected, exitNode: exit };
+    await nativeUpdate(popup, {
+      control: { proxyPort: network.proxyPort },
+      reply: { procRunning: { port: network.proxyPort, pid: 1, version: expectedHostVersion, proxyAuth: proxyCredentials } },
+    });
+    await nativeUpdate(popup, { reply: { status: recovered } });
+    await waitForRouting(popup, "active");
+    await navigate(browser, network, "/recovered-through-proxy", { proxied: true });
+
+    await nativeUpdate(popup, { control: { nativeFailure: "unavailable" }, disconnect: true });
+    await waitForRouting(popup, "blocked");
+    await navigate(browser, network, "/helper-disconnected", { blocked: true });
+
+    await popup.evaluate((host) => window.routingTestPort.postMessage({
+      type: "set-domain-split", config: { mode: "bypass", domains: [host] },
+    }), routingTestHost);
+    await waitForRouting(popup, "blocked", routingTestHost);
+    await navigate(browser, network, "/requested-bypass");
+
+    assert.equal(network.hits.filter((hit) => ["/missing-exit", "/offline-exit", "/helper-disconnected"].includes(hit.path)).length, 0);
+  } finally {
+    await popup?.close();
+    await network.close();
+  }
+}


### PR DESCRIPTION
## What
Keep protected requests blocked when the helper disconnects or the selected exit node disappears. Restore account-scoped routing choices before reconnecting, and show browser routing errors with an explicit option to disconnect and browse normally.

## Why
A helper outage or restart should not silently switch protected browsing to the normal connection.

## How to Test
Typecheck, unit tests, the full Chrome browser suite, and Firefox package validation pass locally. A browser request-count test also verifies blocking, proxy recovery, and explicit bypass.
