### PR TITLE
Support peer short names and restricted DNS routes

### DIFF
--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -402,13 +402,26 @@ When the raw host binary is run in a terminal (detected via `term.IsTerminal`), 
 
 ## Proxy System
 
+### DNS
+
+Known peer short names, full MagicDNS names, and restricted DNS domains use the
+helper. Split DNS follows the most specific domain route from Tailscale or
+Headscale and supports IPv4/IPv6 nameserver addresses. Encrypted resolver URLs
+are not supported. Routes without a supported IP nameserver fail instead of
+falling back to system DNS.
+
+Ordinary browsing keeps the browser/system resolver. Proxied exit-node traffic
+uses the exit node's DNS unless a restricted resolver is configured to stay in
+use with that exit node. Excluded domains keep their normal resolver. Restricted
+DNS routes require the MagicDNS setting to be enabled.
+
 ### Chrome: PAC Script
 
 Chrome uses a dynamically generated PAC (Proxy Auto-Config) script set via `chrome.proxy.settings.set()`. The PAC script routes traffic based on:
 
 1. **Tailscale service IP** (`100.100.100.100`) -> proxy
 2. **CGNAT range** (`100.64.0.0/10`) -> proxy (all Tailscale IPs)
-3. **MagicDNS suffix** (e.g., `*.ts.net`) -> proxy before any `isInNet()` call, avoiding local DNS resolution of ordinary hostnames
+3. **MagicDNS names and restricted DNS domains** -> proxy, including exact known peer short names such as `wiki`
 4. **Tailscale IPv6 prefix** (`fd7a:115c:a1e0::/48`) -> proxy
 5. **Subnet routes** (from subnet router peers) -> proxy via `isInNet()` only for IPv4 literals
 6. **Exit node selected** -> protected traffic stays proxied, or blocked while the node is unavailable

--- a/docs/FEATURE_PARITY.md
+++ b/docs/FEATURE_PARITY.md
@@ -43,7 +43,7 @@ Last updated: 2026-08-16
 | Feature                           | Native Client | Tailchrome | Notes                                                                                                                                                                                   |
 | --------------------------------- | ------------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Access tailnet devices by IP      | Yes           | Yes        | Via SOCKS5/HTTP proxy on `127.0.0.1`                                                                                                                                                    |
-| MagicDNS (access by hostname)     | Yes           | Yes        | `corpDNS` toggle in popup; PAC/listener routes `*.ts.net` suffix                                                                                                                        |
+| MagicDNS (access by hostname)     | Yes           | Yes        | `corpDNS` toggle in popup; full MagicDNS names and exact known peer short names                                                                                                                        |
 | Exit nodes (use)                  | Yes           | Yes        | Full exit node picker with search, country flags, online/offline status                                                                                                                 |
 | Exit node suggestion              | Yes           | Yes        | The picker shows a client-side **Recommended** Mullvad row, preferring an online nearby location based on the browser time zone; it is never auto-applied. |
 | Exit node: allow LAN access       | Yes           | Yes        | Toggle in exit node picker view                                                                                                                                                         |
@@ -52,7 +52,7 @@ Last updated: 2026-08-16
 | Subnet routing (use routes)       | Yes           | Yes        | Auto-detected from peer `subnets[]`; PAC/listener routes matching CIDRs                                                                                                                 |
 | Subnet routing (advertise routes) | Yes           | Yes        | Advanced quick settings accept comma- or newline-separated CIDRs and apply `AdvertiseRoutes` through `set-prefs`. |
 | Advertise as exit node            | Yes           | Yes        | Toggle in quick settings                                                                                                                                                                |
-| Split DNS                         | Yes           | No         | Extension proxies based on destination IP/DNS suffix, but does not configure per-domain DNS resolvers                                                                                   |
+| Split DNS                         | Yes           | Partial    | Uses restricted IP nameservers from the tailnet configuration; encrypted resolver URLs are not supported                                                                                   |
 | Custom DNS nameservers            | Yes           | No         | Not configurable from the extension                                                                                                                                                     |
 | HTTPS proxy / CONNECT tunneling   | Yes           | Yes        | Native host handles `CONNECT` method with bidirectional hijack                                                                                                                          |
 | IPv4 tailnet access               | Yes           | Yes        | Full support via CGNAT range `100.64.0.0/10`                                                                                                                                            |
@@ -182,7 +182,7 @@ Last updated: 2026-08-16
 | Category          | Missing Features                                                                      |
 | ----------------- | ------------------------------------------------------------------------------------- |
 | **File transfer** | Receiving files (Taildrop inbound); sends are capped at 50 MiB and buffered in memory |
-| **Networking**    | Split DNS, custom DNS nameservers                                                      |
+| **Networking**    | Encrypted split DNS resolvers, custom DNS settings                                                      |
 | **Security**      | Network lock, key signing/rotation                                                    |
 | **Services**      | Tailscale Serve, Tailscale Funnel, SSH server                                         |
 | **Diagnostics**   | A full Tailscale bug report and a user-facing `netcheck` control                       |
@@ -195,6 +195,6 @@ These gaps exist for fundamental reasons:
 
 1. **No inbound connections to the browser** -- browsers cannot accept incoming TCP connections, so Taildrop receive, Serve, and Funnel are not possible without a separate receiver process.
 2. **Native messaging payload limit** -- Chrome enforces a 1 MB message limit, so Taildrop sends are split into roughly 700 KB chunks and reassembled by the helper. The implementation caps assembled files at 50 MiB and still buffers the encoded file in extension/host memory.
-3. **Browser sandbox** -- the extension cannot modify system DNS, routing tables, or network configuration. All networking goes through the SOCKS5/HTTP proxy, which means split DNS and custom nameserver configuration are not feasible from the browser alone.
+3. **Browser sandbox** -- the extension cannot modify system DNS, routing tables, or network configuration. The helper handles restricted DNS routes through the tailnet; ordinary browsing keeps the browser/system resolver.
 4. **tsnet scope** -- the native host runs a `tsnet.Server`, which is a userspace Tailscale node. It does not have the full feature surface of `tailscaled` (the system daemon). Features like Serve, Funnel, and network lock require daemon-level integration that `tsnet` does not expose.
 5. **UI surface area** -- the popup is constrained to a small window. Some features (SSH server toggle and advanced daemon diagnostics) remain omitted even when lower layers expose related data.

--- a/docs/puppeteer-testing-suite.md
+++ b/docs/puppeteer-testing-suite.md
@@ -60,6 +60,7 @@ An array provides sequential replies for repeated commands. Every request is sti
 - `popup-loads`: packaged popup renders without page or console errors.
 - `proxy-routing`: Chrome installs a PAC containing service IP, IPv4/IPv6 tailnet ranges, MagicDNS, and subnet routes.
 - `routing-failclosed-network`: real HTTP requests stay blocked when an exit node or helper disappears; recovery uses the proxy and an explicit bypass goes direct.
+- `dns-routing-network`: restricted domains use the proxy, missing updates retain routes, confirmed removals clear them, and helper loss blocks requests.
 - `connection-states`: install, update, login, stopped, and machine-approval views.
 - `toggle-commands`: `up`/`down` commands plus their resulting UI transitions.
 - `connected-dashboard`: identity, helper version, health warnings, peers, and search.

--- a/host/dns_test.go
+++ b/host/dns_test.go
@@ -1,0 +1,341 @@
+package main
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/netip"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+
+	"golang.org/x/net/dns/dnsmessage"
+	"tailscale.com/ipn"
+	"tailscale.com/ipn/ipnstate"
+	"tailscale.com/tailcfg"
+	"tailscale.com/types/dnstype"
+	"tailscale.com/types/netmap"
+)
+
+func TestDNSRouteDomains(t *testing.T) {
+	nm := &netmap.NetworkMap{DNS: tailcfg.DNSConfig{Routes: map[string][]*dnstype.Resolver{
+		"Internal.Example.": nil, "internal.example": nil, "other.example": nil,
+		".": nil, "*.example": nil, "https://bad.example": nil, "127.0.0.1": nil,
+		"bad..example": nil, "-bad.example": nil, "bad.example\n": nil,
+	}}}
+	if got, want := dnsRouteDomains(nm, ""), []string{"internal.example", "other.example"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("domains = %v, want %v", got, want)
+	}
+}
+
+// dnsTestDial serves real DNS wire responses over a connection supplied to the
+// Go resolver. No machine DNS settings or external nameserver are involved.
+func dnsTestDial(t *testing.T, answer func(server, name string, queryType dnsmessage.Type) (netip.Addr, error)) func(context.Context, string, string) (net.Conn, error) {
+	t.Helper()
+	return func(ctx context.Context, network, server string) (net.Conn, error) {
+		client, upstream := net.Pipe()
+		go func() {
+			defer upstream.Close()
+			var size uint16
+			if err := binary.Read(upstream, binary.BigEndian, &size); err != nil {
+				return
+			}
+			packet := make([]byte, size)
+			if _, err := io.ReadFull(upstream, packet); err != nil {
+				return
+			}
+			var query dnsmessage.Message
+			if err := query.Unpack(packet); err != nil || len(query.Questions) != 1 {
+				t.Errorf("invalid query: %v", err)
+				return
+			}
+			question := query.Questions[0]
+			address, err := answer(server, question.Name.String(), question.Type)
+			if err != nil {
+				return
+			}
+			response := dnsmessage.Message{
+				Header:    dnsmessage.Header{ID: query.ID, Response: true, RecursionAvailable: true},
+				Questions: query.Questions,
+			}
+			if address.IsValid() {
+				resource := dnsmessage.Resource{Header: dnsmessage.ResourceHeader{Name: question.Name, Type: question.Type, Class: dnsmessage.ClassINET, TTL: 60}}
+				if question.Type == dnsmessage.TypeA && address.Is4() {
+					resource.Body = &dnsmessage.AResource{A: address.As4()}
+				} else if question.Type == dnsmessage.TypeAAAA && address.Is6() {
+					resource.Body = &dnsmessage.AAAAResource{AAAA: address.As16()}
+				}
+				if resource.Body != nil {
+					response.Answers = []dnsmessage.Resource{resource}
+				}
+			}
+			packet, err = response.Pack()
+			if err != nil {
+				t.Errorf("pack response: %v", err)
+				return
+			}
+			_ = binary.Write(upstream, binary.BigEndian, uint16(len(packet)))
+			_, _ = upstream.Write(packet)
+		}()
+		return client, nil
+	}
+}
+
+func TestRestrictedDNSUsesLongestSuffixAndLiteralNameserver(t *testing.T) {
+	nm := &netmap.NetworkMap{DNS: tailcfg.DNSConfig{Routes: map[string][]*dnstype.Resolver{
+		"example":           {{Addr: "100.64.0.53"}},
+		"internal.example.": {{Addr: "10.0.0.53:5353"}},
+	}}}
+	var mu sync.Mutex
+	var requests []string
+	dial := dnsTestDial(t, func(server, name string, queryType dnsmessage.Type) (netip.Addr, error) {
+		mu.Lock()
+		requests = append(requests, server+" "+name)
+		mu.Unlock()
+		return netip.MustParseAddr("10.0.0.80"), nil
+	})
+	addresses, matched, err := resolveRestrictedDNS(context.Background(), "tcp4", "Wiki.Internal.Example", nm, "", dial)
+	if err != nil || !matched || !reflect.DeepEqual(addresses, []netip.Addr{netip.MustParseAddr("10.0.0.80")}) {
+		t.Fatalf("result = %v, %v, %v", addresses, matched, err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(requests) == 0 {
+		t.Fatal("no DNS requests")
+	}
+	for _, request := range requests {
+		if request != "10.0.0.53:5353 wiki.internal.example." {
+			t.Fatalf("unexpected DNS request %q", request)
+		}
+	}
+}
+
+func TestRestrictedDNSIPv6AndAlternateNameserver(t *testing.T) {
+	nm := &netmap.NetworkMap{DNS: tailcfg.DNSConfig{Routes: map[string][]*dnstype.Resolver{
+		"internal.example": {{Addr: "100.64.0.53"}, {Addr: "[fd7a:115c:a1e0::53]:5353"}},
+	}}}
+	dial := dnsTestDial(t, func(server, name string, queryType dnsmessage.Type) (netip.Addr, error) {
+		if server == "100.64.0.53:53" {
+			return netip.Addr{}, fmt.Errorf("nameserver unavailable")
+		}
+		if server != "[fd7a:115c:a1e0::53]:5353" {
+			t.Errorf("unexpected nameserver %s", server)
+		}
+		return netip.MustParseAddr("fd7a:115c:a1e0::80"), nil
+	})
+	addresses, matched, err := resolveRestrictedDNS(context.Background(), "tcp6", "wiki.internal.example", nm, "", dial)
+	if err != nil || !matched || len(addresses) != 1 || addresses[0].String() != "fd7a:115c:a1e0::80" {
+		t.Fatalf("result = %v, %v, %v", addresses, matched, err)
+	}
+}
+
+func TestRestrictedDNSDoesNotFallBackOutsideMatchedRoute(t *testing.T) {
+	for _, server := range []string{"127.0.0.1", "169.254.169.254", "::", "224.0.0.1", "https://dns.example/query", "10.0.0.1:0"} {
+		t.Run(server, func(t *testing.T) {
+			nm := &netmap.NetworkMap{DNS: tailcfg.DNSConfig{Routes: map[string][]*dnstype.Resolver{
+				"example":          {{Addr: "100.64.0.53"}},
+				"internal.example": {{Addr: server}},
+			}}}
+			_, matched, err := resolveRestrictedDNS(context.Background(), "tcp", "wiki.internal.example", nm, "", func(context.Context, string, string) (net.Conn, error) {
+				t.Error("invalid nameserver or broader DNS route was used")
+				return nil, fmt.Errorf("unexpected dial")
+			})
+			if !matched || err == nil {
+				t.Fatalf("matched = %v, err = %v", matched, err)
+			}
+		})
+	}
+}
+
+func TestRestrictedDNSRejectsLocalAnswer(t *testing.T) {
+	nm := &netmap.NetworkMap{DNS: tailcfg.DNSConfig{Routes: map[string][]*dnstype.Resolver{
+		"internal.example": {{Addr: "100.64.0.53"}},
+	}}}
+	dial := dnsTestDial(t, func(string, string, dnsmessage.Type) (netip.Addr, error) {
+		return netip.MustParseAddr("127.0.0.1"), nil
+	})
+	_, matched, err := resolveRestrictedDNS(context.Background(), "tcp4", "wiki.internal.example", nm, "", dial)
+	if !matched || err == nil {
+		t.Fatalf("matched = %v, err = %v", matched, err)
+	}
+}
+
+func TestRestrictedDNSLeavesUnmatchedAndLocalRecordsAlone(t *testing.T) {
+	nm := &netmap.NetworkMap{DNS: tailcfg.DNSConfig{Routes: map[string][]*dnstype.Resolver{
+		"internal.example":       {{Addr: "100.64.0.53"}},
+		"local.internal.example": nil,
+	}}}
+	for _, name := range []string{"notinternal.example", "example.com", "127.0.0.1", "x.local.internal.example", "bad..internal.example"} {
+		_, matched, err := resolveRestrictedDNS(context.Background(), "tcp", name, nm, "", nil)
+		if matched || err != nil {
+			t.Fatalf("name %q: matched = %v, err = %v", name, matched, err)
+		}
+	}
+}
+
+func TestStatusDNSRoutesFollowNetworkMapAndDNSPreference(t *testing.T) {
+	h := newHost(nil, nil)
+	h.lastNetMap = &netmap.NetworkMap{DNS: tailcfg.DNSConfig{Routes: map[string][]*dnstype.Resolver{"internal.example": nil}}}
+	st := &ipnstate.Status{BackendState: "Running"}
+	if h.buildStatusUpdate(st).DNSRoutes != nil {
+		t.Fatal("DNS routes must wait for current DNS preferences")
+	}
+	h.lastPrefs = &PrefsView{CorpDNS: true}
+	if got := h.buildStatusUpdate(st).DNSRoutes; got == nil || !reflect.DeepEqual(*got, []string{"internal.example"}) {
+		t.Fatalf("DNS routes = %v", got)
+	}
+	for _, disabled := range []bool{false, true} {
+		h.lastPrefs.CorpDNS = !disabled
+		h.lastNetMap = &netmap.NetworkMap{}
+		encoded, err := json.Marshal(h.buildStatusUpdate(st))
+		if err != nil || !strings.Contains(string(encoded), `"dnsRoutes":[]`) {
+			t.Fatalf("confirmed empty DNS must clear browser routes: %s, %v", encoded, err)
+		}
+	}
+	h.clearCachedStatus(&ipn.Prefs{CorpDNS: true})
+	if h.lastNetMap != nil || h.buildStatusUpdate(st).DNSRoutes != nil {
+		t.Fatal("unavailable network map must preserve browser routes")
+	}
+	encoded, err := json.Marshal(h.buildStatusUpdate(st))
+	if err != nil || strings.Contains(string(encoded), `"dnsRoutes"`) {
+		t.Fatalf("unavailable map must omit DNS routes: %s, %v", encoded, err)
+	}
+	h.lastPrefs.CorpDNS = false
+	encoded, err = json.Marshal(h.buildStatusUpdate(st))
+	if err != nil || !strings.Contains(string(encoded), `"dnsRoutes":[]`) {
+		t.Fatalf("explicitly disabled DNS must clear routes even without a map: %s, %v", encoded, err)
+	}
+}
+
+func restrictedExitDNSMap() *netmap.NetworkMap {
+	return &netmap.NetworkMap{
+		Peers: []tailcfg.NodeView{(&tailcfg.Node{StableID: "exit", Cap: 26}).View()},
+		DNS: tailcfg.DNSConfig{Routes: map[string][]*dnstype.Resolver{
+			"internal.example": {{Addr: "10.0.0.51"}, {Addr: "10.0.0.52", UseWithExitNode: true}},
+			"ordinary.example": {{Addr: "10.0.0.53"}},
+			"local.example":    nil,
+		}},
+	}
+}
+
+func TestExitDNSRouteEligibilityMatchesPeerCapabilities(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		peer   *tailcfg.Node
+		exit   string
+		filter bool
+	}{
+		{name: "no exit", peer: &tailcfg.Node{StableID: "exit", Cap: 26}},
+		{name: "modern exit", peer: &tailcfg.Node{StableID: "exit", Cap: 26}, exit: "exit", filter: true},
+		{name: "legacy advertised DNS", peer: &tailcfg.Node{StableID: "exit", Hostinfo: (&tailcfg.Hostinfo{Services: []tailcfg.Service{{Proto: tailcfg.PeerAPIDNS, Port: 1}}}).View()}, exit: "exit", filter: true},
+		{name: "older exit without DNS", peer: &tailcfg.Node{StableID: "exit", Cap: 25}, exit: "exit"},
+		{name: "WireGuard exit", peer: &tailcfg.Node{StableID: "exit", IsWireGuardOnly: true}, exit: "exit"},
+		{name: "missing exit", peer: &tailcfg.Node{StableID: "other", Cap: 26}, exit: "exit"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			nm := restrictedExitDNSMap()
+			nm.Peers = []tailcfg.NodeView{tt.peer.View()}
+			want := []string{"internal.example", "local.example", "ordinary.example"}
+			if tt.filter {
+				want = []string{"internal.example", "local.example"}
+			}
+			if got := dnsRouteDomains(nm, tt.exit); !reflect.DeepEqual(got, want) {
+				t.Fatalf("domains = %v, want %v", got, want)
+			}
+			// Filtering must not alter the authoritative network map.
+			if len(nm.DNS.Routes["internal.example"]) != 2 || len(nm.DNS.Routes["ordinary.example"]) != 1 {
+				t.Fatal("network map routes changed")
+			}
+		})
+	}
+}
+
+func TestRestrictedDNSFiltersMixedResolversBeforeLookup(t *testing.T) {
+	for _, exitNodeID := range []string{"", "exit"} {
+		t.Run("exit="+exitNodeID, func(t *testing.T) {
+			wantServer := "10.0.0.51:53"
+			if exitNodeID != "" {
+				wantServer = "10.0.0.52:53"
+			}
+			dial := dnsTestDial(t, func(server, name string, queryType dnsmessage.Type) (netip.Addr, error) {
+				if server != wantServer {
+					t.Errorf("DNS server = %q, want %q", server, wantServer)
+				}
+				return netip.MustParseAddr("10.0.0.80"), nil
+			})
+			addresses, matched, err := resolveRestrictedDNS(context.Background(), "tcp4", "wiki.internal.example", restrictedExitDNSMap(), exitNodeID, dial)
+			if err != nil || !matched || len(addresses) != 1 {
+				t.Fatalf("result = %v, %v, %v", addresses, matched, err)
+			}
+		})
+	}
+}
+
+func TestIneligibleRestrictedDNSDefersToExitDNS(t *testing.T) {
+	for _, host := range []string{"ordinary.example", "wiki.ordinary.example"} {
+		_, matched, err := resolveRestrictedDNS(context.Background(), "tcp4", host, restrictedExitDNSMap(), "exit", func(context.Context, string, string) (net.Conn, error) {
+			t.Error("ineligible nameserver was used instead of exit DNS")
+			return nil, fmt.Errorf("unexpected DNS dial")
+		})
+		if matched || err != nil {
+			t.Fatalf("host %s: matched = %v, err = %v", host, matched, err)
+		}
+	}
+}
+
+func TestExitDNSFiltersRoutesBeforeLongestSuffixSelection(t *testing.T) {
+	nm := restrictedExitDNSMap()
+	nm.DNS.Routes = map[string][]*dnstype.Resolver{
+		"example":                {{Addr: "10.0.0.52", UseWithExitNode: true}},
+		"internal.example":       {{Addr: "10.0.0.51"}},
+		"local.internal.example": nil,
+	}
+	dial := dnsTestDial(t, func(server, name string, queryType dnsmessage.Type) (netip.Addr, error) {
+		if server != "10.0.0.52:53" {
+			t.Errorf("DNS server = %q, want eligible parent route", server)
+		}
+		return netip.MustParseAddr("10.0.0.80"), nil
+	})
+	_, matched, err := resolveRestrictedDNS(context.Background(), "tcp4", "wiki.internal.example", nm, "exit", dial)
+	if !matched || err != nil {
+		t.Fatalf("matched = %v, err = %v", matched, err)
+	}
+	_, matched, err = resolveRestrictedDNS(context.Background(), "tcp4", "wiki.local.internal.example", nm, "exit", nil)
+	if matched || err != nil {
+		t.Fatal("empty local-record route did not suppress broader resolver")
+	}
+}
+
+func TestExitDNSDoesNotFallBackToIneligiblePlainResolver(t *testing.T) {
+	nm := restrictedExitDNSMap()
+	nm.DNS.Routes["internal.example"] = []*dnstype.Resolver{
+		{Addr: "10.0.0.51"},
+		{Addr: "https://dns.example/query", UseWithExitNode: true},
+	}
+	_, matched, err := resolveRestrictedDNS(context.Background(), "tcp4", "wiki.internal.example", nm, "exit", func(context.Context, string, string) (net.Conn, error) {
+		t.Error("ineligible fallback resolver was used")
+		return nil, fmt.Errorf("unexpected DNS dial")
+	})
+	if !matched || err == nil {
+		t.Fatalf("matched = %v, err = %v", matched, err)
+	}
+}
+
+func TestStatusAdvertisesOnlyEligibleExitDNSRoutes(t *testing.T) {
+	h := newHost(nil, nil)
+	h.lastNetMap = restrictedExitDNSMap()
+	h.lastPrefs = &PrefsView{ExitNodeID: "exit", CorpDNS: true}
+	want := []string{"internal.example", "local.example"}
+	if got := h.buildStatusUpdate(&ipnstate.Status{}).DNSRoutes; got == nil || !reflect.DeepEqual(*got, want) {
+		t.Fatalf("domains from selected exit prefs = %v, want %v", got, want)
+	}
+	h.lastPrefs.ExitNodeID = ""
+	st := &ipnstate.Status{ExitNodeStatus: &ipnstate.ExitNodeStatus{ID: "exit"}}
+	if got := h.buildStatusUpdate(st).DNSRoutes; got == nil || len(*got) != 3 {
+		t.Fatalf("cached prefs should override stale exit status: %v", got)
+	}
+}

--- a/host/protocol.go
+++ b/host/protocol.go
@@ -80,6 +80,7 @@ type StatusUpdate struct {
 	Running        bool       `json:"running"`
 	Tailnet        string     `json:"tailnet"`
 	MagicDNSSuffix string     `json:"magicDNSSuffix"`
+	DNSRoutes      *[]string  `json:"dnsRoutes,omitempty"`
 	SelfNode       *PeerInfo  `json:"selfNode,omitempty"`
 	NeedsLogin     bool       `json:"needsLogin"`
 	BrowseToURL    string     `json:"browseToURL,omitempty"`

--- a/host/status.go
+++ b/host/status.go
@@ -218,6 +218,16 @@ func (h *Host) buildStatusUpdate(st *ipnstate.Status) *StatusUpdate {
 	browseToURL := h.lastBrowseToURL
 	prefs := h.lastPrefs
 	health := h.lastHealth
+	var dnsRoutes *[]string
+	// An unavailable map cannot clear routes saved by the browser. A known empty
+	// map or disabled DNS setting can, so preserve that distinction on the wire.
+	if prefs != nil && (!prefs.CorpDNS || h.lastNetMap != nil) {
+		domains := []string{}
+		if prefs.CorpDNS {
+			domains = dnsRouteDomains(h.lastNetMap, prefs.ExitNodeID)
+		}
+		dnsRoutes = &domains
+	}
 	h.stateMu.Unlock()
 
 	// Use the backend state from the status if we don't have one cached.
@@ -237,6 +247,7 @@ func (h *Host) buildStatusUpdate(st *ipnstate.Status) *StatusUpdate {
 		AuthURL:      authURL,
 		Prefs:        prefs,
 		Health:       health,
+		DNSRoutes:    dnsRoutes,
 		Peers:        []PeerInfo{},
 	}
 

--- a/packages/extension/src/background/chrome-proxy-manager.test.ts
+++ b/packages/extension/src/background/chrome-proxy-manager.test.ts
@@ -86,6 +86,25 @@ describe("ChromeProxyManager", () => {
   });
 
   describe("PAC script generation", () => {
+    it.each(["tailnet", "only", "bypass"] as const)("routes known DNS names before %s split rules", (mode) => {
+      const state = baseState({
+        peers: [makePeer({ hostname: "unrelated", dnsName: "wiki.example.ts.net." })],
+        dnsRoutes: ["Internal.Example.", "*.invalid", 'bad\";'],
+        exitNode: mode === "tailnet" ? null : { id: "exit", hostname: "exit", dnsName: "exit.example.ts.net", online: true, location: null },
+        domainSplit: { mode: mode === "bypass" ? "bypass" : "only", domains: mode === "bypass" ? ["wiki", "internal.example", "wiki.local", "unrelated", "notinternal.example", "example.com"] : [] },
+      });
+      const route = evalPAC(pm, state);
+      expect(route("http://wiki/", "wiki")).toContain("PROXY");
+      expect(route("http://wiki/", "WIKI.")).toContain("PROXY");
+      expect(route("http://wiki.local/", "wiki.local")).toBe("DIRECT");
+      expect(route("http://unrelated/", "unrelated")).toBe("DIRECT");
+      expect(route("http://internal.example/", "internal.example")).toContain("PROXY");
+      expect(route("http://app.internal.example/", "app.internal.example")).toContain("PROXY");
+      expect(route("http://notinternal.example/", "notinternal.example")).toBe("DIRECT");
+      expect(route("https://example.com/", "example.com")).toBe("DIRECT");
+      expect(capturePAC(pm, { ...state, dnsRoutes: [], peers: [] })).not.toBeNull();
+    });
+
     it("always proxies the Tailscale service IP", () => {
       const pac = capturePAC(pm, baseState())!;
       expect(pac).toContain('host === "100.100.100.100"');

--- a/packages/extension/src/background/chrome-proxy-manager.ts
+++ b/packages/extension/src/background/chrome-proxy-manager.ts
@@ -13,8 +13,7 @@ import {
   parseCIDR,
   sanitizeMagicDNSSuffix,
   sanitizeDomain,
-  collectSubnetCIDRs,
-  shouldProxyState,
+  sanitizeDNSRoutes,
 } from "@tailchrome/shared/background/proxy-utils";
 
 import {
@@ -109,6 +108,8 @@ export class ChromeProxyManager {
           policy.subnetCIDRs,
           policy.domainSplit.mode,
           sanitizeSplitDomains(policy.domainSplit),
+          policy.shortNames,
+          policy.dnsRoutes,
         ),
       },
     };
@@ -218,6 +219,8 @@ export class ChromeProxyManager {
     subnets: string[],
     splitMode: "bypass" | "only",
     splitDomains: string[],
+    shortNames: string[],
+    dnsRoutes: string[],
   ): string {
     const proxy = `PROXY 127.0.0.1:${port}`;
 
@@ -230,7 +233,13 @@ export class ChromeProxyManager {
       .filter((line): line is string => line !== null)
       .join("\n");
 
-    const safeDNSSuffix = sanitizeMagicDNSSuffix(magicDNSSuffix);
+    const safeDNSSuffix = sanitizeMagicDNSSuffix(magicDNSSuffix).toLowerCase();
+    const dnsChecks = [
+      ...sanitizeDNSRoutes(shortNames).filter((name) => !name.includes("."))
+        .map((name) => `host === "${name}"`),
+      ...sanitizeDNSRoutes(dnsRoutes)
+        .map((domain) => `(host === "${domain}" || dnsDomainIs(host, ".${domain}"))`),
+    ].join(" || ");
 
     const domainChecks =
       splitDomains
@@ -250,11 +259,13 @@ export class ChromeProxyManager {
     }
 
     return `function FindProxyForURL(url, host) {
+  host = host.toLowerCase().replace(/\\.$/, "");
   var proxy = "${proxy}";
   var isIPv4 = /^\\d{1,3}(?:\\.\\d{1,3}){3}$/.test(host);
 
   if (host === "${TAILSCALE_SERVICE_IP}") return proxy;
 ${safeDNSSuffix ? `  if (dnsDomainIs(host, ".${safeDNSSuffix}") || host === "${safeDNSSuffix}") return proxy;` : "  // No MagicDNS suffix configured"}
+${dnsChecks ? `  if (${dnsChecks}) return proxy;` : "  // No additional DNS routes"}
   if (host.toLowerCase().indexOf("${TAILSCALE_IPV6_PREFIX}") === 0) return proxy;
   if (isIPv4 && isInNet(host, "100.64.0.0", "255.192.0.0")) return proxy;
 

--- a/packages/extension/src/background/firefox-proxy-manager.test.ts
+++ b/packages/extension/src/background/firefox-proxy-manager.test.ts
@@ -110,6 +110,24 @@ describe("FirefoxProxyManager", () => {
   });
 
   describe("routing decisions", () => {
+    it.each(["tailnet", "only", "bypass"] as const)("routes known DNS names before %s split rules", (mode) => {
+      pm.apply(baseState({
+        peers: [makePeer({ hostname: "unrelated", dnsName: "wiki.example.ts.net." })],
+        dnsRoutes: ["Internal.Example.", "*.invalid"],
+        exitNode: mode === "tailnet" ? null : { id: "exit", hostname: "exit", dnsName: "exit.example.ts.net", online: true, location: null },
+        domainSplit: { mode: mode === "bypass" ? "bypass" : "only", domains: mode === "bypass" ? ["wiki", "internal.example", "wiki.local", "unrelated", "notinternal.example", "example.com"] : [] },
+      }));
+      for (const url of ["http://wiki/", "http://WIKI./", "http://internal.example/", "http://app.internal.example/"]) {
+        expect(first(pm, url)).toMatchObject({ type: "socks", proxyDNS: true });
+      }
+      for (const url of ["http://wiki.local/", "http://unrelated/", "http://notinternal.example/", "https://example.com/"]) {
+        expect(first(pm, url)).toMatchObject({ type: "direct" });
+      }
+      pm.apply(baseState({ peers: [], dnsRoutes: [] }));
+      expect(first(pm, "http://wiki/")).toMatchObject({ type: "direct" });
+      expect(first(pm, "http://internal.example/")).toMatchObject({ type: "direct" });
+    });
+
     it("routes Tailscale IPs through proxy, regular sites direct", () => {
       pm.apply(baseState());
       const resolve = (url: string) => first(pm, url);

--- a/packages/extension/src/background/firefox-proxy-manager.ts
+++ b/packages/extension/src/background/firefox-proxy-manager.ts
@@ -14,8 +14,7 @@ import {
   ipToNum,
   sanitizeMagicDNSSuffix,
   sanitizeDomain,
-  collectSubnetCIDRs,
-  shouldProxyState,
+  sanitizeDNSRoutes,
   CGNAT_NETWORK,
   CGNAT_MASK,
 } from "@tailchrome/shared/background/proxy-utils";
@@ -61,6 +60,8 @@ export class FirefoxProxyManager {
   private subnetRanges: Array<{ network: number; mask: number }> = [];
   private splitMode: DomainSplitMode = "bypass";
   private splitDomains: string[] = [];
+  private shortNames = new Set<string>();
+  private dnsRoutes: string[] = [];
   private mode: "active" | "blocked" | "direct" = "blocked";
   private failedKey = "";
   private policyKey = "";
@@ -99,7 +100,9 @@ export class FirefoxProxyManager {
     this.proxyPort = policy.proxyPort ?? BLOCKED_PROXY_PORT;
     this.exitNodeActive =
       policy.blockAll === true || policy.selectedExitNodeID !== null;
-    this.magicDNSSuffix = sanitizeMagicDNSSuffix(policy.magicDNSSuffix);
+    this.magicDNSSuffix = sanitizeMagicDNSSuffix(policy.magicDNSSuffix).toLowerCase();
+    this.shortNames = new Set(sanitizeDNSRoutes(policy.shortNames).filter((name) => !name.includes(".")));
+    this.dnsRoutes = sanitizeDNSRoutes(policy.dnsRoutes);
     this.subnetRanges = policy.subnetCIDRs
       .map((cidr) => parseCIDR(cidr))
       .filter((r): r is { network: number; mask: number } => r !== null);
@@ -160,7 +163,7 @@ export class FirefoxProxyManager {
 
     let host: string;
     try {
-      host = new URL(url).hostname;
+      host = new URL(url).hostname.toLowerCase().replace(/\.$/, "");
       if (host.startsWith("[") && host.endsWith("]")) {
         host = host.slice(1, -1);
       }
@@ -169,6 +172,8 @@ export class FirefoxProxyManager {
     }
 
     if (host === TAILSCALE_SERVICE_IP) return proxy;
+    if (this.shortNames.has(host)) return proxy;
+    if (this.dnsRoutes.some((domain) => host === domain || host.endsWith(`.${domain}`))) return proxy;
     if (host.toLowerCase().startsWith(TAILSCALE_IPV6_PREFIX)) return proxy;
 
     const hostNum = ipToNum(host);

--- a/packages/shared/src/background/native-host.test.ts
+++ b/packages/shared/src/background/native-host.test.ts
@@ -834,3 +834,14 @@ describe("isValidNativeReply", () => {
     expect(isValidNativeReply(reply)).toBe(false);
   });
 });
+
+
+describe("native DNS route validation", () => {
+  it("accepts older helpers and string domain routes, rejects malformed arrays", () => {
+    expect(isValidNativeReply({ status: makeValidStatus() })).toBe(true);
+    expect(isValidNativeReply({ status: { ...makeValidStatus(), dnsRoutes: ["internal.example"] } })).toBe(true);
+    for (const dnsRoutes of [null, "internal.example", [1], [{}]]) {
+      expect(isValidNativeReply({ status: { ...makeValidStatus(), dnsRoutes } })).toBe(false);
+    }
+  });
+});

--- a/packages/shared/src/background/native-host.ts
+++ b/packages/shared/src/background/native-host.ts
@@ -438,6 +438,7 @@ function isStatus(value: unknown): boolean {
     isBoolean(value["running"]) &&
     isNullableString(value["tailnet"]) &&
     isString(value["magicDNSSuffix"]) &&
+    optionalField(value, "dnsRoutes", (routes) => Array.isArray(routes) && routes.every(isString)) &&
     optionalField(
       value,
       "selfNode",

--- a/packages/shared/src/background/proxy-utils.test.ts
+++ b/packages/shared/src/background/proxy-utils.test.ts
@@ -4,6 +4,9 @@ import {
   parseCIDR,
   sanitizeMagicDNSSuffix,
   collectSubnetCIDRs,
+  collectShortNames,
+  sanitizeDNSName,
+  sanitizeDNSRoutes,
   shouldProxyState,
   CGNAT_NETWORK,
   CGNAT_MASK,
@@ -233,5 +236,26 @@ describe("CGNAT constants", () => {
     // Outside range
     expect(check("100.128.0.0")).toBe(false);
     expect(check("10.0.0.1")).toBe(false);
+  });
+});
+
+
+describe("DNS names and routes", () => {
+  it("keeps only complete, valid DNS names", () => {
+    expect(sanitizeDNSRoutes(["Internal.Example.", "internal.example", "other.example"])).toEqual(["internal.example", "other.example"]);
+    for (const name of ["", ".", "*.example", "https://internal.example", "bad..example", "bad.example:53", "127.0.0.1", "-bad.example", "bad-.example", "bad\n.example", "a".repeat(64) + ".example"]) {
+      expect(sanitizeDNSName(name)).toBeNull();
+    }
+    expect(sanitizeDNSRoutes([12, null, {}, "good.example"])).toEqual(["good.example"]);
+  });
+
+  it("derives exact short names from peer DNS records, not device hostnames", () => {
+    expect(collectShortNames(baseState({ peers: [
+      makePeer({ hostname: "wrong", dnsName: "Wiki.Example.Ts.Net." }),
+      makePeer({ hostname: "router", dnsName: "router.other.ts.net." }),
+      makePeer({ dnsName: "nested.wiki.example.ts.net." }),
+      makePeer({ dnsName: "wiki.example.ts.net." }),
+    ] }))).toEqual(["wiki"]);
+    expect(collectShortNames(baseState({ magicDNSSuffix: null, peers: [makePeer()] }))).toEqual([]);
   });
 });

--- a/packages/shared/src/background/proxy-utils.ts
+++ b/packages/shared/src/background/proxy-utils.ts
@@ -68,6 +68,40 @@ export function sanitizeMagicDNSSuffix(suffix: string | null | undefined): strin
   return /^[a-zA-Z0-9.\-]+$/.test(stripped) ? stripped : "";
 }
 
+/** Validate a DNS name without interpreting URLs, wildcards, or address literals. */
+export function sanitizeDNSName(input: unknown): string | null {
+  if (typeof input !== "string") return null;
+  const name = input.toLowerCase().replace(/\.$/, "");
+  if (!name || name.length > 253 || /^[0-9.]+$/.test(name)) return null;
+  const valid = name.split(".").every((label) =>
+    label.length <= 63 && /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(label),
+  );
+  return valid ? name : null;
+}
+
+export function sanitizeDNSRoutes(routes: unknown): string[] {
+  if (!Array.isArray(routes)) return [];
+  const names = routes.map(sanitizeDNSName)
+    .filter((name): name is string => name !== null);
+  return [...new Set(names)].sort();
+}
+
+/** Only names actually present in MagicDNS may intercept a short local hostname. */
+export function collectShortNames(
+  state: Pick<TailscaleState, "peers" | "selfNode" | "magicDNSSuffix">,
+): string[] {
+  const suffix = sanitizeDNSName(state.magicDNSSuffix);
+  if (!suffix) return [];
+  const names: string[] = [];
+  for (const peer of [...(state.peers ?? []), ...(state.selfNode ? [state.selfNode] : [])]) {
+    const fullName = sanitizeDNSName(peer.dnsName);
+    if (!fullName?.endsWith(`.${suffix}`)) continue;
+    const shortName = fullName.slice(0, -(suffix.length + 1));
+    if (!shortName.includes(".") && sanitizeDNSName(shortName)) names.push(shortName);
+  }
+  return [...new Set(names)].sort();
+}
+
 /**
  * Normalize a user-entered domain for split-tunnel matching. Lowercases,
  * trims whitespace, strips an optional scheme/path/port, and rejects any

--- a/packages/shared/src/background/routing-protection.test.ts
+++ b/packages/shared/src/background/routing-protection.test.ts
@@ -235,6 +235,63 @@ describe("routing protection", () => {
       domainSplit: { mode: "only", domains: ["work.example"] },
     });
   });
+  it("replaces restricted DNS routes from current status, including an empty list", async () => {
+    const routing = new RoutingProtection();
+    await routing.restore();
+    const state = connected({ dnsRoutes: ["Old.Example."] });
+    routing.confirmStatus(status(state), state);
+    expect(routing.decorate(state).routingPolicy?.dnsRoutes).toEqual(["old.example"]);
+    routing.confirmStatus({ ...status(state), dnsRoutes: ["new.example"] }, state);
+    expect(routing.decorate(state).routingPolicy?.dnsRoutes).toEqual(["new.example"]);
+    routing.confirmStatus({ ...status(state), dnsRoutes: [] }, state);
+    expect(routing.decorate(state).routingPolicy?.dnsRoutes).toEqual([]);
+  });
+  it("preserves missing DNS routes across disconnect and restore without crossing accounts", async () => {
+    const routing = new RoutingProtection();
+    await routing.restore();
+    const state = connected({ dnsRoutes: ["internal.example"] });
+    routing.confirmStatus(status(state), state);
+    routing.confirmStatus({ ...status(state), dnsRoutes: undefined }, state);
+    await flush();
+    const restored = new RoutingProtection();
+    await restored.restore();
+    expect(restored.decorate(offline()).routingPolicy).toMatchObject({
+      mode: "blocked", dnsRoutes: ["internal.example"],
+    });
+    const other = connected({ selfNode: { ...makePeer(), keyExpiry: null, id: "self2" } });
+    restored.confirmStatus(status(other), other);
+    expect(restored.decorate(other).routingPolicy?.dnsRoutes).toEqual([]);
+  });
+  it("replaces known short names only after a complete peer update", async () => {
+    const routing = new RoutingProtection();
+    await routing.restore();
+    const state = connected({ peers: [makePeer({ dnsName: "wiki.example.ts.net." })] });
+    routing.confirmStatus(status(state), state);
+    expect(routing.decorate(state).routingPolicy?.shortNames).toEqual(["router", "wiki"]);
+    const missing = { ...status(state), peers: null } as unknown as StatusUpdate;
+    routing.confirmStatus(missing, state);
+    expect(routing.decorate(state).routingPolicy?.shortNames).toContain("wiki");
+    const partial = { ...status(state), peers: [makePeer({ dnsName: "docs.example.ts.net." })], peersTruncated: true };
+    routing.confirmStatus(partial, state);
+    expect(routing.decorate(state).routingPolicy?.shortNames).toEqual(["router", "wiki", "docs"]);
+    routing.confirmStatus({ ...partial, peersTruncated: false }, state);
+    expect(routing.decorate(state).routingPolicy?.shortNames).toEqual(["docs", "router"]);
+    routing.confirmStatus({ ...status(state), peers: [] }, state);
+    expect(routing.decorate(state).routingPolicy?.shortNames).toEqual(["router"]);
+  });
+  it("keeps known short names protected after restart and a missing suffix", async () => {
+    const routing = new RoutingProtection();
+    await routing.restore();
+    const state = connected({ peers: [makePeer({ dnsName: "wiki.example.ts.net." })] });
+    routing.confirmStatus(status(state), state);
+    routing.confirmStatus({ ...status(state), peers: [], magicDNSSuffix: "" }, state);
+    await flush();
+    const restored = new RoutingProtection();
+    await restored.restore();
+    expect(restored.decorate(offline()).routingPolicy).toMatchObject({
+      mode: "blocked", shortNames: ["router", "wiki"],
+    });
+  });
   it.each(["Stopped", "NeedsLogin"] as const)("releases a requested disconnect after %s is confirmed", async (backendState) => {
     const routing = new RoutingProtection();
     await routing.restore();

--- a/packages/shared/src/background/routing-protection.ts
+++ b/packages/shared/src/background/routing-protection.ts
@@ -2,7 +2,10 @@ import type { RoutingPolicy, StatusUpdate, TailscaleState } from "../types";
 import { normalizeDomainSplit } from "./domain-split";
 import {
   collectSubnetCIDRs,
+  collectShortNames,
   parseCIDR,
+  sanitizeDNSName,
+  sanitizeDNSRoutes,
   sanitizeMagicDNSSuffix,
   shouldProxyState,
 } from "./proxy-utils";
@@ -46,15 +49,11 @@ function snapshot(value: unknown): Snapshot | null {
     (s) => /\/\d{1,2}$/.test(s) && parseCIDR(s) !== null,
   );
   const shortNames = strings(raw.shortNames, (s) =>
-    /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/.test(s),
+    !s.includes(".") && sanitizeDNSName(s) === s,
   );
   const dnsRoutes = strings(
     raw.dnsRoutes,
-    (s) =>
-      s.length < 254 &&
-      s
-        .split(".")
-        .every((label) => /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/.test(label)),
+    (s) => sanitizeDNSName(s) === s,
   );
   for (const [key, clean] of [
     ["subnetCIDRs", subnetCIDRs],
@@ -117,9 +116,11 @@ export function policyFromState(state: TailscaleState): RoutingPolicy {
     proxyPort: state.proxyPort,
     selectedExitNodeID,
     magicDNSSuffix: sanitizeMagicDNSSuffix(state.magicDNSSuffix),
-    subnetCIDRs: collectSubnetCIDRs(state.peers).filter(
+    subnetCIDRs: collectSubnetCIDRs(state.peers ?? []).filter(
       (s) => parseCIDR(s) !== null,
     ),
+    shortNames: collectShortNames(state),
+    dnsRoutes: sanitizeDNSRoutes(state.dnsRoutes),
     domainSplit: normalizeDomainSplit(state.domainSplit),
   };
 }
@@ -274,12 +275,15 @@ export class RoutingProtection {
       subnetCIDRs: [
         ...new Set([...(prior?.subnetCIDRs ?? []), ...policy.subnetCIDRs]),
       ],
-      shortNames: [
-        ...new Set([...(prior?.shortNames ?? []), ...policy.shortNames]),
-      ],
-      dnsRoutes: [
-        ...new Set([...(prior?.dnsRoutes ?? []), ...policy.dnsRoutes]),
-      ],
+      shortNames:
+        Array.isArray(status.peers) &&
+        !status.peersTruncated &&
+        sanitizeDNSName(status.magicDNSSuffix)
+          ? policy.shortNames
+          : [...new Set([...(prior?.shortNames ?? []), ...policy.shortNames])],
+      dnsRoutes: status.dnsRoutes !== undefined
+        ? policy.dnsRoutes
+        : prior?.dnsRoutes ?? [],
       domainSplit: policy.domainSplit,
     };
     this.save();

--- a/packages/shared/src/background/state-store.test.ts
+++ b/packages/shared/src/background/state-store.test.ts
@@ -128,6 +128,7 @@ describe("StateStore", () => {
         running: true,
         tailnet: "my-tailnet",
         magicDNSSuffix: "my-tailnet.ts.net",
+        dnsRoutes: ["Internal.Example.", "*.invalid", "internal.example"],
         selfNode: {
           id: "self1",
           hostname: "my-machine",
@@ -151,7 +152,12 @@ describe("StateStore", () => {
       expect(state.backendState).toBe("Running");
       expect(state.tailnet).toBe("my-tailnet");
       expect(state.magicDNSSuffix).toBe("my-tailnet.ts.net");
+      expect(state.dnsRoutes).toEqual(["internal.example"]);
       expect(state.selfNode?.hostname).toBe("my-machine");
+      store.applyStatusUpdate({ ...status, dnsRoutes: undefined });
+      expect(store.getState().dnsRoutes).toEqual(["internal.example"]);
+      store.applyStatusUpdate({ ...status, dnsRoutes: [] });
+      expect(store.getState().dnsRoutes).toEqual([]);
     });
 
     it("keeps raw status errors out of normal state copy", () => {

--- a/packages/shared/src/background/state-store.ts
+++ b/packages/shared/src/background/state-store.ts
@@ -1,4 +1,5 @@
 import type { TailscaleState, StatusUpdate, PeerInfo } from "../types";
+import { sanitizeDNSRoutes } from "./proxy-utils";
 import { sanitizeDiagnosticMessage } from "../helper-diagnostics";
 
 export type StateListener = (state: TailscaleState) => void;
@@ -15,6 +16,7 @@ const DEFAULT_STATE: TailscaleState = {
   peers: [],
   exitNode: null,
   magicDNSSuffix: null,
+  dnsRoutes: [],
   browseToURL: null,
   prefs: null,
   health: [],
@@ -95,6 +97,9 @@ export class StateStore {
       })),
       exitNode: status.exitNode ?? null,
       magicDNSSuffix: status.magicDNSSuffix,
+      dnsRoutes: status.dnsRoutes === undefined
+        ? this.state.dnsRoutes
+        : sanitizeDNSRoutes(status.dnsRoutes),
       browseToURL: status.browseToURL || status.authURL || null,
       prefs: status.prefs,
       health,

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -71,6 +71,8 @@ export interface StatusUpdate {
   running: boolean;
   tailnet: string | null;
   magicDNSSuffix: string;
+  /** Restricted DNS suffixes; omitted until available or by older helpers. */
+  dnsRoutes?: string[];
   selfNode: SelfNode | null;
   needsLogin: boolean;
   browseToURL: string;
@@ -236,6 +238,7 @@ export interface TailscaleState {
   peers: PeerInfo[];
   exitNode: ExitNodeInfo | null;
   magicDNSSuffix: string | null;
+  dnsRoutes?: string[];
   browseToURL: string | null;
   prefs: TailscalePrefs | null;
   health: string[];

--- a/scripts/e2e/scenarios/dns-routing-network.mjs
+++ b/scripts/e2e/scenarios/dns-routing-network.mjs
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { waitForPopup } from "../assertions.mjs";
+import { makeControl, makeRunningState, expectedHostVersion } from "../fixtures.mjs";
+import { createRoutingNetwork, routingTestHost, proxyCredentials } from "../network-fixture.mjs";
+
+export const suite = "smoke";
+export const browsers = ["chrome", "firefox"];
+export const launchOptions = {
+  chromeArgs: [`--host-resolver-rules=MAP ${routingTestHost} 127.0.0.1`],
+  firefoxPrefs: { "network.dns.localDomains": routingTestHost },
+};
+export const control = () => makeControl({ allowRuntimeUpdates: true, proxyAuth: proxyCredentials });
+
+export async function run({ browser, openPopup }) {
+  const network = await createRoutingNetwork();
+  let popup;
+  try {
+    popup = await openPopup();
+    await waitForPopup(popup);
+    await popup.evaluate(() => {
+      const port = chrome.runtime.connect({ name: "popup" });
+      window.dnsTestPort = port;
+      port.onMessage.addListener((message) => {
+        if (message.type === "state") window.dnsTestState = message.state;
+      });
+    });
+    const wait = async (expectedMode, present) => popup.waitForFunction((mode, hasRoute) => {
+      const state = window.dnsTestState;
+      return state?.routingPolicy?.mode === mode &&
+        state.routingPolicy.dnsRoutes.includes("tailchrome.test") === hasRoute &&
+        (mode === "blocked" || state.routingHealth?.status === "active");
+    }, { timeout: 10_000 }, expectedMode, present);
+    const update = async (value) => popup.evaluate(
+      (message) => chrome.runtime.sendMessage({ tailchromeE2ENative: message }), value,
+    );
+    const navigate = async (path, expected) => {
+      const page = await browser.newPage();
+      let response;
+      let error;
+      try {
+        response = await page.goto(network.baseURL + path, { waitUntil: "domcontentloaded", timeout: 4_000 });
+      } catch (err) {
+        error = err;
+      } finally {
+        await page.close();
+      }
+      const hits = network.hits.filter((hit) => hit.path === path);
+      if (expected === "blocked") {
+        assert.equal(hits.length, 0, `Protected DNS request reached the origin: ${JSON.stringify(hits)}`);
+        assert.ok(error || !response?.ok(), `Blocked DNS request ${path} succeeded`);
+      } else {
+        if (error) throw error;
+        assert.equal(response?.status(), 200);
+        assert.ok(hits.length > 0);
+        assert.ok(hits.every((hit) => hit.proxied === (expected === "proxy")), `Wrong route: ${JSON.stringify(hits)}`);
+      }
+    };
+
+    await wait("active", false);
+    await navigate("/dns-direct-control", "direct");
+    await update({
+      control: { proxyPort: network.proxyPort },
+      reply: { procRunning: { port: network.proxyPort, pid: 1, version: expectedHostVersion, proxyAuth: proxyCredentials } },
+    });
+    const state = makeRunningState({ dnsRoutes: ["tailchrome.test"] });
+    await update({ reply: { status: state } });
+    await wait("active", true);
+    await navigate("/dns-route-proxy", "proxy");
+
+    const { dnsRoutes, ...unknown } = state;
+    await update({ reply: { status: unknown } });
+    await wait("active", true);
+    await navigate("/dns-unknown-keeps-proxy", "proxy");
+    await update({ reply: { status: { ...state, dnsRoutes: [] } } });
+    await wait("active", false);
+    await navigate("/dns-cleared-direct", "direct");
+
+    await update({ reply: { status: state } });
+    await wait("active", true);
+    await update({ control: { nativeFailure: "unavailable" }, disconnect: true });
+    await wait("blocked", true);
+    await navigate("/dns-helper-disconnected", "blocked");
+  } finally {
+    await popup?.close();
+    await network.close();
+  }
+}


### PR DESCRIPTION
## What
Route exact peer short names and restricted DNS domains through the helper. Resolve restricted domains using their configured nameservers, including exit-node eligibility rules.

## Why
Internal services should work by hostname when their subnet route is available. Closes #119.

## How to Test
Typecheck, unit tests, Go race tests/vet, the full Chrome and Firefox browser suites, and Firefox package validation pass.
