### PR TITLE
Authenticate the local proxy and restrict destinations

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -57,6 +57,10 @@ Helper diagnostic reports are generated only when the user clicks the copy or ex
 
 ## Local Proxy Trust Boundary
 
-The helper exposes its SOCKS5/HTTP proxy only on a randomly assigned `127.0.0.1` port. Browser proxy APIs do not support attaching authentication credentials to PAC/listener-selected SOCKS connections, so the listener itself is unauthenticated.
+The helper exposes its SOCKS5/HTTP proxy on a randomly assigned `127.0.0.1` port and requires a fresh random credential on every helper launch. Credentials are sent over native messaging and held only by the background proxy manager, outside popup state, storage, and diagnostics. Chromium uses authenticated HTTP proxying; Firefox uses authenticated SOCKS5.
 
-On a normal single-user workstation, the loopback binding prevents remote access and the random port limits accidental discovery. On a shared machine, another process running as any local user may be able to discover the listening port and use the browser profile's tailnet access. Tailchrome should therefore be installed only on machines where local users and processes are trusted; use separate OS accounts or a dedicated machine for mutually untrusted users.
+Update the extension and helper together. The extension blocks proxy use when a helper does not provide the authenticated proxy capability; current helpers do not expose an unauthenticated compatibility listener.
+
+The helper checks destinations against its authoritative network map and current preferences. It permits Tailscale addresses, approved subnet routes, public destinations through a selected exit node, and attached private LAN destinations when LAN access is explicitly enabled. Loopback, link-local, and multicast destinations are blocked. The local Tailscale web client is authenticated separately before dispatch. DNS answers are checked before literal addresses are dialed; protected connections cannot fall back to the system network after route removal.
+
+This limits access by other local users and processes that can discover the port. It does not protect against processes that can read the browser or helper memory or control the same operating-system account.

--- a/host/dns.go
+++ b/host/dns.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/netip"
+	"sort"
+	"strings"
+	"time"
+
+	"tailscale.com/types/netmap"
+)
+
+// dnsName accepts only literal DNS names, never URLs, wildcards, or IP addresses.
+func dnsName(raw string) (string, bool) {
+	name := strings.ToLower(strings.TrimSuffix(raw, "."))
+	if len(name) == 0 || len(name) > 253 || strings.Trim(name, "0123456789.") == "" {
+		return "", false
+	}
+	if _, err := netip.ParseAddr(name); err == nil {
+		return "", false
+	}
+	for _, label := range strings.Split(name, ".") {
+		if len(label) == 0 || len(label) > 63 || label[0] == '-' || label[len(label)-1] == '-' {
+			return "", false
+		}
+		for _, c := range label {
+			if !(c >= 'a' && c <= 'z' || c >= '0' && c <= '9' || c == '-') {
+				return "", false
+			}
+		}
+	}
+	return name, true
+}
+
+func dnsRouteDomains(nm *netmap.NetworkMap) []string {
+	domains := []string{}
+	if nm == nil {
+		return domains
+	}
+	seen := map[string]bool{}
+	for raw := range nm.DNS.Routes {
+		if domain, ok := dnsName(raw); ok && !seen[domain] {
+			seen[domain] = true
+			domains = append(domains, domain)
+		}
+	}
+	sort.Strings(domains)
+	return domains
+}
+
+// resolveRestrictedDNS resolves through the most specific configured DNS route.
+// Dial is bound to the same tsnet session as nm. Callers must validate the returned
+// addresses against their destination policy and dial a literal address, so a
+// later DNS answer cannot change the destination after that check.
+func resolveRestrictedDNS(ctx context.Context, network, hostname string, nm *netmap.NetworkMap, dial func(context.Context, string, string) (net.Conn, error)) ([]netip.Addr, bool, error) {
+	host, ok := dnsName(hostname)
+	if !ok || nm == nil {
+		return nil, false, nil
+	}
+	matched := ""
+	for _, domain := range dnsRouteDomains(nm) {
+		if (host == domain || strings.HasSuffix(host, "."+domain)) && len(domain) > len(matched) {
+			matched = domain
+		}
+	}
+	if matched == "" {
+		return nil, false, nil
+	}
+	// Keep lookup order deterministic even if a map contains duplicate normalized keys.
+	keys := make([]string, 0, len(nm.DNS.Routes))
+	for key := range nm.DNS.Routes {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	servers := []string{}
+	for _, key := range keys {
+		if domain, valid := dnsName(key); !valid || domain != matched {
+			continue
+		}
+		resolvers := nm.DNS.Routes[key]
+		if len(resolvers) == 0 {
+			// Empty routes belong to Tailscale's in-memory DNS records.
+			return nil, false, nil
+		}
+		for _, resolver := range resolvers {
+			if resolver == nil {
+				continue
+			}
+			ipp, valid := resolver.IPPort()
+			if !valid || ipp.Port() == 0 || !validDNSAddress(ipp.Addr()) {
+				continue
+			}
+			servers = append(servers, netip.AddrPortFrom(ipp.Addr().Unmap(), ipp.Port()).String())
+		}
+	}
+	if len(servers) == 0 {
+		return nil, true, fmt.Errorf("split DNS route %q has no supported IP nameserver", matched)
+	}
+	queryNetwork := "ip"
+	if strings.HasSuffix(network, "4") {
+		queryNetwork = "ip4"
+	} else if strings.HasSuffix(network, "6") {
+		queryNetwork = "ip6"
+	}
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	var lastErr error
+	for _, server := range servers {
+		// Bound each server attempt, leaving time to try the configured alternates.
+		attemptCtx, attemptCancel := context.WithTimeout(ctx, 3*time.Second)
+		resolver := &net.Resolver{
+			PreferGo:     true,
+			StrictErrors: true,
+			Dial: func(ctx context.Context, network, _ string) (net.Conn, error) {
+				return dial(ctx, network, server)
+			},
+		}
+		// A trailing dot prevents local search-domain expansion.
+		addresses, err := resolver.LookupNetIP(attemptCtx, queryNetwork, host+".")
+		attemptCancel()
+		if err == nil && len(addresses) > 0 {
+			for i, address := range addresses {
+				address = address.Unmap()
+				if !validDNSAddress(address) {
+					return nil, true, fmt.Errorf("split DNS returned an invalid destination")
+				}
+				addresses[i] = address
+			}
+			return addresses, true, nil
+		}
+		lastErr = err
+		if ctx.Err() != nil {
+			break
+		}
+	}
+	return nil, true, fmt.Errorf("split DNS lookup failed for %q: %w", host, lastErr)
+}
+
+func validDNSAddress(ip netip.Addr) bool {
+	ip = ip.Unmap()
+	return ip.IsGlobalUnicast() && !ip.IsLoopback() && ip.Zone() == ""
+}

--- a/host/dns.go
+++ b/host/dns.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"tailscale.com/tailcfg"
+	"tailscale.com/types/dnstype"
 	"tailscale.com/types/netmap"
 )
 
@@ -34,13 +36,55 @@ func dnsName(raw string) (string, bool) {
 	return name, true
 }
 
-func dnsRouteDomains(nm *netmap.NetworkMap) []string {
-	domains := []string{}
+// restrictedDNSRoutes mirrors Tailscale's exit-node DNS selection: when the
+// selected peer can proxy DNS, only opted-in resolvers override that peer.
+// Empty routes still belong to the built-in DNS records.
+func restrictedDNSRoutes(nm *netmap.NetworkMap, exitNodeID string) map[string][]*dnstype.Resolver {
 	if nm == nil {
-		return domains
+		return nil
 	}
+	useExitDNS := false
+	for _, peer := range nm.Peers {
+		if !peer.Valid() || exitNodeID == "" || string(peer.StableID()) != exitNodeID {
+			continue
+		}
+		useExitDNS = peer.Cap() >= 26
+		if !useExitDNS && peer.Hostinfo().Valid() {
+			for _, service := range peer.Hostinfo().Services().All() {
+				if service.Proto == tailcfg.PeerAPIDNS && service.Port >= 1 {
+					useExitDNS = true
+					break
+				}
+			}
+		}
+		break
+	}
+	if !useExitDNS {
+		return nm.DNS.Routes
+	}
+	routes := make(map[string][]*dnstype.Resolver)
+	for domain, resolvers := range nm.DNS.Routes {
+		if len(resolvers) == 0 {
+			routes[domain] = nil
+			continue
+		}
+		for _, resolver := range resolvers {
+			if resolver != nil && resolver.UseWithExitNode {
+				routes[domain] = append(routes[domain], resolver)
+			}
+		}
+	}
+	return routes
+}
+
+func dnsRouteDomains(nm *netmap.NetworkMap, exitNodeID string) []string {
+	return dnsDomains(restrictedDNSRoutes(nm, exitNodeID))
+}
+
+func dnsDomains(routes map[string][]*dnstype.Resolver) []string {
+	domains := []string{}
 	seen := map[string]bool{}
-	for raw := range nm.DNS.Routes {
+	for raw := range routes {
 		if domain, ok := dnsName(raw); ok && !seen[domain] {
 			seen[domain] = true
 			domains = append(domains, domain)
@@ -54,13 +98,14 @@ func dnsRouteDomains(nm *netmap.NetworkMap) []string {
 // Dial is bound to the same tsnet session as nm. Callers must validate the returned
 // addresses against their destination policy and dial a literal address, so a
 // later DNS answer cannot change the destination after that check.
-func resolveRestrictedDNS(ctx context.Context, network, hostname string, nm *netmap.NetworkMap, dial func(context.Context, string, string) (net.Conn, error)) ([]netip.Addr, bool, error) {
+func resolveRestrictedDNS(ctx context.Context, network, hostname string, nm *netmap.NetworkMap, exitNodeID string, dial func(context.Context, string, string) (net.Conn, error)) ([]netip.Addr, bool, error) {
 	host, ok := dnsName(hostname)
 	if !ok || nm == nil {
 		return nil, false, nil
 	}
+	routes := restrictedDNSRoutes(nm, exitNodeID)
 	matched := ""
-	for _, domain := range dnsRouteDomains(nm) {
+	for _, domain := range dnsDomains(routes) {
 		if (host == domain || strings.HasSuffix(host, "."+domain)) && len(domain) > len(matched) {
 			matched = domain
 		}
@@ -69,8 +114,8 @@ func resolveRestrictedDNS(ctx context.Context, network, hostname string, nm *net
 		return nil, false, nil
 	}
 	// Keep lookup order deterministic even if a map contains duplicate normalized keys.
-	keys := make([]string, 0, len(nm.DNS.Routes))
-	for key := range nm.DNS.Routes {
+	keys := make([]string, 0, len(routes))
+	for key := range routes {
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
@@ -79,7 +124,7 @@ func resolveRestrictedDNS(ctx context.Context, network, hostname string, nm *net
 		if domain, valid := dnsName(key); !valid || domain != matched {
 			continue
 		}
-		resolvers := nm.DNS.Routes[key]
+		resolvers := routes[key]
 		if len(resolvers) == 0 {
 			// Empty routes belong to Tailscale's in-memory DNS records.
 			return nil, false, nil

--- a/host/exit_dns.go
+++ b/host/exit_dns.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"golang.org/x/net/dns/dnsmessage"
+	"io"
+	"net"
+	"net/http"
+	"net/netip"
+	"tailscale.com/tailcfg"
+	"tailscale.com/tsnet"
+	"tailscale.com/types/dnstype"
+	"tailscale.com/types/netmap"
+)
+
+// Exit DNS remains active when accepting the tailnet's DNS configuration is off.
+// Capture the selected peer's literal endpoint and never use the system resolver
+// or follow an HTTP redirect. Returned addresses still require destination checks.
+func queryExitProxyDNS(ctx context.Context, nm *netmap.NetworkMap, exitNodeID, network, hostname string, dial func(context.Context, string, string) (net.Conn, error)) ([]netip.Addr, error) {
+	host, valid := dnsName(hostname)
+	if !valid || nm == nil || exitNodeID == "" {
+		return nil, errProxyDestinationDenied
+	}
+	for _, peer := range nm.Peers {
+		if !peer.Valid() || string(peer.StableID()) != exitNodeID {
+			continue
+		}
+		if endpoint := exitProxyDNSEndpoint(nm, peer); endpoint != "" {
+			transport := &http.Transport{DialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
+				if address != endpoint {
+					return nil, errProxyDestinationDenied
+				}
+				return dial(ctx, network, endpoint)
+			}, DisableKeepAlives: true}
+			defer transport.CloseIdleConnections()
+			client := &http.Client{Transport: transport, CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}
+			var addresses []netip.Addr
+			name, err := dnsmessage.NewName(host + ".")
+			if err != nil {
+				return nil, errProxyDestinationDenied
+			}
+			for _, kind := range []dnsmessage.Type{dnsmessage.TypeA, dnsmessage.TypeAAAA} {
+				question := dnsmessage.Question{Name: name, Type: kind, Class: dnsmessage.ClassINET}
+				query := dnsmessage.Message{Header: dnsmessage.Header{RecursionDesired: true}, Questions: []dnsmessage.Question{question}}
+				packet, err := query.Pack()
+				if err != nil {
+					return nil, err
+				}
+				req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://"+endpoint+"/dns-query", bytes.NewReader(packet))
+				if err != nil {
+					return nil, err
+				}
+				req.Header.Set("Content-Type", "application/dns-message")
+				res, err := client.Do(req)
+				if err != nil {
+					return nil, err
+				}
+				wire, readErr := io.ReadAll(io.LimitReader(res.Body, 65536))
+				res.Body.Close()
+				if readErr != nil || len(wire) > 65535 || res.StatusCode != http.StatusOK || res.Header.Get("Content-Type") != "application/dns-message" {
+					return nil, fmt.Errorf("exit DNS returned an invalid response")
+				}
+				var response dnsmessage.Message
+				if err := response.Unpack(wire); err != nil || !response.Response || response.Truncated || response.RCode != dnsmessage.RCodeSuccess || response.ID != query.ID || len(response.Questions) != 1 || response.Questions[0] != question {
+					return nil, fmt.Errorf("exit DNS query failed")
+				}
+				for _, answer := range response.Answers {
+					switch body := answer.Body.(type) {
+					case *dnsmessage.AResource:
+						addresses = append(addresses, netip.AddrFrom4(body.A))
+					case *dnsmessage.AAAAResource:
+						addresses = append(addresses, netip.AddrFrom16(body.AAAA).Unmap())
+					}
+				}
+			}
+			if len(addresses) == 0 {
+				return nil, fmt.Errorf("exit DNS returned no addresses")
+			}
+			return addresses, nil
+		}
+		if peer.IsWireGuardOnly() {
+			var resolvers []*dnstype.Resolver
+			for _, resolver := range peer.ExitNodeDNSResolvers().All() {
+				resolvers = append(resolvers, resolver.AsStruct())
+			}
+			if len(resolvers) > 0 {
+				// The selected exit's explicit DNS addresses may be private; this narrow
+				// exception still dials only through that session's netstack.
+				dnsMap := &netmap.NetworkMap{DNS: tailcfg.DNSConfig{Routes: map[string][]*dnstype.Resolver{host: resolvers}}}
+				addresses, _, err := resolveRestrictedDNS(ctx, network, host, dnsMap, "", dial)
+				return addresses, err
+			}
+		}
+		break
+	}
+	return nil, fmt.Errorf("selected exit has no supported DNS endpoint")
+}
+
+func exitProxyDNSEndpoint(nm *netmap.NetworkMap, peer tailcfg.NodeView) string {
+	if !peer.Hostinfo().Valid() {
+		return ""
+	}
+	canProxy := peer.Cap() >= 26
+	for _, service := range peer.Hostinfo().Services().All() {
+		if service.Proto == tailcfg.PeerAPIDNS && service.Port > 0 {
+			canProxy = true
+		}
+	}
+	if !canProxy {
+		return ""
+	}
+	for _, is4 := range []bool{true, false} {
+		haveFamily := false
+		for _, address := range nm.GetAddresses().All() {
+			if address.IsSingleIP() && address.Addr().Is4() == is4 {
+				haveFamily = true
+			}
+		}
+		if !haveFamily {
+			continue
+		}
+		for _, service := range peer.Hostinfo().Services().All() {
+			if service.Port == 0 || (is4 && service.Proto != tailcfg.PeerAPI4) || (!is4 && service.Proto != tailcfg.PeerAPI6) {
+				continue
+			}
+			for _, address := range peer.Addresses().All() {
+				if address.IsSingleIP() && address.Addr().Is4() == is4 && safeProxyIP(address.Addr()) {
+					return netip.AddrPortFrom(address.Addr(), service.Port).String()
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func dialProxyDNSNetstack(ctx context.Context, ts *tsnet.Server, network, address string) (net.Conn, error) {
+	target, err := netip.ParseAddrPort(address)
+	if err != nil || target.Port() == 0 || !safeProxyIP(target.Addr()) {
+		return nil, errProxyDestinationDenied
+	}
+	dialer := ts.Sys().Dialer.Get()
+	switch network {
+	case "tcp", "tcp4", "tcp6":
+		if dialer.NetstackDialTCP != nil {
+			return dialer.NetstackDialTCP(ctx, target)
+		}
+	case "udp", "udp4", "udp6":
+		if dialer.NetstackDialUDP != nil {
+			return dialer.NetstackDialUDP(ctx, target)
+		}
+	}
+	return nil, errProxyDestinationDenied
+}

--- a/host/exit_dns_test.go
+++ b/host/exit_dns_test.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"context"
+	"encoding/binary"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"reflect"
+	"testing"
+
+	"golang.org/x/net/dns/dnsmessage"
+	"tailscale.com/tailcfg"
+	"tailscale.com/types/dnstype"
+	"tailscale.com/types/netmap"
+)
+
+func exitDNSMap() *netmap.NetworkMap {
+	self := (&tailcfg.Node{Addresses: []netip.Prefix{netip.MustParsePrefix("100.64.0.1/32")}}).View()
+	peer := (&tailcfg.Node{StableID: "exit", Cap: 26, Addresses: []netip.Prefix{netip.MustParsePrefix("100.64.0.2/32")}, Hostinfo: (&tailcfg.Hostinfo{Services: []tailcfg.Service{{Proto: tailcfg.PeerAPI4, Port: 1234}}}).View()}).View()
+	return &netmap.NetworkMap{SelfNode: self, Peers: []tailcfg.NodeView{peer}}
+}
+
+func exitDNSResponse(t *testing.T, packet []byte) []byte {
+	t.Helper()
+	var query dnsmessage.Message
+	if err := query.Unpack(packet); err != nil || len(query.Questions) != 1 {
+		t.Errorf("invalid query: %v", err)
+		return nil
+	}
+	q := query.Questions[0]
+	response := dnsmessage.Message{Header: dnsmessage.Header{ID: query.ID, Response: true}, Questions: query.Questions}
+	if q.Type == dnsmessage.TypeA {
+		response.Answers = []dnsmessage.Resource{{Header: dnsmessage.ResourceHeader{Name: q.Name, Type: q.Type, Class: dnsmessage.ClassINET}, Body: &dnsmessage.AResource{A: [4]byte{8, 8, 8, 8}}}}
+	}
+	packet, err := response.Pack()
+	if err != nil {
+		t.Errorf("pack response: %v", err)
+	}
+	return packet
+}
+
+func TestExitDNSPinsSelectedPeerEndpoint(t *testing.T) {
+	for _, mode := range []string{"success", "redirect", "wrong content", "wrong question"} {
+		t.Run(mode, func(t *testing.T) {
+			count := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				count++
+				if r.Host != "100.64.0.2:1234" || r.Method != http.MethodPost || r.URL.Path != "/dns-query" || r.Header.Get("Content-Type") != "application/dns-message" {
+					t.Errorf("unexpected request: %s %s %s", r.Method, r.Host, r.URL)
+				}
+				if mode == "redirect" {
+					http.Redirect(w, r, "http://127.0.0.1/private", http.StatusFound)
+					return
+				}
+				packet, err := io.ReadAll(r.Body)
+				if err != nil {
+					t.Error(err)
+					return
+				}
+				wire := exitDNSResponse(t, packet)
+				w.Header().Set("Content-Type", "application/dns-message")
+				if mode == "wrong content" {
+					w.Header().Set("Content-Type", "text/plain")
+				}
+				if mode == "wrong question" {
+					var response dnsmessage.Message
+					_ = response.Unpack(wire)
+					response.Questions = nil
+					wire, _ = response.Pack()
+				}
+				_, _ = w.Write(wire)
+			}))
+			defer server.Close()
+			dial := func(ctx context.Context, network, address string) (net.Conn, error) {
+				if address != "100.64.0.2:1234" {
+					t.Errorf("unselected endpoint %s", address)
+				}
+				var d net.Dialer
+				return d.DialContext(ctx, network, server.Listener.Addr().String())
+			}
+			addresses, err := queryExitProxyDNS(context.Background(), exitDNSMap(), "exit", "tcp", "www.example.test", dial)
+			if mode == "success" {
+				if err != nil || !reflect.DeepEqual(addresses, []netip.Addr{netip.MustParseAddr("8.8.8.8")}) || count != 2 {
+					t.Fatalf("addresses %v, error %v, requests %d", addresses, err, count)
+				}
+			} else if err == nil || count != 1 {
+				t.Fatalf("invalid reply accepted or redirect followed: %v, %d requests", err, count)
+			}
+		})
+	}
+}
+
+func TestExitDNSDoesNotFallBackWhenSelectedPeerUnavailable(t *testing.T) {
+	for _, id := range []string{"", "missing"} {
+		_, err := queryExitProxyDNS(context.Background(), exitDNSMap(), id, "tcp", "www.example.test", func(context.Context, string, string) (net.Conn, error) { t.Fatal("unexpected dial"); return nil, nil })
+		if err == nil {
+			t.Fatal("missing exit accepted")
+		}
+	}
+	nm := exitDNSMap()
+	peer := nm.Peers[0].AsStruct()
+	peer.Cap = 0
+	nm.Peers[0] = peer.View()
+	if endpoint := exitProxyDNSEndpoint(nm, nm.Peers[0]); endpoint != "" {
+		t.Fatalf("unsupported exit endpoint %s", endpoint)
+	}
+	peer.Hostinfo = (&tailcfg.Hostinfo{Services: []tailcfg.Service{{Proto: tailcfg.PeerAPI4, Port: 1234}, {Proto: tailcfg.PeerAPIDNS, Port: 1}}}).View()
+	nm.Peers[0] = peer.View()
+	if endpoint := exitProxyDNSEndpoint(nm, nm.Peers[0]); endpoint != "100.64.0.2:1234" {
+		t.Fatalf("legacy exit endpoint %s", endpoint)
+	}
+}
+
+func TestWireGuardExitDNSUsesOnlyAdvertisedLiteralResolver(t *testing.T) {
+	nm := exitDNSMap()
+	peer := nm.Peers[0].AsStruct()
+	peer.Cap = 0
+	peer.IsWireGuardOnly = true
+	peer.ExitNodeDNSResolvers = []*dnstype.Resolver{{Addr: "10.64.0.1"}}
+	nm.Peers[0] = peer.View()
+	dial := func(ctx context.Context, network, address string) (net.Conn, error) {
+		if address != "10.64.0.1:53" {
+			t.Errorf("unexpected DNS address %s", address)
+		}
+		client, upstream := net.Pipe()
+		go func() {
+			defer upstream.Close()
+			var size uint16
+			if binary.Read(upstream, binary.BigEndian, &size) != nil {
+				return
+			}
+			packet := make([]byte, size)
+			if _, err := io.ReadFull(upstream, packet); err != nil {
+				return
+			}
+			wire := exitDNSResponse(t, packet)
+			_ = binary.Write(upstream, binary.BigEndian, uint16(len(wire)))
+			_, _ = upstream.Write(wire)
+		}()
+		return client, nil
+	}
+	addresses, err := queryExitProxyDNS(context.Background(), nm, "exit", "tcp4", "www.example.test", dial)
+	if err != nil || !reflect.DeepEqual(addresses, []netip.Addr{netip.MustParseAddr("8.8.8.8")}) {
+		t.Fatalf("addresses %v, err %v", addresses, err)
+	}
+	peer.ExitNodeDNSResolvers = []*dnstype.Resolver{{Addr: "127.0.0.1"}}
+	nm.Peers[0] = peer.View()
+	_, err = queryExitProxyDNS(context.Background(), nm, "exit", "tcp4", "www.example.test", func(context.Context, string, string) (net.Conn, error) {
+		t.Fatal("unsafe resolver dialed")
+		return nil, nil
+	})
+	if err == nil {
+		t.Fatal("unsafe resolver accepted")
+	}
+}

--- a/host/host.go
+++ b/host/host.go
@@ -22,6 +22,7 @@ import (
 	"tailscale.com/ipn/ipnstate"
 	"tailscale.com/tailcfg"
 	"tailscale.com/tsnet"
+	"tailscale.com/types/netmap"
 )
 
 const (
@@ -67,6 +68,7 @@ type Host struct {
 	lastBrowseToURL string
 	lastPrefs       *PrefsView
 	lastHealth      []string
+	lastNetMap      *netmap.NetworkMap
 
 	pendingMu        sync.Mutex
 	pendingTransfers map[string]*fileTransferAccumulator
@@ -76,6 +78,9 @@ type Host struct {
 
 	webMu    sync.Mutex
 	webCache *webServerCache
+
+	proxyAuth     *ProxyAuth
+	proxyListener net.Listener
 
 	// proxyDial is a test seam; production leaves it nil and uses tsnet.
 	proxyDial func(context.Context, string, string) (net.Conn, error)
@@ -215,6 +220,7 @@ func (h *Host) clearCachedStatus(prefs *ipn.Prefs) {
 	h.lastBrowseToURL = ""
 	h.lastPrefs = nil
 	h.lastHealth = nil
+	h.lastNetMap = nil
 	if prefs != nil {
 		h.lastPrefs = prefsViewFromIPN(prefs.View())
 	}
@@ -985,6 +991,8 @@ func (h *Host) handleLogout() {
 	}
 
 	h.cancelStartupCorrection()
+	restartWatcher := h.beginProxyProfileChange(lc)
+	defer restartWatcher()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()

--- a/host/main.go
+++ b/host/main.go
@@ -109,6 +109,7 @@ func main() {
 		Cmd: "procRunning",
 		ProcRunning: &ProcRunningReply{
 			Port:                     port,
+			ProxyAuth:                h.proxyAuth,
 			PID:                      os.Getpid(),
 			Version:                  version,
 			SupportsNetcheck:         false,

--- a/host/profiles.go
+++ b/host/profiles.go
@@ -49,6 +49,8 @@ func (h *Host) handleSwitchProfile(profileID string) {
 	}
 
 	h.cancelStartupCorrection()
+	restartWatcher := h.beginProxyProfileChange(lc)
+	defer restartWatcher()
 
 	ctx := context.Background()
 	if err := lc.SwitchProfile(ctx, ipn.ProfileID(profileID)); err != nil {
@@ -68,6 +70,8 @@ func (h *Host) handleNewProfile() {
 	}
 
 	h.cancelStartupCorrection()
+	restartWatcher := h.beginProxyProfileChange(lc)
+	defer restartWatcher()
 
 	ctx := context.Background()
 	if err := lc.SwitchToEmptyProfile(ctx); err != nil {
@@ -92,6 +96,8 @@ func (h *Host) handleDeleteProfile(profileID string) {
 	}
 
 	h.cancelStartupCorrection()
+	restartWatcher := h.beginProxyProfileChange(lc)
+	defer restartWatcher()
 
 	ctx := context.Background()
 	if err := lc.DeleteProfile(ctx, ipn.ProfileID(profileID)); err != nil {

--- a/host/protocol.go
+++ b/host/protocol.go
@@ -46,17 +46,24 @@ type Reply struct {
 	Error              *ErrorReply            `json:"error,omitempty"`
 }
 
-// ProcRunningReply is sent immediately after the host starts to inform the
-// extension of the proxy port and process ID.
+// ProxyAuth is delivered only over the private native messaging channel.
+type ProxyAuth struct {
+	Version  int    `json:"version"`
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+// ProcRunningReply announces the proxy endpoint and its process credential.
 type ProcRunningReply struct {
-	Port                     int    `json:"port"`
-	PID                      int    `json:"pid"`
-	Version                  string `json:"version"`
-	Error                    string `json:"error,omitempty"`
-	SupportsNetcheck         bool   `json:"supportsNetcheck,omitempty"`
-	SupportsPingPeer         bool   `json:"supportsPingPeer,omitempty"`
-	SupportsLogin            bool   `json:"supportsLogin,omitempty"`
-	SupportsCustomControlURL bool   `json:"supportsCustomControlURL,omitempty"`
+	ProxyAuth                *ProxyAuth `json:"proxyAuth,omitempty"`
+	Port                     int        `json:"port"`
+	PID                      int        `json:"pid"`
+	Version                  string     `json:"version"`
+	Error                    string     `json:"error,omitempty"`
+	SupportsNetcheck         bool       `json:"supportsNetcheck,omitempty"`
+	SupportsPingPeer         bool       `json:"supportsPingPeer,omitempty"`
+	SupportsLogin            bool       `json:"supportsLogin,omitempty"`
+	SupportsCustomControlURL bool       `json:"supportsCustomControlURL,omitempty"`
 }
 
 // InitReply is the response to an "init" command.

--- a/host/proxy.go
+++ b/host/proxy.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"log"
@@ -9,6 +12,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"strings"
+	"time"
 
 	"tailscale.com/client/local"
 	"tailscale.com/client/web"
@@ -22,13 +26,15 @@ type webServerCache struct {
 }
 
 // startProxy starts an HTTP+SOCKS5 proxy on 127.0.0.1:0 and returns the port.
-// The proxy uses the tsnet.Server's Dial method to route connections through the tailnet.
+// Protected connections use the userspace network stack after destination validation.
 func (h *Host) startProxy() (int, error) {
+	h.proxyAuth = &ProxyAuth{Version: 1, Username: "tailchrome", Password: rand.Text() + rand.Text()}
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		return 0, fmt.Errorf("failed to listen: %w", err)
 	}
 
+	h.proxyListener = ln
 	port := ln.Addr().(*net.TCPAddr).Port
 
 	// Split the listener into SOCKS5 and HTTP listeners.
@@ -36,8 +42,10 @@ func (h *Host) startProxy() (int, error) {
 
 	// Start the SOCKS5 proxy.
 	socksServer := &socks5.Server{
-		Logf:   log.Printf,
-		Dialer: h.tsnetDialer,
+		Logf:     func(string, ...any) {},
+		Username: h.proxyAuth.Username,
+		Password: h.proxyAuth.Password,
+		Dialer:   h.tsnetDialer,
 	}
 	go func() {
 		if err := socksServer.Serve(socksLn); err != nil {
@@ -64,13 +72,13 @@ func (h *Host) tsnetDialer(ctx context.Context, network, addr string) (net.Conn,
 	if ts == nil {
 		return nil, fmt.Errorf("tsnet server not initialized")
 	}
-	return ts.Dial(ctx, network, addr)
+	return h.dialAllowedProxyDestination(ctx, ts, network, addr)
 }
 
 // serveHTTPProxy serves HTTP proxy requests, routing 100.100.100.100 to the
 // Tailscale web client and everything else through the tailnet.
 func (h *Host) serveHTTPProxy(ln net.Listener) error {
-	server := &http.Server{Handler: h.httpProxyHandler()}
+	server := &http.Server{Handler: h.httpProxyHandler(), ReadHeaderTimeout: 10 * time.Second}
 	return server.Serve(ln)
 }
 
@@ -80,11 +88,18 @@ func (h *Host) httpProxyHandler() http.Handler {
 			// No-op: we handle the request ourselves.
 		},
 		Transport: &http.Transport{
-			DialContext: h.tsnetDialer,
+			DialContext:       h.tsnetDialer,
+			DisableKeepAlives: true,
 		},
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !h.authenticateProxyRequest(r) {
+			w.Header().Set("Proxy-Authenticate", `Basic realm="Tailchrome"`)
+			http.Error(w, "Proxy authentication required", http.StatusProxyAuthRequired)
+			return
+		}
+		r.Header.Del("Proxy-Authorization")
 		host := r.Host
 		if h, _, err := net.SplitHostPort(host); err == nil {
 			host = h
@@ -198,4 +213,21 @@ func (h *Host) handleConnect(w http.ResponseWriter, r *http.Request) {
 	}()
 	<-done
 	<-done
+}
+
+func (h *Host) authenticateProxyRequest(r *http.Request) bool {
+	if h.proxyAuth == nil {
+		return false
+	}
+	const prefix = "Basic "
+	value := r.Header.Get("Proxy-Authorization")
+	if len(value) < len(prefix) || !strings.EqualFold(value[:len(prefix)], prefix) {
+		return false
+	}
+	decoded, err := base64.StdEncoding.DecodeString(value[len(prefix):])
+	if err != nil {
+		return false
+	}
+	expected := h.proxyAuth.Username + ":" + h.proxyAuth.Password
+	return subtle.ConstantTimeCompare(decoded, []byte(expected)) == 1
 }

--- a/host/proxy_auth_test.go
+++ b/host/proxy_auth_test.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func proxyAuthorization(h *Host) string {
+	return "Basic " + base64.StdEncoding.EncodeToString([]byte(h.proxyAuth.Username+":"+h.proxyAuth.Password))
+}
+
+func TestProxyAuthenticatesAllHTTPPaths(t *testing.T) {
+	for _, tc := range []struct{ method, target string }{{"GET", "http://100.64.0.2/"}, {"CONNECT", "http://100.64.0.2:443"}, {"GET", "http://100.100.100.100/"}} {
+		t.Run(tc.method+tc.target, func(t *testing.T) {
+			h := newHost(nil, nil)
+			h.proxyAuth = &ProxyAuth{Version: 1, Username: "user", Password: "secret"}
+			h.proxyDial = func(context.Context, string, string) (net.Conn, error) {
+				t.Error("unauthenticated request dialed")
+				return nil, fmt.Errorf("denied")
+			}
+			for _, header := range []string{"", "Basic dXNlcjp3cm9uZw==", "Bearer secret"} {
+				req := httptest.NewRequest(tc.method, tc.target, nil)
+				req.Header.Set("Proxy-Authorization", header)
+				res := httptest.NewRecorder()
+				h.httpProxyHandler().ServeHTTP(res, req)
+				if res.Code != http.StatusProxyAuthRequired || res.Header().Get("Proxy-Authenticate") == "" {
+					t.Fatalf("authentication not enforced: %d", res.Code)
+				}
+			}
+		})
+	}
+}
+
+func TestAuthenticatedHTTPStripsProxyCredentials(t *testing.T) {
+	seen := make(chan string, 1)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen <- r.Header.Get("Proxy-Authorization")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+	h := newHost(nil, nil)
+	h.proxyAuth = &ProxyAuth{Version: 1, Username: "user", Password: "secret"}
+	h.proxyDial = func(ctx context.Context, network, address string) (net.Conn, error) {
+		var dialer net.Dialer
+		return dialer.DialContext(ctx, network, upstream.Listener.Addr().String())
+	}
+	req := httptest.NewRequest("GET", "http://100.64.0.2/", nil)
+	req.Header.Set("Proxy-Authorization", proxyAuthorization(h))
+	res := httptest.NewRecorder()
+	h.httpProxyHandler().ServeHTTP(res, req)
+	if res.Code != http.StatusNoContent {
+		t.Fatalf("status = %d", res.Code)
+	}
+	if header := <-seen; header != "" {
+		t.Fatal("proxy credential reached upstream")
+	}
+}
+
+func TestSOCKSRequiresProcessCredential(t *testing.T) {
+	h := newHost(nil, nil)
+	port, err := h.startProxy()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { h.proxyListener.Close() })
+	connect := func() net.Conn {
+		conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+		if err != nil {
+			t.Fatal(err)
+		}
+		conn.SetDeadline(time.Now().Add(2 * time.Second))
+		t.Cleanup(func() { conn.Close() })
+		return conn
+	}
+	c := connect()
+	c.Write([]byte{5, 1, 0})
+	response := make([]byte, 2)
+	if _, err := io.ReadFull(c, response); err != nil {
+		t.Fatal(err)
+	}
+	if response[1] != 255 {
+		t.Fatalf("no-auth accepted: %v", response)
+	}
+	for _, password := range []string{"wrong", h.proxyAuth.Password} {
+		c := connect()
+		c.Write([]byte{5, 1, 2})
+		if _, err := io.ReadFull(c, response); err != nil {
+			t.Fatal(err)
+		}
+		if response[1] != 2 {
+			t.Fatalf("password method not selected: %v", response)
+		}
+		payload := append([]byte{1, byte(len(h.proxyAuth.Username))}, []byte(h.proxyAuth.Username)...)
+		payload = append(payload, byte(len(password)))
+		payload = append(payload, []byte(password)...)
+		c.Write(payload)
+		if _, err := io.ReadFull(c, response); err != nil {
+			t.Fatal(err)
+		}
+		if (response[1] == 0) != (password == h.proxyAuth.Password) {
+			t.Fatalf("incorrect auth result: %v", response)
+		}
+	}
+}
+
+func TestProxyCredentialRotatesWithHelper(t *testing.T) {
+	first, second := newHost(nil, nil), newHost(nil, nil)
+	for _, h := range []*Host{first, second} {
+		if _, err := h.startProxy(); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { h.proxyListener.Close() })
+	}
+	if first.proxyAuth.Password == second.proxyAuth.Password {
+		t.Fatal("credential reused")
+	}
+	req := httptest.NewRequest("GET", "http://100.100.100.100/", nil)
+	req.Header.Set("Proxy-Authorization", proxyAuthorization(first))
+	if second.authenticateProxyRequest(req) {
+		t.Fatal("old helper credential accepted")
+	}
+}
+
+func TestAuthenticatedConnectEstablishesTunnel(t *testing.T) {
+	h := newHost(nil, nil)
+	h.proxyAuth = &ProxyAuth{Version: 1, Username: "user", Password: "secret"}
+	upstream, target := net.Pipe()
+	defer target.Close()
+	h.proxyDial = func(context.Context, string, string) (net.Conn, error) { return upstream, nil }
+	proxy := httptest.NewServer(h.httpProxyHandler())
+	defer proxy.Close()
+	conn, err := net.Dial("tcp", proxy.Listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	conn.SetDeadline(time.Now().Add(2 * time.Second))
+	fmt.Fprintf(conn, "CONNECT 100.64.0.2:443 HTTP/1.1\r\nHost: 100.64.0.2:443\r\nProxy-Authorization: %s\r\n\r\n", proxyAuthorization(h))
+	response, err := http.ReadResponse(bufio.NewReader(conn), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", response.StatusCode)
+	}
+}

--- a/host/proxy_policy.go
+++ b/host/proxy_policy.go
@@ -159,6 +159,15 @@ func proxyMagicDNSAddresses(nm *netmap.NetworkMap, hostname string) []netip.Addr
 	for _, peer := range nm.Peers {
 		add(peer)
 	}
+	for _, record := range nm.DNS.ExtraRecords {
+		name, valid := dnsName(record.Name)
+		if !valid || name != hostname || (record.Type != "" && record.Type != "A" && record.Type != "AAAA") {
+			continue
+		}
+		if ip, err := netip.ParseAddr(record.Value); err == nil {
+			ips = append(ips, ip.Unmap())
+		}
+	}
 	return ips
 }
 
@@ -197,10 +206,14 @@ func (h *Host) dialAllowedProxyDestination(ctx context.Context, ts *tsnet.Server
 	} else if ips = proxyMagicDNSAddresses(nm, hostname); len(ips) == 0 {
 		var matched bool
 		if prefs.CorpDNS {
-			ips, matched, err = resolveRestrictedDNS(ctx, network, hostname, nm, func(ctx context.Context, network, address string) (net.Conn, error) {
+			ips, matched, err = resolveRestrictedDNS(ctx, network, hostname, nm, string(prefs.ExitNodeID), func(ctx context.Context, network, address string) (net.Conn, error) {
 				h.sessionMu.RLock()
 				defer h.sessionMu.RUnlock()
 				if h.lc != lc || h.sessionGeneration != generation {
+					return nil, errProxyDestinationDenied
+				}
+				currentPrefs, err := lc.GetPrefs(ctx)
+				if err != nil || !sameProxyPrefs(prefs, currentPrefs) {
 					return nil, errProxyDestinationDenied
 				}
 				return dialProxyDNS(ctx, ts, nm, prefs, network, address)
@@ -213,7 +226,20 @@ func (h *Host) dialAllowedProxyDestination(ctx context.Context, ts *tsnet.Server
 			if prefs.ExitNodeID == "" {
 				return nil, errProxyDestinationDenied
 			}
-			ips, err = queryProxyDNS(ctx, lc, hostname)
+			if prefs.CorpDNS {
+				ips, err = queryProxyDNS(ctx, lc, hostname)
+			} else {
+				// Exit DNS is independent of accepting the tailnet DNS settings.
+				// QueryDNS has no upstream routes when CorpDNS is disabled.
+				ips, err = queryExitProxyDNS(ctx, nm, string(prefs.ExitNodeID), network, hostname, func(ctx context.Context, network, address string) (net.Conn, error) {
+					h.sessionMu.RLock()
+					defer h.sessionMu.RUnlock()
+					if h.lc != lc || h.sessionGeneration != generation {
+						return nil, errProxyDestinationDenied
+					}
+					return dialProxyDNSNetstack(ctx, ts, network, address)
+				})
+			}
 			if err != nil {
 				return nil, errProxyDestinationDenied
 			}
@@ -261,6 +287,11 @@ func (h *Host) dialAllowedProxyDestination(ctx context.Context, ts *tsnet.Server
 			return nil, errProxyDestinationDenied
 		}
 		if localAddresses[target.Addr()] {
+			// A staggered attempt may run after LAN access was disabled.
+			currentPrefs, err := lc.GetPrefs(ctx)
+			if err != nil || !sameProxyPrefs(prefs, currentPrefs) {
+				return nil, errProxyDestinationDenied
+			}
 			var localDialer net.Dialer
 			return localDialer.DialContext(ctx, network, target.String())
 		}

--- a/host/proxy_policy.go
+++ b/host/proxy_policy.go
@@ -1,0 +1,376 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/netip"
+	"strconv"
+	"strings"
+	"time"
+
+	"golang.org/x/net/dns/dnsmessage"
+	"tailscale.com/client/local"
+	"tailscale.com/ipn"
+	"tailscale.com/net/netx"
+	"tailscale.com/net/tsaddr"
+	"tailscale.com/tailcfg"
+	"tailscale.com/tsnet"
+	"tailscale.com/types/netmap"
+)
+
+var errProxyDestinationDenied = errors.New("destination is not permitted by the current routing policy")
+
+// These addresses must never become reachable via a broad subnet advertisement.
+var forbiddenProxyRanges = []netip.Prefix{
+	netip.MustParsePrefix("0.0.0.0/8"), netip.MustParsePrefix("127.0.0.0/8"),
+	netip.MustParsePrefix("169.254.0.0/16"), netip.MustParsePrefix("224.0.0.0/4"),
+	netip.MustParsePrefix("240.0.0.0/4"), netip.MustParsePrefix("::/128"),
+	netip.MustParsePrefix("::1/128"), netip.MustParsePrefix("fe80::/10"),
+	netip.MustParsePrefix("ff00::/8"),
+}
+
+func safeProxyIP(ip netip.Addr) bool {
+	if !ip.IsValid() || ip.Zone() != "" {
+		return false
+	}
+	ip = ip.Unmap()
+	for _, p := range forbiddenProxyRanges {
+		if p.Contains(ip) {
+			return false
+		}
+	}
+	return true
+}
+
+func safeProxyRoute(p netip.Prefix) bool {
+	if !p.IsValid() || p.Bits() == 0 || p.Addr().Is4In6() {
+		return false
+	}
+	for _, blocked := range forbiddenProxyRanges {
+		if p.Overlaps(blocked) {
+			return false
+		}
+	}
+	return true
+}
+
+// Only primary routes authorized in AllowedIPs are accepted; advertisements and
+// the extension's truncated peer list are not an authorization source.
+func approvedProxySubnet(nm *netmap.NetworkMap, ip netip.Addr) bool {
+	for _, peer := range nm.Peers {
+		for _, primary := range peer.PrimaryRoutes().All() {
+			if !safeProxyRoute(primary) || !primary.Contains(ip) {
+				continue
+			}
+			for _, allowed := range peer.AllowedIPs().All() {
+				if allowed == primary {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func selectedExitRoutesIP(nm *netmap.NetworkMap, prefs *ipn.Prefs, ip netip.Addr) bool {
+	if prefs.ExitNodeID == "" {
+		return false
+	}
+	for _, peer := range nm.Peers {
+		if peer.StableID() != prefs.ExitNodeID {
+			continue
+		}
+		for _, p := range peer.AllowedIPs().All() {
+			if p.Bits() == 0 && p.Contains(ip) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func proxyIPAllowed(nm *netmap.NetworkMap, prefs *ipn.Prefs, ip netip.Addr, lan []netip.Prefix) (allowed, localLAN bool) {
+	ip = ip.Unmap()
+	if nm == nil || prefs == nil || !prefs.WantRunning || !safeProxyIP(ip) {
+		return false, false
+	}
+	if tsaddr.IsTailscaleIP(ip) {
+		return true, false
+	}
+	if prefs.RouteAll && approvedProxySubnet(nm, ip) {
+		return true, false
+	}
+	if prefs.ExitNodeID != "" && prefs.ExitNodeAllowLANAccess && ip.IsPrivate() {
+		for _, p := range lan {
+			if p.Contains(ip) {
+				return true, true
+			}
+		}
+	}
+	if !ip.IsPrivate() && selectedExitRoutesIP(nm, prefs, ip) {
+		return true, false
+	}
+	return false, false
+}
+
+func proxyLANPrefixes() []netip.Prefix {
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return nil
+	}
+	var prefixes []netip.Prefix
+	for _, iface := range interfaces {
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, addr := range addrs {
+			p, err := netip.ParsePrefix(addr.String())
+			if err == nil && p.Addr().IsPrivate() && !tsaddr.IsTailscaleIP(p.Addr()) && safeProxyRoute(p) {
+				prefixes = append(prefixes, p.Masked())
+			}
+		}
+	}
+	return prefixes
+}
+
+func proxyMagicDNSAddresses(nm *netmap.NetworkMap, hostname string) []netip.Addr {
+	hostname = strings.ToLower(strings.TrimSuffix(hostname, "."))
+	var ips []netip.Addr
+	add := func(node tailcfg.NodeView) {
+		if !node.Valid() {
+			return
+		}
+		fqdn := strings.ToLower(strings.TrimSuffix(node.Name(), "."))
+		short, _, _ := strings.Cut(fqdn, ".")
+		if hostname != fqdn && hostname != short {
+			return
+		}
+		for _, addr := range node.Addresses().All() {
+			ips = append(ips, addr.Addr().Unmap())
+		}
+	}
+	add(nm.SelfNode)
+	for _, peer := range nm.Peers {
+		add(peer)
+	}
+	return ips
+}
+
+func (h *Host) dialAllowedProxyDestination(ctx context.Context, ts *tsnet.Server, network, address string) (net.Conn, error) {
+	if network != "tcp" && network != "tcp4" && network != "tcp6" {
+		return nil, errProxyDestinationDenied
+	}
+	hostname, portText, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, errProxyDestinationDenied
+	}
+	port, err := strconv.ParseUint(portText, 10, 16)
+	if err != nil || port == 0 {
+		return nil, errProxyDestinationDenied
+	}
+	currentServer, lc, generation := h.sessionSnapshot()
+	if lc == nil || currentServer != ts {
+		return nil, errProxyDestinationDenied
+	}
+	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	prefs, err := lc.GetPrefs(ctx)
+	if err != nil {
+		return nil, errProxyDestinationDenied
+	}
+	h.stateMu.Lock()
+	nm := h.lastNetMap
+	h.stateMu.Unlock()
+	if nm == nil || !prefs.WantRunning {
+		return nil, errProxyDestinationDenied
+	}
+
+	var ips []netip.Addr
+	if ip, err := netip.ParseAddr(hostname); err == nil {
+		ips = []netip.Addr{ip.Unmap()}
+	} else if ips = proxyMagicDNSAddresses(nm, hostname); len(ips) == 0 {
+		var matched bool
+		if prefs.CorpDNS {
+			ips, matched, err = resolveRestrictedDNS(ctx, network, hostname, nm, func(ctx context.Context, network, address string) (net.Conn, error) {
+				h.sessionMu.RLock()
+				defer h.sessionMu.RUnlock()
+				if h.lc != lc || h.sessionGeneration != generation {
+					return nil, errProxyDestinationDenied
+				}
+				return dialProxyDNS(ctx, ts, nm, prefs, network, address)
+			})
+		}
+		if err != nil {
+			return nil, errProxyDestinationDenied
+		}
+		if !matched {
+			if prefs.ExitNodeID == "" {
+				return nil, errProxyDestinationDenied
+			}
+			ips, err = queryProxyDNS(ctx, lc, hostname)
+			if err != nil {
+				return nil, errProxyDestinationDenied
+			}
+		}
+	}
+	if len(ips) == 0 {
+		return nil, errProxyDestinationDenied
+	}
+	currentPrefs, err := lc.GetPrefs(ctx)
+	if err != nil || !sameProxyPrefs(prefs, currentPrefs) {
+		return nil, errProxyDestinationDenied
+	}
+	status, err := lc.StatusWithoutPeers(ctx)
+	if err != nil || status.BackendState != "Running" || status.Self == nil || !nm.SelfNode.Valid() || status.Self.ID != nm.SelfNode.StableID() {
+		return nil, errProxyDestinationDenied
+	}
+	lan := proxyLANPrefixes()
+	var destinations []netip.AddrPort
+	localAddresses := make(map[netip.Addr]bool)
+	for _, ip := range ips {
+		ip = ip.Unmap()
+		allowed, local := proxyIPAllowed(nm, prefs, ip, lan)
+		// Validate every answer before dialing any. Never resolve the name twice.
+		if !allowed {
+			return nil, errProxyDestinationDenied
+		}
+		if (network == "tcp4" && !ip.Is4()) || (network == "tcp6" && !ip.Is6()) {
+			continue
+		}
+		destinations = append(destinations, netip.AddrPortFrom(ip, uint16(port)))
+		localAddresses[ip] = local
+	}
+	if len(destinations) == 0 {
+		return nil, errProxyDestinationDenied
+	}
+	dialer := ts.Sys().Dialer.Get()
+	return netx.RaceDial(ctx, destinations, func(ctx context.Context, network, address string) (net.Conn, error) {
+		target, err := netip.ParseAddrPort(address)
+		h.sessionMu.RLock()
+		defer h.sessionMu.RUnlock()
+		h.stateMu.Lock()
+		currentMap := h.lastNetMap == nm
+		h.stateMu.Unlock()
+		if !currentMap || err != nil || h.lc != lc || h.sessionGeneration != generation {
+			return nil, errProxyDestinationDenied
+		}
+		if localAddresses[target.Addr()] {
+			var localDialer net.Dialer
+			return localDialer.DialContext(ctx, network, target.String())
+		}
+		// UserDial may fall back to the OS after a route disappears. A protected
+		// connection must stay in netstack even during that route-change race.
+		if dialer.NetstackDialTCP == nil {
+			return nil, errProxyDestinationDenied
+		}
+		return dialer.NetstackDialTCP(ctx, target)
+	}, 300*time.Millisecond)
+}
+
+func queryProxyDNS(ctx context.Context, lc *local.Client, hostname string) ([]netip.Addr, error) {
+	type result struct {
+		ips []netip.Addr
+		err error
+	}
+	results := make(chan result, 2)
+	for _, queryType := range []string{"A", "AAAA"} {
+		go func() {
+			wire, _, err := lc.QueryDNS(ctx, hostname, queryType)
+			if err != nil {
+				results <- result{err: err}
+				return
+			}
+			var message dnsmessage.Message
+			if err := message.Unpack(wire); err != nil || message.Header.RCode != dnsmessage.RCodeSuccess {
+				results <- result{err: fmt.Errorf("DNS query failed")}
+				return
+			}
+			var ips []netip.Addr
+			for _, answer := range message.Answers {
+				switch body := answer.Body.(type) {
+				case *dnsmessage.AResource:
+					ips = append(ips, netip.AddrFrom4(body.A))
+				case *dnsmessage.AAAAResource:
+					ips = append(ips, netip.AddrFrom16(body.AAAA))
+				}
+			}
+			results <- result{ips: ips}
+		}()
+	}
+	var ips []netip.Addr
+	for range 2 {
+		r := <-results
+		ips = append(ips, r.ips...)
+	}
+	if len(ips) == 0 {
+		return nil, fmt.Errorf("DNS returned no addresses")
+	}
+	return ips, nil
+}
+
+// Called only for literal nameservers from the authoritative DNS configuration.
+func dialProxyDNS(ctx context.Context, ts *tsnet.Server, nm *netmap.NetworkMap, prefs *ipn.Prefs, network, address string) (net.Conn, error) {
+	target, err := netip.ParseAddrPort(address)
+	if err != nil || !safeProxyIP(target.Addr()) {
+		return nil, errProxyDestinationDenied
+	}
+	allowed, local := proxyIPAllowed(nm, prefs, target.Addr(), proxyLANPrefixes())
+	publicDNS := !target.Addr().IsPrivate() && !tsaddr.IsTailscaleIP(target.Addr())
+	if (!allowed && publicDNS && prefs.ExitNodeID == "") || local {
+		var dialer net.Dialer
+		return dialer.DialContext(ctx, network, target.String())
+	}
+	if !allowed {
+		return nil, errProxyDestinationDenied
+	}
+	dialer := ts.Sys().Dialer.Get()
+	if strings.HasPrefix(network, "udp") && dialer.NetstackDialUDP != nil {
+		return dialer.NetstackDialUDP(ctx, target)
+	}
+	if strings.HasPrefix(network, "tcp") && dialer.NetstackDialTCP != nil {
+		return dialer.NetstackDialTCP(ctx, target)
+	}
+	return nil, errProxyDestinationDenied
+}
+
+func sameProxyPrefs(a, b *ipn.Prefs) bool {
+	return a.WantRunning == b.WantRunning && a.RouteAll == b.RouteAll && a.ExitNodeID == b.ExitNodeID && a.ExitNodeAllowLANAccess == b.ExitNodeAllowLANAccess && a.CorpDNS == b.CorpDNS && a.ControlURL == b.ControlURL
+}
+
+// Profile changes reuse tsnet. Advance the session generation before switching
+// and restart the watcher afterwards so neither cached maps nor in-flight DNS
+// results can authorize connections under another profile.
+func (h *Host) beginProxyProfileChange(lc *local.Client) func() {
+	h.sessionMu.Lock()
+	if h.lc != lc {
+		h.sessionMu.Unlock()
+		return func() {}
+	}
+	oldCancel := h.watchCancel
+	h.watchCancel = nil
+	h.sessionGeneration++
+	generation := h.sessionGeneration
+	h.clearCachedStatus(nil)
+	h.sessionMu.Unlock()
+	if oldCancel != nil {
+		oldCancel()
+	}
+	return func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		h.sessionMu.Lock()
+		if h.lc != lc || h.sessionGeneration != generation {
+			h.sessionMu.Unlock()
+			cancel()
+			return
+		}
+		h.watchCancel = cancel
+		h.sessionMu.Unlock()
+		go h.watchIPNBus(ctx, lc, generation)
+	}
+}

--- a/host/proxy_policy_test.go
+++ b/host/proxy_policy_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"net/netip"
+	"tailscale.com/ipn"
+	"tailscale.com/tailcfg"
+	"tailscale.com/types/netmap"
+	"testing"
+)
+
+func proxyPolicyMap() *netmap.NetworkMap {
+	node := &tailcfg.Node{StableID: "exit", Name: "router.example.ts.net.", Addresses: []netip.Prefix{netip.MustParsePrefix("100.64.0.2/32")},
+		AllowedIPs: []netip.Prefix{netip.MustParsePrefix("0.0.0.0/0"), netip.MustParsePrefix("::/0"), netip.MustParsePrefix("10.20.0.0/16")}, PrimaryRoutes: []netip.Prefix{netip.MustParsePrefix("10.20.0.0/16")}}
+	return &netmap.NetworkMap{Peers: []tailcfg.NodeView{node.View()}}
+}
+
+func TestProxyDestinationPolicy(t *testing.T) {
+	nm := proxyPolicyMap()
+	lan := []netip.Prefix{netip.MustParsePrefix("192.168.1.0/24")}
+	for _, tc := range []struct {
+		name, ip, exit                       string
+		routes, lan, running, allowed, local bool
+	}{
+		{name: "tailnet", ip: "100.64.0.2", running: true, allowed: true},
+		{name: "tailnet IPv6", ip: "fd7a:115c:a1e0::1", running: true, allowed: true},
+		{name: "approved route", ip: "10.20.1.1", routes: true, running: true, allowed: true},
+		{name: "routes disabled", ip: "10.20.1.1", running: true},
+		{name: "unapproved private", ip: "10.21.1.1", routes: true, running: true},
+		{name: "internet no exit", ip: "8.8.8.8", running: true},
+		{name: "internet exit", ip: "8.8.8.8", exit: "exit", running: true, allowed: true},
+		{name: "missing selected exit", ip: "8.8.8.8", exit: "gone", running: true},
+		{name: "LAN disabled", ip: "192.168.1.10", exit: "exit", running: true},
+		{name: "attached LAN", ip: "192.168.1.10", exit: "exit", lan: true, running: true, allowed: true, local: true},
+		{name: "unattached LAN", ip: "192.168.2.10", exit: "exit", lan: true, running: true},
+		{name: "loopback", ip: "127.0.0.1", exit: "exit", lan: true, running: true},
+		{name: "mapped loopback", ip: "::ffff:127.0.0.1", exit: "exit", running: true},
+		{name: "metadata", ip: "169.254.169.254", exit: "exit", running: true},
+		{name: "multicast", ip: "224.0.0.1", exit: "exit", running: true},
+		{name: "IPv6 linklocal", ip: "fe80::1", exit: "exit", running: true},
+		{name: "stopped", ip: "100.64.0.2"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			prefs := &ipn.Prefs{WantRunning: tc.running, RouteAll: tc.routes, ExitNodeID: tailcfg.StableNodeID(tc.exit), ExitNodeAllowLANAccess: tc.lan}
+			got, local := proxyIPAllowed(nm, prefs, netip.MustParseAddr(tc.ip), lan)
+			if got != tc.allowed || local != tc.local {
+				t.Fatalf("allowed/local = %v/%v, want %v/%v", got, local, tc.allowed, tc.local)
+			}
+		})
+	}
+}
+
+func TestProxyPolicyRejectsUnapprovedAndUnsafeRoutes(t *testing.T) {
+	for _, cidr := range []string{"0.0.0.0/0", "0.0.0.0/1", "127.0.0.0/8", "169.254.0.0/16", "::/0", "fe80::/10"} {
+		if safeProxyRoute(netip.MustParsePrefix(cidr)) {
+			t.Errorf("accepted unsafe route %s", cidr)
+		}
+	}
+	nm := proxyPolicyMap()
+	peer := nm.Peers[0].AsStruct()
+	peer.AllowedIPs = []netip.Prefix{netip.MustParsePrefix("0.0.0.0/0")}
+	nm.Peers = []tailcfg.NodeView{peer.View()}
+	if approvedProxySubnet(nm, netip.MustParseAddr("10.20.1.1")) {
+		t.Fatal("unapproved primary route accepted through default route")
+	}
+}
+
+func TestProxyMagicDNSUsesAuthoritativeAddresses(t *testing.T) {
+	nm := proxyPolicyMap()
+	for _, name := range []string{"router", "router.example.ts.net", "ROUTER.EXAMPLE.TS.NET."} {
+		got := proxyMagicDNSAddresses(nm, name)
+		if len(got) != 1 || got[0] != netip.MustParseAddr("100.64.0.2") {
+			t.Fatalf("lookup %s = %v", name, got)
+		}
+	}
+	if len(proxyMagicDNSAddresses(nm, "router.example.ts.net.evil")) != 0 {
+		t.Fatal("suffix spoof accepted")
+	}
+}

--- a/host/proxy_policy_test.go
+++ b/host/proxy_policy_test.go
@@ -76,3 +76,29 @@ func TestProxyMagicDNSUsesAuthoritativeAddresses(t *testing.T) {
 		t.Fatal("suffix spoof accepted")
 	}
 }
+
+func TestProxyExtraDNSRecordsUseExactNamesAndValidatedDestinations(t *testing.T) {
+	nm := proxyPolicyMap()
+	nm.DNS.ExtraRecords = []tailcfg.DNSRecord{
+		{Name: "Wiki.Internal.Example.", Value: "100.64.0.3"},
+		{Name: "wiki.internal.example", Type: "A", Value: "10.20.1.1"},
+		{Name: "wiki.internal.example", Type: "AAAA", Value: "fd7a:115c:a1e0::3"},
+		{Name: "wiki.internal.example", Type: "TXT", Value: "100.64.0.9"},
+		{Name: "wiki.internal.example", Type: "A", Value: "not-an-address"},
+		{Name: "local.internal.example", Value: "::ffff:127.0.0.1"},
+	}
+	got := proxyMagicDNSAddresses(nm, "WIKI.INTERNAL.EXAMPLE.")
+	if len(got) != 3 {
+		t.Fatalf("addresses %v", got)
+	}
+	if len(proxyMagicDNSAddresses(nm, "wiki")) != 0 || len(proxyMagicDNSAddresses(nm, "wiki.internal.example.attacker")) != 0 {
+		t.Fatal("inexact extra record matched")
+	}
+	local := proxyMagicDNSAddresses(nm, "local.internal.example")
+	if len(local) != 1 {
+		t.Fatal("missing local record")
+	}
+	if allowed, _ := proxyIPAllowed(nm, &ipn.Prefs{WantRunning: true, RouteAll: true}, local[0], nil); allowed {
+		t.Fatal("unsafe extra record bypassed destination validation")
+	}
+}

--- a/host/proxy_test.go
+++ b/host/proxy_test.go
@@ -15,6 +15,7 @@ import (
 
 func TestHTTPProxyDoesNotFallThroughForUninitializedWebClient(t *testing.T) {
 	h := newHost(nil, nil)
+	h.proxyAuth = &ProxyAuth{Version: 1, Username: "test", Password: "test-password"}
 	dialed := false
 	h.proxyDial = func(context.Context, string, string) (net.Conn, error) {
 		dialed = true
@@ -23,6 +24,7 @@ func TestHTTPProxyDoesNotFallThroughForUninitializedWebClient(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "http://100.100.100.100/", nil)
 	req.Host = "100.100.100.100"
+	req.Header.Set("Proxy-Authorization", "Basic dGVzdDp0ZXN0LXBhc3N3b3Jk")
 
 	h.httpProxyHandler().ServeHTTP(recorder, req)
 

--- a/host/status.go
+++ b/host/status.go
@@ -132,6 +132,9 @@ func (h *Host) watchIPNBusSession(ctx context.Context, lc *local.Client, generat
 				return context.Canceled
 			}
 			h.stateMu.Lock()
+			if n.NetMap != nil {
+				h.lastNetMap = n.NetMap
+			}
 			if stateChanged {
 				h.lastState = n.State.String()
 			}

--- a/packages/extension/src/background/chrome-proxy-auth.test.ts
+++ b/packages/extension/src/background/chrome-proxy-auth.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from "vitest";
+import { ChromeProxyAuth } from "./chrome-proxy-auth";
+
+function challenge(overrides: Record<string, unknown> = {}) {
+  return { isProxy: true, challenger: { host: "127.0.0.1", port: 1055 }, requestId: "1", ...overrides } as chrome.webRequest.OnAuthRequiredDetails;
+}
+
+describe("Chrome proxy authentication", () => {
+  it("responds only to proxy challenges at the current loopback port", () => {
+    const auth = new ChromeProxyAuth();
+    auth.set({ port: 1055, username: "user", password: "secret" });
+    const callback = vi.fn();
+    for (const details of [challenge({ isProxy: false }), challenge({ challenger: { host: "evil.example", port: 1055 } }), challenge({ challenger: { host: "127.0.0.1", port: 9999 } })]) {
+      auth.listener(details, callback);
+      expect(callback).toHaveBeenLastCalledWith({});
+    }
+    auth.listener(challenge(), callback);
+    expect(callback).toHaveBeenLastCalledWith({ authCredentials: { username: "user", password: "secret" } });
+    auth.listener(challenge(), callback);
+    expect(callback).toHaveBeenLastCalledWith({ cancel: true });
+    auth.set(null);
+    auth.listener(challenge({ requestId: "2" }), callback);
+    expect(callback).toHaveBeenLastCalledWith({});
+  });
+});

--- a/packages/extension/src/background/chrome-proxy-auth.ts
+++ b/packages/extension/src/background/chrome-proxy-auth.ts
@@ -1,0 +1,49 @@
+import { ProxySession } from "@tailchrome/shared/background/proxy-session";
+import type { ProxySessionCredentials } from "@tailchrome/shared/types";
+
+export class ChromeProxyAuth {
+  private readonly session = new ProxySession();
+  private readonly attemptedRequests = new Set<string>();
+
+  constructor() {
+    chrome.webRequest.onAuthRequired.addListener(
+      this.listener,
+      { urls: ["<all_urls>"] },
+      ["asyncBlocking"],
+    );
+  }
+
+  hasSession(port: number): boolean {
+    return this.session.credentialsFor(port) !== undefined;
+  }
+
+  set(session: ProxySessionCredentials | null): void {
+    this.session.set(session);
+    this.attemptedRequests.clear();
+  }
+
+  readonly listener = (
+    details: chrome.webRequest.OnAuthRequiredDetails,
+    callback?: (response: chrome.webRequest.BlockingResponse) => void,
+  ): undefined => {
+    if (!details.isProxy || details.challenger.host !== "127.0.0.1") {
+      callback?.({});
+      return;
+    }
+    const credentials = this.session.credentialsFor(details.challenger.port);
+    if (!credentials) {
+      callback?.({});
+      return;
+    }
+    // Do not open an endless challenge loop if a process no longer accepts its credential.
+    if (this.attemptedRequests.has(details.requestId)) {
+      callback?.({ cancel: true });
+      return;
+    }
+    if (this.attemptedRequests.size >= 1024) {
+      this.attemptedRequests.delete(this.attemptedRequests.values().next().value!);
+    }
+    this.attemptedRequests.add(details.requestId);
+    callback?.({ authCredentials: credentials });
+  };
+}

--- a/packages/extension/src/background/chrome-proxy-manager.test.ts
+++ b/packages/extension/src/background/chrome-proxy-manager.test.ts
@@ -37,6 +37,22 @@ describe("ChromeProxyManager", () => {
   });
 
   describe("apply", () => {
+    it("blocks the protected policy without a matching authenticated session", () => {
+      pm.setProxySession(null);
+      const report = vi.fn();
+      pm.setRoutingHealthListener(report);
+      const set = vi.spyOn(chrome.proxy.settings, "set");
+      pm.apply(baseState());
+      const pac = (set.mock.calls.at(-1)![0].value as chrome.proxy.ProxyConfig).pacScript!.data!;
+      expect(pac).toContain("PROXY 127.0.0.1:1");
+      expect(pac).not.toContain("PROXY 127.0.0.1:1055");
+      expect(report).toHaveBeenLastCalledWith(expect.objectContaining({ status: "blocked" }));
+      pm.setProxySession({ port: 1055, username: "fixture", password: "fixture-credential-".repeat(3) });
+      pm.apply(baseState());
+      expect((set.mock.calls.at(-1)![0].value as chrome.proxy.ProxyConfig).pacScript!.data).toContain("PROXY 127.0.0.1:1055");
+      expect(report).toHaveBeenLastCalledWith({ status: "active", message: "" });
+    });
+
     it("sets proxy when state is running and proxy enabled", () => {
       const spy = vi.spyOn(chrome.proxy.settings, "set");
       pm.apply(baseState());
@@ -412,6 +428,7 @@ describe("ChromeProxyManager", () => {
       },
     );
     const manager = new ChromeProxyManager();
+    manager.setProxySession({ port: 1055, username: "fixture", password: "fixture-credential-".repeat(3) });
     const reports: string[] = [];
     manager.setRoutingHealthListener((health) => {
       reports.push(health.status);
@@ -432,6 +449,7 @@ describe("ChromeProxyManager", () => {
       },
     );
     const manager = new ChromeProxyManager();
+    manager.setProxySession({ port: 1055, username: "fixture", password: "fixture-credential-".repeat(3) });
     const report = vi.fn();
     manager.setRoutingHealthListener(report);
     manager.apply(baseState());

--- a/packages/extension/src/background/chrome-proxy-manager.test.ts
+++ b/packages/extension/src/background/chrome-proxy-manager.test.ts
@@ -29,6 +29,7 @@ describe("ChromeProxyManager", () => {
 
   beforeEach(() => {
     pm = new ChromeProxyManager();
+    pm.setProxySession({ port: 1055, username: "fixture", password: "fixture-credential-".repeat(3) });
   });
 
   afterEach(() => {
@@ -147,13 +148,13 @@ describe("ChromeProxyManager", () => {
       const route = evalPAC(pm, baseState());
       expect(route("http://google.com", "google.com")).toBe("DIRECT");
       expect(route("http://100.64.0.5", "100.64.0.5")).toBe(
-        "SOCKS5 127.0.0.1:1055",
+        "PROXY 127.0.0.1:1055",
       );
       expect(route("http://100.100.100.100", "100.100.100.100")).toBe(
-        "SOCKS5 127.0.0.1:1055",
+        "PROXY 127.0.0.1:1055",
       );
       expect(route("http://100.127.255.255", "100.127.255.255")).toBe(
-        "SOCKS5 127.0.0.1:1055",
+        "PROXY 127.0.0.1:1055",
       );
     });
 
@@ -161,9 +162,9 @@ describe("ChromeProxyManager", () => {
       const route = evalPAC(pm, baseState());
       expect(
         route("http://my-server.example.ts.net", "my-server.example.ts.net"),
-      ).toBe("SOCKS5 127.0.0.1:1055");
+      ).toBe("PROXY 127.0.0.1:1055");
       expect(route("http://example.ts.net", "example.ts.net")).toBe(
-        "SOCKS5 127.0.0.1:1055",
+        "PROXY 127.0.0.1:1055",
       );
       expect(route("http://notexample.ts.net", "notexample.ts.net")).toBe(
         "DIRECT",
@@ -174,7 +175,7 @@ describe("ChromeProxyManager", () => {
       const route = evalPAC(pm, baseState());
       expect(
         route("http://[fd7a:115c:a1e0::1234]/", "fd7a:115c:a1e0::1234"),
-      ).toBe("SOCKS5 127.0.0.1:1055");
+      ).toBe("PROXY 127.0.0.1:1055");
     });
 
     it("never calls isInNet for a DNS hostname", () => {
@@ -210,10 +211,10 @@ describe("ChromeProxyManager", () => {
         }),
       );
       expect(route("http://google.com", "google.com")).toBe(
-        "SOCKS5 127.0.0.1:1055",
+        "PROXY 127.0.0.1:1055",
       );
       expect(route("http://192.168.1.1", "192.168.1.1")).toBe(
-        "SOCKS5 127.0.0.1:1055",
+        "PROXY 127.0.0.1:1055",
       );
     });
 
@@ -225,10 +226,10 @@ describe("ChromeProxyManager", () => {
         }),
       );
       expect(route("http://10.0.0.50", "10.0.0.50")).toBe(
-        "SOCKS5 127.0.0.1:1055",
+        "PROXY 127.0.0.1:1055",
       );
       expect(route("http://172.20.5.1", "172.20.5.1")).toBe(
-        "SOCKS5 127.0.0.1:1055",
+        "PROXY 127.0.0.1:1055",
       );
       expect(route("http://10.0.1.1", "10.0.1.1")).toBe("DIRECT");
       expect(route("http://172.32.0.1", "172.32.0.1")).toBe("DIRECT");
@@ -262,7 +263,7 @@ describe("ChromeProxyManager", () => {
         route("https://x.teams.microsoft.com/", "x.teams.microsoft.com"),
       ).toBe("DIRECT");
       expect(route("https://example.com/", "example.com")).toBe(
-        "SOCKS5 127.0.0.1:1055",
+        "PROXY 127.0.0.1:1055",
       );
     });
 
@@ -274,7 +275,7 @@ describe("ChromeProxyManager", () => {
         }),
       );
       expect(route("https://work.example.com/", "work.example.com")).toBe(
-        "SOCKS5 127.0.0.1:1055",
+        "PROXY 127.0.0.1:1055",
       );
       expect(route("https://google.com/", "google.com")).toBe("DIRECT");
     });
@@ -287,10 +288,10 @@ describe("ChromeProxyManager", () => {
         }),
       );
       expect(route("http://100.100.100.100", "100.100.100.100")).toBe(
-        "SOCKS5 127.0.0.1:1055",
+        "PROXY 127.0.0.1:1055",
       );
       expect(route("http://srv.example.ts.net", "srv.example.ts.net")).toBe(
-        "SOCKS5 127.0.0.1:1055",
+        "PROXY 127.0.0.1:1055",
       );
     });
 
@@ -303,10 +304,10 @@ describe("ChromeProxyManager", () => {
       expect(route("https://google.com/", "google.com")).toBe("DIRECT");
       // Tailscale-mandatory traffic still proxies.
       expect(route("http://100.100.100.100", "100.100.100.100")).toBe(
-        "SOCKS5 127.0.0.1:1055",
+        "PROXY 127.0.0.1:1055",
       );
       expect(route("http://srv.example.ts.net", "srv.example.ts.net")).toBe(
-        "SOCKS5 127.0.0.1:1055",
+        "PROXY 127.0.0.1:1055",
       );
     });
 
@@ -316,7 +317,7 @@ describe("ChromeProxyManager", () => {
         withExit({ domainSplit: { mode: "bypass", domains: [] } }),
       );
       expect(route("https://example.com/", "example.com")).toBe(
-        "SOCKS5 127.0.0.1:1055",
+        "PROXY 127.0.0.1:1055",
       );
     });
 

--- a/packages/extension/src/background/chrome-proxy-manager.ts
+++ b/packages/extension/src/background/chrome-proxy-manager.ts
@@ -1,4 +1,6 @@
+import { ChromeProxyAuth } from "./chrome-proxy-auth";
 import type {
+  ProxySessionCredentials,
   DomainSplitConfig,
   TailscaleState,
   RoutingHealth,
@@ -21,6 +23,12 @@ import {
 } from "@tailchrome/shared/background/routing-protection";
 
 export class ChromeProxyManager {
+  private readonly auth = new ChromeProxyAuth();
+
+  setProxySession(session: ProxySessionCredentials | null): void {
+    this.auth.set(session);
+  }
+
   private desired: chrome.proxy.ProxyConfig | null = null;
   private desiredKey = "";
   private appliedKey = "";
@@ -77,12 +85,15 @@ export class ChromeProxyManager {
       this.clear();
       return;
     }
-    const blocked = policy.mode === "blocked";
+    const authenticationMissing = !this.auth.hasSession(policy.proxyPort ?? 0);
+    const blocked = policy.mode === "blocked" || authenticationMissing;
     const port = blocked ? BLOCKED_PROXY_PORT : policy.proxyPort!;
     this.desiredHealth = blocked
       ? {
           status: "blocked",
-          message: policy.selectedExitNodeID
+          message: authenticationMissing && policy.mode === "active"
+            ? "Helper authentication unavailable — protected browsing is blocked."
+            : policy.selectedExitNodeID
             ? "Exit node unavailable — protected browsing is blocked."
             : "Connection unavailable — tailnet browsing is blocked.",
         }
@@ -208,7 +219,7 @@ export class ChromeProxyManager {
     splitMode: "bypass" | "only",
     splitDomains: string[],
   ): string {
-    const proxy = `SOCKS5 127.0.0.1:${port}`;
+    const proxy = `PROXY 127.0.0.1:${port}`;
 
     const subnetChecks = subnets
       .map((cidr) => {

--- a/packages/extension/src/background/firefox-proxy-manager.test.ts
+++ b/packages/extension/src/background/firefox-proxy-manager.test.ts
@@ -14,6 +14,7 @@ describe("FirefoxProxyManager", () => {
   beforeEach(() => {
     resetSessionStorage();
     pm = new FirefoxProxyManager();
+    pm.setProxySession({ port: 1055, username: "fixture", password: "fixture-credential-".repeat(3) });
   });
 
   afterEach(() => {
@@ -21,6 +22,17 @@ describe("FirefoxProxyManager", () => {
   });
 
   describe("apply / clear", () => {
+    it("uses credentials only for the matching helper port and never persists them", async () => {
+      const password = "private-credential-".repeat(3);
+      pm.setProxySession({ port: 1055, username: "user", password });
+      pm.apply(baseState());
+      expect(first(pm, "http://100.64.0.2/")).toMatchObject({ username: "user", password });
+      const stored = await (globalThis as any).browser.storage.session.get("proxyConfig");
+      expect(JSON.stringify(stored)).not.toContain(password);
+      pm.setProxySession(null);
+      expect(first(pm, "http://100.64.0.2/")).not.toHaveProperty("password");
+    });
+
     it("sets config when state is running and proxy enabled", () => {
       pm.apply(baseState());
       const browserProxy = (
@@ -221,7 +233,7 @@ describe("FirefoxProxyManager", () => {
   it("terminates protected proxy chains without browser fallback", () => {
     pm.apply(baseState());
     expect(pm.listener({ url: "https://100.64.0.5/" })).toEqual([
-      { type: "socks", host: "127.0.0.1", port: 1055, proxyDNS: true },
+      { type: "socks", host: "127.0.0.1", port: 1055, proxyDNS: true, username: "fixture", password: "fixture-credential-".repeat(3) },
       null,
     ]);
   });

--- a/packages/extension/src/background/firefox-proxy-manager.test.ts
+++ b/packages/extension/src/background/firefox-proxy-manager.test.ts
@@ -22,6 +22,21 @@ describe("FirefoxProxyManager", () => {
   });
 
   describe("apply / clear", () => {
+    it("blocks without credentials and after an active session is revoked", () => {
+      pm.setProxySession(null);
+      pm.apply(baseState());
+      expect(pm.listener({ url: "http://100.64.0.2/" })).toEqual([
+        { type: "socks", host: "127.0.0.1", port: 1, proxyDNS: true }, null,
+      ]);
+      pm.setProxySession({ port: 1055, username: "fixture", password: "fixture-credential-".repeat(3) });
+      pm.apply(baseState());
+      expect(first(pm, "http://100.64.0.2/").port).toBe(1055);
+      pm.setProxySession(null);
+      expect(pm.listener({ url: "http://100.64.0.2/" })).toEqual([
+        { type: "socks", host: "127.0.0.1", port: 1, proxyDNS: true }, null,
+      ]);
+    });
+
     it("uses credentials only for the matching helper port and never persists them", async () => {
       const password = "private-credential-".repeat(3);
       pm.setProxySession({ port: 1055, username: "user", password });

--- a/packages/extension/src/background/firefox-proxy-manager.ts
+++ b/packages/extension/src/background/firefox-proxy-manager.ts
@@ -1,4 +1,6 @@
+import { ProxySession } from "@tailchrome/shared/background/proxy-session";
 import type {
+  ProxySessionCredentials,
   DomainSplitConfig,
   DomainSplitMode,
   TailscaleState,
@@ -29,6 +31,8 @@ export interface FirefoxProxyInfo {
   host?: string;
   port?: number;
   proxyDNS?: boolean;
+  username?: string;
+  password?: string;
 }
 
 declare const browser: {
@@ -45,6 +49,12 @@ declare const browser: {
 };
 
 export class FirefoxProxyManager {
+  private readonly session = new ProxySession();
+
+  setProxySession(session: ProxySessionCredentials | null): void {
+    this.session.set(session);
+  }
+
   private proxyPort = BLOCKED_PROXY_PORT;
   private magicDNSSuffix = "";
   private exitNodeActive = true;
@@ -76,7 +86,10 @@ export class FirefoxProxyManager {
   }
 
   apply(state: TailscaleState): void {
-    const policy = policyFromState(state);
+    const requestedPolicy = policyFromState(state);
+    const policy = requestedPolicy.mode === "active" && !this.session.credentialsFor(requestedPolicy.proxyPort ?? 0)
+      ? { ...requestedPolicy, mode: "blocked" as const, proxyPort: null }
+      : requestedPolicy;
     const nextKey = JSON.stringify(policy);
     if (nextKey !== this.policyKey) this.failedKey = "";
     this.policyKey = nextKey;
@@ -134,8 +147,9 @@ export class FirefoxProxyManager {
       {
         type: "socks",
         host: "127.0.0.1",
-        port: this.mode === "blocked" ? BLOCKED_PROXY_PORT : this.proxyPort,
+        port: this.mode === "blocked" || !this.session.credentialsFor(this.proxyPort) ? BLOCKED_PROXY_PORT : this.proxyPort,
         proxyDNS: true,
+        ...(this.mode === "active" ? this.session.credentialsFor(this.proxyPort) : undefined),
       },
       null,
     ];

--- a/packages/extension/src/background/firefox-proxy-manager.ts
+++ b/packages/extension/src/background/firefox-proxy-manager.ts
@@ -87,7 +87,8 @@ export class FirefoxProxyManager {
 
   apply(state: TailscaleState): void {
     const requestedPolicy = policyFromState(state);
-    const policy = requestedPolicy.mode === "active" && !this.session.credentialsFor(requestedPolicy.proxyPort ?? 0)
+    const authenticationMissing = !this.session.credentialsFor(requestedPolicy.proxyPort ?? 0);
+    const policy = requestedPolicy.mode === "active" && authenticationMissing
       ? { ...requestedPolicy, mode: "blocked" as const, proxyPort: null }
       : requestedPolicy;
     const nextKey = JSON.stringify(policy);
@@ -114,7 +115,9 @@ export class FirefoxProxyManager {
         this.mode === "blocked"
           ? {
               status: "blocked",
-              message: this.exitNodeActive
+              message: authenticationMissing && requestedPolicy.mode === "active"
+                ? "Helper authentication unavailable — protected browsing is blocked."
+                : this.exitNodeActive
                 ? "Exit node unavailable — protected browsing is blocked."
                 : "Connection unavailable — tailnet browsing is blocked.",
             }
@@ -143,13 +146,14 @@ export class FirefoxProxyManager {
 
     if (this.mode === "direct") return direct;
 
+    const credentials = this.mode === "active" ? this.session.credentialsFor(this.proxyPort) : undefined;
     const proxy: [FirefoxProxyInfo, null] = [
       {
         type: "socks",
         host: "127.0.0.1",
-        port: this.mode === "blocked" || !this.session.credentialsFor(this.proxyPort) ? BLOCKED_PROXY_PORT : this.proxyPort,
+        port: credentials ? this.proxyPort : BLOCKED_PROXY_PORT,
         proxyDNS: true,
-        ...(this.mode === "active" ? this.session.credentialsFor(this.proxyPort) : undefined),
+        ...credentials,
       },
       null,
     ];

--- a/packages/extension/wxt.config.ts
+++ b/packages/extension/wxt.config.ts
@@ -105,7 +105,7 @@ export default defineConfig({
         "nativeMessaging",
         "contextMenus",
         "alarms",
-        ...(browser === "chrome" ? ["sidePanel" as const] : []),
+        ...(browser === "chrome" ? ["sidePanel" as const, "webRequest" as const, "webRequestAuthProvider" as const] : []),
       ],
       action: {
         default_icon: chromeActionIcons,

--- a/packages/shared/src/__test__/chrome-mock.ts
+++ b/packages/shared/src/__test__/chrome-mock.ts
@@ -8,6 +8,7 @@ const storageChangedListeners: Array<
 
 let proxyValue: unknown = { mode: "system" };
 const chromeMock = {
+  webRequest: { onAuthRequired: { addListener: vi.fn() } },
   action: {
     setIcon: (_details: unknown) => Promise.resolve(),
     setBadgeText: (_details: unknown) => {},

--- a/packages/shared/src/background/background.test.ts
+++ b/packages/shared/src/background/background.test.ts
@@ -148,6 +148,7 @@ describe("initBackground", () => {
     vi.useFakeTimers();
 
     proxyManager = {
+      setProxySession: vi.fn(),
       apply: vi.fn(),
       clear: vi.fn(),
     };
@@ -205,7 +206,7 @@ describe("initBackground", () => {
 
   function advertiseLoginSupport() {
     sendNativeMessage({
-      procRunning: {
+      procRunning: { proxyAuth: { version: 1, username: "tailchrome", password: "a".repeat(52) },
         port: 1055,
         pid: 1234,
         version: "0.1.11",
@@ -216,7 +217,7 @@ describe("initBackground", () => {
 
   function advertiseCustomControlURLSupport() {
     sendNativeMessage({
-      procRunning: {
+      procRunning: { proxyAuth: { version: 1, username: "tailchrome", password: "a".repeat(52) },
         port: 1055,
         pid: 1234,
         version: "0.1.11",
@@ -248,9 +249,34 @@ describe("initBackground", () => {
   });
 
   describe("native message handling", () => {
+    it("rejects legacy unauthenticated helpers visibly", async () => {
+      await setupBackground();
+      sendNativeMessage({ procRunning: { port: 1055, pid: 1 } });
+      expect(proxyManager.setProxySession).toHaveBeenLastCalledWith(null);
+      expect(proxyManager.apply).toHaveBeenLastCalledWith(expect.objectContaining({
+        proxyPort: null, proxyEnabled: false,
+        helperFailure: expect.objectContaining({ kind: "helper-incompatible", diagnosticCode: "helper-proxy-auth-required" }),
+      }));
+    });
+
+    it("delivers credentials privately and clears them on disconnect", async () => {
+      await setupBackground();
+      const popup = createPopupPort();
+      connectListeners[0]!(popup);
+      const password = "private-credential-".repeat(3);
+      sendNativeMessage({ procRunning: { port: 1055, pid: 1, proxyAuth: { version: 1, username: "user", password } } });
+      expect(proxyManager.setProxySession).toHaveBeenLastCalledWith({ port: 1055, username: "user", password });
+      expect(JSON.stringify(vi.mocked(proxyManager.apply).mock.calls)).not.toContain(password);
+      expect(JSON.stringify(popup.postMessage.mock.calls)).not.toContain(password);
+      expect(JSON.stringify(vi.mocked(chrome.storage.local.set).mock.calls)).not.toContain(password);
+      expect(JSON.stringify(vi.mocked(chrome.storage.session.set).mock.calls)).not.toContain(password);
+      nativePort.onDisconnect._listeners[0]!(nativePort);
+      expect(proxyManager.setProxySession).toHaveBeenLastCalledWith(null);
+    });
+
     it("updates proxy port on procRunning message", async () => {
       await setupBackground();
-      sendNativeMessage({ procRunning: { port: 1055, pid: 1234 } });
+      sendNativeMessage({ procRunning: { proxyAuth: { version: 1, username: "tailchrome", password: "a".repeat(52) }, port: 1055, pid: 1234 } });
 
       // proxyManager.apply should have been called with state containing new port
       expect(proxyManager.apply).toHaveBeenCalledWith(
@@ -267,7 +293,7 @@ describe("initBackground", () => {
     it("sets supportsNetcheck when procRunning advertises it", async () => {
       await setupBackground();
       sendNativeMessage({
-        procRunning: { port: 1055, pid: 1234, supportsNetcheck: true },
+        procRunning: { proxyAuth: { version: 1, username: "tailchrome", password: "a".repeat(52) }, port: 1055, pid: 1234, supportsNetcheck: true },
       });
 
       expect(proxyManager.apply).toHaveBeenCalledWith(
@@ -278,7 +304,7 @@ describe("initBackground", () => {
     it("sets supportsPingPeer when procRunning advertises it", async () => {
       await setupBackground();
       sendNativeMessage({
-        procRunning: { port: 1055, pid: 1234, supportsPingPeer: true },
+        procRunning: { proxyAuth: { version: 1, username: "tailchrome", password: "a".repeat(52) }, port: 1055, pid: 1234, supportsPingPeer: true },
       });
 
       expect(proxyManager.apply).toHaveBeenCalledWith(
@@ -289,7 +315,7 @@ describe("initBackground", () => {
     it("sets supportsLogin when procRunning advertises it", async () => {
       await setupBackground();
       sendNativeMessage({
-        procRunning: { port: 1055, pid: 1234, supportsLogin: true },
+        procRunning: { proxyAuth: { version: 1, username: "tailchrome", password: "a".repeat(52) }, port: 1055, pid: 1234, supportsLogin: true },
       });
 
       expect(proxyManager.apply).toHaveBeenCalledWith(
@@ -300,7 +326,7 @@ describe("initBackground", () => {
     it("sets supportsCustomControlURL when procRunning advertises it", async () => {
       await setupBackground();
       sendNativeMessage({
-        procRunning: { port: 1055, pid: 1234, version: "0.1.11", supportsCustomControlURL: true },
+        procRunning: { proxyAuth: { version: 1, username: "tailchrome", password: "a".repeat(52) }, port: 1055, pid: 1234, version: "0.1.11", supportsCustomControlURL: true },
       });
 
       expect(proxyManager.apply).toHaveBeenCalledWith(
@@ -311,7 +337,7 @@ describe("initBackground", () => {
     it("defaults supportsCustomControlURL to false on older helpers", async () => {
       await setupBackground();
       sendNativeMessage({
-        procRunning: { port: 1055, pid: 1234 },
+        procRunning: { proxyAuth: { version: 1, username: "tailchrome", password: "a".repeat(52) }, port: 1055, pid: 1234 },
       });
 
       expect(proxyManager.apply).toHaveBeenCalledWith(
@@ -322,7 +348,7 @@ describe("initBackground", () => {
     it("keeps a differing helper version connected with a non-blocking notice", async () => {
       await setupBackground();
       sendNativeMessage({
-        procRunning: {
+        procRunning: { proxyAuth: { version: 1, username: "tailchrome", password: "a".repeat(52) },
           port: 1055,
           pid: 1234,
           version: "0.1.11",
@@ -347,10 +373,10 @@ describe("initBackground", () => {
     it("clears the version notice when the companion helper connects", async () => {
       await setupBackground();
       sendNativeMessage({
-        procRunning: { port: 1055, pid: 1234, version: "0.1.11" },
+        procRunning: { proxyAuth: { version: 1, username: "tailchrome", password: "a".repeat(52) }, port: 1055, pid: 1234, version: "0.1.11" },
       });
       sendNativeMessage({
-        procRunning: { port: 1055, pid: 1234, version: "0.1.13" },
+        procRunning: { proxyAuth: { version: 1, username: "tailchrome", password: "a".repeat(52) }, port: 1055, pid: 1234, version: "0.1.13" },
       });
 
       expect(proxyManager.apply).toHaveBeenLastCalledWith(
@@ -367,7 +393,7 @@ describe("initBackground", () => {
       async (version) => {
         await setupBackground();
         sendNativeMessage({
-          procRunning: {
+          procRunning: { proxyAuth: { version: 1, username: "tailchrome", password: "a".repeat(52) },
             port: 1055,
             pid: 1234,
             ...(version === undefined ? {} : { version }),
@@ -412,7 +438,7 @@ describe("initBackground", () => {
       await setupBackground();
       sendNativeMessage({ init: { error: "failed at /Users/alice/private" } });
       sendNativeMessage({
-        procRunning: { port: 1055, pid: 1234, version: "0.1.12" },
+        procRunning: { proxyAuth: { version: 1, username: "tailchrome", password: "a".repeat(52) }, port: 1055, pid: 1234, version: "0.1.12" },
       });
 
       expect(proxyManager.apply).toHaveBeenLastCalledWith(
@@ -444,7 +470,7 @@ describe("initBackground", () => {
     it("requires procRunning and init recovery from the same connection attempt", async () => {
       await setupBackground();
       sendNativeMessage({
-        procRunning: { port: 1055, pid: 1234, version: "0.1.12" },
+        procRunning: { proxyAuth: { version: 1, username: "tailchrome", password: "a".repeat(52) }, port: 1055, pid: 1234, version: "0.1.12" },
       });
       sendNativeMessage({ init: { error: "first attempt failed" } });
 
@@ -470,7 +496,7 @@ describe("initBackground", () => {
       );
 
       secondPort.onMessage._listeners[0]!({
-        procRunning: { port: 1055, pid: 4321, version: "0.1.12" },
+        procRunning: { proxyAuth: { version: 1, username: "tailchrome", password: "a".repeat(52) }, port: 1055, pid: 4321, version: "0.1.12" },
       });
       expect(proxyManager.apply).toHaveBeenLastCalledWith(
         expect.objectContaining({
@@ -824,7 +850,7 @@ describe("initBackground", () => {
       await setupBackground();
       // Helper connects and reports an older version: non-blocking notice state.
       sendNativeMessage({
-        procRunning: { port: 1055, pid: 1234, version: "0.0.1", supportsLogin: true },
+        procRunning: { proxyAuth: { version: 1, username: "tailchrome", password: "a".repeat(52) }, port: 1055, pid: 1234, version: "0.0.1", supportsLogin: true },
       });
 
       const popupPort = createPopupPort();
@@ -1318,7 +1344,7 @@ describe("initBackground", () => {
     it("does not send login command when native helper lacks login support", async () => {
       await setupBackground();
       sendNativeMessage({
-        procRunning: { port: 1055, pid: 1234, version: "0.1.11" },
+        procRunning: { proxyAuth: { version: 1, username: "tailchrome", password: "a".repeat(52) }, port: 1055, pid: 1234, version: "0.1.11" },
       });
       sendNativeMessage({
         status: {
@@ -2009,7 +2035,7 @@ describe("initBackground", () => {
     it("does not open the stale login URL after switching coordination servers", async () => {
       await setupBackground();
       sendNativeMessage({
-        procRunning: {
+        procRunning: { proxyAuth: { version: 1, username: "tailchrome", password: "a".repeat(52) },
           port: 1055,
           pid: 1234,
           version: "0.1.11",
@@ -2064,7 +2090,7 @@ describe("initBackground", () => {
     it("clears the saved exit node when the coordination server changes", async () => {
       await setupBackground();
       sendNativeMessage({
-        procRunning: { port: 1055, pid: 1234, version: "0.1.11", supportsCustomControlURL: true },
+        procRunning: { proxyAuth: { version: 1, username: "tailchrome", password: "a".repeat(52) }, port: 1055, pid: 1234, version: "0.1.11", supportsCustomControlURL: true },
       });
       sendNativeMessage({
         status: {
@@ -2134,7 +2160,7 @@ describe("initBackground", () => {
     it("keeps the saved exit node when the host rolls a server switch back", async () => {
       await setupBackground();
       sendNativeMessage({
-        procRunning: { port: 1055, pid: 1234, version: "0.1.11", supportsCustomControlURL: true },
+        procRunning: { proxyAuth: { version: 1, username: "tailchrome", password: "a".repeat(52) }, port: 1055, pid: 1234, version: "0.1.11", supportsCustomControlURL: true },
       });
       sendNativeMessage({
         status: {
@@ -2201,7 +2227,7 @@ describe("initBackground", () => {
     it("keeps the saved exit node when re-saving the same coordination server", async () => {
       await setupBackground();
       sendNativeMessage({
-        procRunning: { port: 1055, pid: 1234, version: "0.1.11", supportsCustomControlURL: true },
+        procRunning: { proxyAuth: { version: 1, username: "tailchrome", password: "a".repeat(52) }, port: 1055, pid: 1234, version: "0.1.11", supportsCustomControlURL: true },
       });
       sendNativeMessage({
         status: {
@@ -2525,7 +2551,7 @@ describe("initBackground", () => {
 
       nativePort.postMessage.mockClear();
       sendNativeMessage({
-        procRunning: {
+        procRunning: { proxyAuth: { version: 1, username: "tailchrome", password: "a".repeat(52) },
           port: 1055,
           pid: 1234,
           version: "0.1.11",

--- a/packages/shared/src/background/background.ts
+++ b/packages/shared/src/background/background.ts
@@ -23,6 +23,7 @@ import {
   type NativeConnectionEvent,
 } from "./native-host";
 import { sanitizeDiagnosticMessage } from "../helper-diagnostics";
+import { readProxySession } from "./proxy-session";
 import { BadgeManager } from "./badge-manager";
 import { DefaultTimerService, type TimerService } from "./timer-service";
 import { applyUiSurface, readUiSurface, type BrowserKind } from "./ui-surface";
@@ -642,6 +643,21 @@ export function initBackground(
   function handleNativeMessage(msg: NativeReply): void {
     // Process running: the native host tells us which port to proxy through
     if (msg.procRunning) {
+      const session = msg.procRunning.error ? null : readProxySession(msg.procRunning);
+      proxyManager.setProxySession?.(session);
+      if (!msg.procRunning.error && !session) {
+        sawHealthyProcRunning = false;
+        store.update({
+          proxyPort: null,
+          proxyEnabled: false,
+          helperFailure: {
+            kind: "helper-incompatible",
+            diagnosticCode: "helper-proxy-auth-required",
+            diagnosticMessage: "Update the helper and extension together to enable authenticated browsing.",
+          },
+        });
+        return;
+      }
       const hostVersion = normalizedHelperVersion(msg.procRunning.version);
       const helperVersionNotice = getHelperVersionNotice(
         hostVersion,
@@ -882,6 +898,7 @@ export function initBackground(
       return;
     }
 
+    proxyManager.setProxySession?.(null);
     exitNodeRestoreAttempted = false;
     autoDisconnectAttempted = false;
     sawHealthyProcRunning = false;

--- a/packages/shared/src/background/proxy-session.test.ts
+++ b/packages/shared/src/background/proxy-session.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { ProxySession, readProxySession } from "./proxy-session";
+import type { NativeReply } from "../types";
+
+const auth = { version: 1 as const, username: "tailchrome", password: "a".repeat(52) };
+
+describe("proxy credentials", () => {
+  it("rejects missing capability, invalid ports and malformed credentials", () => {
+    for (const reply of [
+      { port: 1055, pid: 1 },
+      { port: 0, pid: 1, proxyAuth: auth },
+      { port: 65536, pid: 1, proxyAuth: auth },
+      { port: 1.5, pid: 1, proxyAuth: auth },
+      { port: 1055, pid: 1, proxyAuth: { ...auth, version: 2 } },
+      { port: 1055, pid: 1, proxyAuth: { ...auth, username: "user:password" } },
+      { port: 1055, pid: 1, proxyAuth: { ...auth, password: "short" } },
+    ]) expect(readProxySession(reply as NonNullable<NativeReply["procRunning"]>)).toBeNull();
+  });
+
+  it("keeps credentials private and revokes the old port on replacement and disconnect", () => {
+    const session = new ProxySession();
+    session.set(readProxySession({ port: 1055, pid: 1, proxyAuth: auth }));
+    expect(session.credentialsFor(1055)).toEqual({ username: auth.username, password: auth.password });
+    expect(session.credentialsFor(1056)).toBeUndefined();
+    expect(JSON.stringify(session)).toBe("{}");
+    session.set({ port: 1056, username: "new", password: "b".repeat(52) });
+    expect(session.credentialsFor(1055)).toBeUndefined();
+    session.set(null);
+    expect(session.credentialsFor(1056)).toBeUndefined();
+  });
+});

--- a/packages/shared/src/background/proxy-session.ts
+++ b/packages/shared/src/background/proxy-session.ts
@@ -1,0 +1,28 @@
+import type { NativeReply, ProxySessionCredentials } from "../types";
+
+/** Credentials travel only from native messaging to the background proxy manager. */
+export function readProxySession(
+  reply: NonNullable<NativeReply["procRunning"]>,
+): ProxySessionCredentials | null {
+  const auth = reply.proxyAuth;
+  if (
+    !Number.isInteger(reply.port) || reply.port < 1 || reply.port > 65535 ||
+    !auth || auth.version !== 1 ||
+    typeof auth.username !== "string" || !/^[A-Za-z0-9_-]{1,64}$/.test(auth.username) ||
+    typeof auth.password !== "string" || !/^[A-Za-z0-9_-]{32,128}$/.test(auth.password)
+  ) return null;
+  return { port: reply.port, username: auth.username, password: auth.password };
+}
+
+export class ProxySession {
+  #session: ProxySessionCredentials | null = null;
+
+  set(session: ProxySessionCredentials | null): void {
+    this.#session = session ? { ...session } : null;
+  }
+
+  credentialsFor(port: number): { username: string; password: string } | undefined {
+    if (!this.#session || this.#session.port !== port) return undefined;
+    return { username: this.#session.username, password: this.#session.password };
+  }
+}

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -52,6 +52,7 @@ export interface NativeReply {
     supportsLogin?: boolean;
     /** When true, the native host accepts a `controlURL` field in `set-prefs` (omitted on older helpers). */
     supportsCustomControlURL?: boolean;
+    proxyAuth?: { version: 1; username: string; password: string };
   };
   init?: { error?: string };
   pong?: Record<string, never>;
@@ -329,7 +330,14 @@ export type BackgroundMessage =
 
 // === Proxy manager interface ===
 
+export interface ProxySessionCredentials {
+  port: number;
+  username: string;
+  password: string;
+}
+
 export interface ProxyManager {
+  setProxySession?(session: ProxySessionCredentials | null): void;
   apply(state: TailscaleState): void;
   clear(): void;
   setRoutingHealthListener?(listener: (health: RoutingHealth) => void): void;

--- a/scripts/e2e/native-host.mjs
+++ b/scripts/e2e/native-host.mjs
@@ -342,7 +342,7 @@ function mockSource(baseUrl, initialControl) {
       }
       onMessage.dispatch({
         procRunning: {
-          ...(control.legacyProxy ? {} : { proxyAuth: { version: 1, username: "fixture", password: "fixture-credential-".repeat(3) } }),
+          ...(control.legacyProxy ? {} : { proxyAuth: control.proxyAuth ?? { version: 1, username: "fixture", password: "fixture-credential-".repeat(3) } }),
           port: control.proxyPort ?? 1055,
           pid: 1,
           version: control.hostVersion ?? ${JSON.stringify(expectedHostVersion)},

--- a/scripts/e2e/native-host.mjs
+++ b/scripts/e2e/native-host.mjs
@@ -155,9 +155,7 @@ function mockSource(baseUrl, initialControl) {
   }
 
 
-  // The incompatible kind is intentionally defensive-only in production until
-  // a future protocol supplies explicit evidence. Transform background state
-  // only inside this fixture so both browser families still exercise that UI.
+  // Inject explicit helper failures so both browser families exercise recovery.
   if (control.popupFailureKind) {
     chrome.runtime.onConnect.addListener((port) => {
       if (port.name !== "popup") return;
@@ -344,6 +342,7 @@ function mockSource(baseUrl, initialControl) {
       }
       onMessage.dispatch({
         procRunning: {
+          ...(control.legacyProxy ? {} : { proxyAuth: { version: 1, username: "fixture", password: "fixture-credential-".repeat(3) } }),
           port: control.proxyPort ?? 1055,
           pid: 1,
           version: control.hostVersion ?? ${JSON.stringify(expectedHostVersion)},

--- a/scripts/e2e/network-fixture.mjs
+++ b/scripts/e2e/network-fixture.mjs
@@ -94,7 +94,7 @@ export async function createRoutingNetwork() {
         if (stage === "hello") {
           if (buffer.length < 2 || buffer.length < buffer[1] + 2) return;
           const methods = buffer.subarray(2, buffer[1] + 2);
-          const method = methods.includes(2) ? 2 : methods.includes(0) ? 0 : 255;
+          const method = methods.includes(2) ? 2 : 255;
           buffer = buffer.subarray(buffer[1] + 2);
           client.write(Buffer.from([5, method]));
           if (method === 255) { client.end(); return; }

--- a/scripts/e2e/scenarios/proxy-routing.mjs
+++ b/scripts/e2e/scenarios/proxy-routing.mjs
@@ -27,7 +27,7 @@ export async function run({ openPopup }) {
     }
     const data = proxyConfig.pacScript?.data ?? "";
     for (const expected of [
-      "SOCKS5 127.0.0.1:1055",
+      "PROXY 127.0.0.1:1055",
       "100.100.100.100",
       "100.64.0.0",
       "fd7a:115c:a1e0:",

--- a/scripts/e2e/scenarios/split-tunneling.mjs
+++ b/scripts/e2e/scenarios/split-tunneling.mjs
@@ -89,7 +89,7 @@ export async function run({ openPopup }) {
     if (!pac.includes('return "DIRECT"')) {
       throw new Error("Bypass branch missing from PAC");
     }
-    if (!pac.includes("SOCKS5 127.0.0.1:1055")) {
+    if (!pac.includes("PROXY 127.0.0.1:1055")) {
       throw new Error("Proxy still expected for unlisted hosts");
     }
 


### PR DESCRIPTION
## What
Require a fresh local proxy credential for each helper launch. Limit connections to tailnet addresses, approved routes, and destinations allowed by the selected exit node. Older helpers show an update prompt.

## Why
Finding the loopback port should not grant access to a browser profile's tailnet.

## How to Test
Typecheck, unit tests, Go race tests/vet, and both browser builds pass. Real Chrome and Firefox requests verify authenticated recovery and blocking after helper failure.
